### PR TITLE
Implement color arithmetics

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub};
+
 use {Color, Rgb, Luma, Xyz, Lab, Lch, Hsv, ColorSpace, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
 
 ///Linear HSL color space with an alpha component.
@@ -143,6 +145,58 @@ impl Default for Hsl {
 	fn default() -> Hsl {
 		Hsl::hsl(0.0.into(), 0.0, 0.0)
 	}
+}
+
+impl Add<Hsl> for Hsl {
+    type Output = Hsl;
+
+    fn add(self, other: Hsl) -> Hsl {
+        Hsl {
+            hue: self.hue + other.hue,
+            saturation: self.saturation + other.saturation,
+            lightness: self.lightness + other.lightness,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Hsl {
+    type Output = Hsl;
+
+    fn add(self, c: f32) -> Hsl {
+        Hsl {
+            hue: self.hue + c,
+            saturation: self.saturation + c,
+            lightness: self.lightness + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Hsl> for Hsl {
+    type Output = Hsl;
+
+    fn sub(self, other: Hsl) -> Hsl {
+        Hsl {
+            hue: self.hue - other.hue,
+            saturation: self.saturation - other.saturation,
+            lightness: self.lightness - other.lightness,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Hsl {
+    type Output = Hsl;
+
+    fn sub(self, c: f32) -> Hsl {
+        Hsl {
+            hue: self.hue - c,
+            saturation: self.saturation - c,
+            lightness: self.lightness - c,
+            alpha: self.alpha - c,
+        }
+    }
 }
 
 from_color!(to Hsl from Rgb, Luma, Xyz, Lab, Lch, Hsv);

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub};
+
 use {Color, Rgb, Luma, Xyz, Lab, Lch, Hsl, ColorSpace, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
 
 ///Linear HSV color space with an alpha component.
@@ -141,6 +143,58 @@ impl Saturate for Hsv {
 impl Default for Hsv {
     fn default() -> Hsv {
         Hsv::hsv(0.0.into(), 0.0, 0.0)
+    }
+}
+
+impl Add<Hsv> for Hsv {
+    type Output = Hsv;
+
+    fn add(self, other: Hsv) -> Hsv {
+        Hsv {
+            hue: self.hue + other.hue,
+            saturation: self.saturation + other.saturation,
+            value: self.value + other.value,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Hsv {
+    type Output = Hsv;
+
+    fn add(self, c: f32) -> Hsv {
+        Hsv {
+            hue: self.hue + c,
+            saturation: self.saturation + c,
+            value: self.value + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Hsv> for Hsv {
+    type Output = Hsv;
+
+    fn sub(self, other: Hsv) -> Hsv {
+        Hsv {
+            hue: self.hue - other.hue,
+            saturation: self.saturation - other.saturation,
+            value: self.value - other.value,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Hsv {
+    type Output = Hsv;
+
+    fn sub(self, c: f32) -> Hsv {
+        Hsv {
+            hue: self.hue - c,
+            saturation: self.saturation - c,
+            value: self.value - c,
+            alpha: self.alpha - c,
+        }
     }
 }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub, Mul, Div};
+
 use {Color, Rgb, Luma, Xyz, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, LabHue, clamp};
 
 use tristimulus::{X_N, Y_N, Z_N};
@@ -113,6 +115,110 @@ impl GetHue for Lab {
 impl Default for Lab {
     fn default() -> Lab {
         Lab::lab(0.0, 0.0, 0.0)
+    }
+}
+
+impl Add<Lab> for Lab {
+    type Output = Lab;
+
+    fn add(self, other: Lab) -> Lab {
+        Lab {
+            l: self.l + other.l,
+            a: self.a + other.a,
+            b: self.b + other.b,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Lab {
+    type Output = Lab;
+
+    fn add(self, c: f32) -> Lab {
+        Lab {
+            l: self.l + c,
+            a: self.a + c,
+            b: self.b + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Lab> for Lab {
+    type Output = Lab;
+
+    fn sub(self, other: Lab) -> Lab {
+        Lab {
+            l: self.l - other.l,
+            a: self.a - other.a,
+            b: self.b - other.b,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Lab {
+    type Output = Lab;
+
+    fn sub(self, c: f32) -> Lab {
+        Lab {
+            l: self.l - c,
+            a: self.a - c,
+            b: self.b - c,
+            alpha: self.alpha - c,
+        }
+    }
+}
+
+impl Mul<Lab> for Lab {
+    type Output = Lab;
+
+    fn mul(self, other: Lab) -> Lab {
+        Lab {
+            l: self.l * other.l,
+            a: self.a * other.a,
+            b: self.b * other.b,
+            alpha: self.alpha * other.alpha,
+        }
+    }
+}
+
+impl Mul<f32> for Lab {
+    type Output = Lab;
+
+    fn mul(self, c: f32) -> Lab {
+        Lab {
+            l: self.l * c,
+            a: self.a * c,
+            b: self.b * c,
+            alpha: self.alpha * c,
+        }
+    }
+}
+
+impl Div<Lab> for Lab {
+    type Output = Lab;
+
+    fn div(self, other: Lab) -> Lab {
+        Lab {
+            l: self.l / other.l,
+            a: self.a / other.a,
+            b: self.b / other.b,
+            alpha: self.alpha / other.alpha,
+        }
+    }
+}
+
+impl Div<f32> for Lab {
+    type Output = Lab;
+
+    fn div(self, c: f32) -> Lab {
+        Lab {
+            l: self.l / c,
+            a: self.a / c,
+            b: self.b / c,
+            alpha: self.alpha / c,
+        }
     }
 }
 

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub};
+
 use {Color, ColorSpace, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
 
 ///CIE L*C*h°, a polar version of [CIE L*a*b*](struct.Lab.html), with an alpha
@@ -140,6 +142,58 @@ impl Saturate for Lch {
 impl Default for Lch {
     fn default() -> Lch {
         Lch::lch(0.0, 0.0, 0.0.into())
+    }
+}
+
+impl Add<Lch> for Lch {
+    type Output = Lch;
+
+    fn add(self, other: Lch) -> Lch {
+        Lch {
+            l: self.l + other.l,
+            chroma: self.chroma + other.chroma,
+            hue: self.hue + other.hue,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Lch {
+    type Output = Lch;
+
+    fn add(self, c: f32) -> Lch {
+        Lch {
+            l: self.l + c,
+            chroma: self.chroma + c,
+            hue: self.hue + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Lch> for Lch {
+    type Output = Lch;
+
+    fn sub(self, other: Lch) -> Lch {
+        Lch {
+            l: self.l - other.l,
+            chroma: self.chroma - other.chroma,
+            hue: self.hue - other.hue,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Lch {
+    type Output = Lch;
+
+    fn sub(self, c: f32) -> Lch {
+        Lch {
+            l: self.l - c,
+            chroma: self.chroma - c,
+            hue: self.hue - c,
+            alpha: self.alpha - c,
+        }
     }
 }
 

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub, Mul, Div};
+
 use {Color, Rgb, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
 
 ///Linear luminance with an alpha component.
@@ -92,6 +94,94 @@ impl Shade for Luma {
 impl Default for Luma {
     fn default() -> Luma {
         Luma::y(0.0)
+    }
+}
+
+impl Add<Luma> for Luma {
+    type Output = Luma;
+
+    fn add(self, other: Luma) -> Luma {
+        Luma {
+            luma: self.luma + other.luma,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Luma {
+    type Output = Luma;
+
+    fn add(self, c: f32) -> Luma {
+        Luma {
+            luma: self.luma + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Luma> for Luma {
+    type Output = Luma;
+
+    fn sub(self, other: Luma) -> Luma {
+        Luma {
+            luma: self.luma - other.luma,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Luma {
+    type Output = Luma;
+
+    fn sub(self, c: f32) -> Luma {
+        Luma {
+            luma: self.luma - c,
+            alpha: self.alpha - c,
+        }
+    }
+}
+
+impl Mul<Luma> for Luma {
+    type Output = Luma;
+
+    fn mul(self, other: Luma) -> Luma {
+        Luma {
+            luma: self.luma * other.luma,
+            alpha: self.alpha * other.alpha,
+        }
+    }
+}
+
+impl Mul<f32> for Luma {
+    type Output = Luma;
+
+    fn mul(self, c: f32) -> Luma {
+        Luma {
+            luma: self.luma * c,
+            alpha: self.alpha * c,
+        }
+    }
+}
+
+impl Div<Luma> for Luma {
+    type Output = Luma;
+
+    fn div(self, other: Luma) -> Luma {
+        Luma {
+            luma: self.luma / other.luma,
+            alpha: self.alpha / other.alpha,
+        }
+    }
+}
+
+impl Div<f32> for Luma {
+    type Output = Luma;
+
+    fn div(self, c: f32) -> Luma {
+        Luma {
+            luma: self.luma / c,
+            alpha: self.alpha / c,
+        }
     }
 }
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub, Mul, Div};
+
 use {Color, Luma, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, RgbHue, clamp};
 
 ///Linear RGB with an alpha component.
@@ -296,6 +298,110 @@ impl GetHue for Rgb {
 impl Default for Rgb {
     fn default() -> Rgb {
         Rgb::linear_rgb(0.0, 0.0, 0.0)
+    }
+}
+
+impl Add<Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn add(self, other: Rgb) -> Rgb {
+        Rgb {
+            red: self.red + other.red,
+            green: self.green + other.green,
+            blue: self.blue + other.blue,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Rgb {
+    type Output = Rgb;
+
+    fn add(self, c: f32) -> Rgb {
+        Rgb {
+            red: self.red + c,
+            green: self.green + c,
+            blue: self.blue + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn sub(self, other: Rgb) -> Rgb {
+        Rgb {
+            red: self.red - other.red,
+            green: self.green - other.green,
+            blue: self.blue - other.blue,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Rgb {
+    type Output = Rgb;
+
+    fn sub(self, c: f32) -> Rgb {
+        Rgb {
+            red: self.red - c,
+            green: self.green - c,
+            blue: self.blue - c,
+            alpha: self.alpha - c,
+        }
+    }
+}
+
+impl Mul<Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn mul(self, other: Rgb) -> Rgb {
+        Rgb {
+            red: self.red * other.red,
+            green: self.green * other.green,
+            blue: self.blue * other.blue,
+            alpha: self.alpha * other.alpha,
+        }
+    }
+}
+
+impl Mul<f32> for Rgb {
+    type Output = Rgb;
+
+    fn mul(self, c: f32) -> Rgb {
+        Rgb {
+            red: self.red * c,
+            green: self.green * c,
+            blue: self.blue * c,
+            alpha: self.alpha * c,
+        }
+    }
+}
+
+impl Div<Rgb> for Rgb {
+    type Output = Rgb;
+
+    fn div(self, other: Rgb) -> Rgb {
+        Rgb {
+            red: self.red / other.red,
+            green: self.green / other.green,
+            blue: self.blue / other.blue,
+            alpha: self.alpha / other.alpha,
+        }
+    }
+}
+
+impl Div<f32> for Rgb {
+    type Output = Rgb;
+
+    fn div(self, c: f32) -> Rgb {
+        Rgb {
+            red: self.red / c,
+            green: self.green / c,
+            blue: self.blue / c,
+            alpha: self.alpha / c,
+        }
     }
 }
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -1,3 +1,5 @@
+use std::ops::{Add, Sub, Mul, Div};
+
 use {Color, Rgb, Luma, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
 
 use tristimulus::{X_N, Y_N, Z_N};
@@ -101,6 +103,110 @@ impl Shade for Xyz {
 impl Default for Xyz {
     fn default() -> Xyz {
         Xyz::xyz(0.0, 0.0, 0.0)
+    }
+}
+
+impl Add<Xyz> for Xyz {
+    type Output = Xyz;
+
+    fn add(self, other: Xyz) -> Xyz {
+        Xyz {
+            x: self.x + other.x,
+            y: self.y + other.y,
+            z: self.z + other.z,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl Add<f32> for Xyz {
+    type Output = Xyz;
+
+    fn add(self, c: f32) -> Xyz {
+        Xyz {
+            x: self.x + c,
+            y: self.y + c,
+            z: self.z + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl Sub<Xyz> for Xyz {
+    type Output = Xyz;
+
+    fn sub(self, other: Xyz) -> Xyz {
+        Xyz {
+            x: self.x - other.x,
+            y: self.y - other.y,
+            z: self.z - other.z,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl Sub<f32> for Xyz {
+    type Output = Xyz;
+
+    fn sub(self, c: f32) -> Xyz {
+        Xyz {
+            x: self.x - c,
+            y: self.y - c,
+            z: self.z - c,
+            alpha: self.alpha - c,
+        }
+    }
+}
+
+impl Mul<Xyz> for Xyz {
+    type Output = Xyz;
+
+    fn mul(self, other: Xyz) -> Xyz {
+        Xyz {
+            x: self.x * other.x,
+            y: self.y * other.y,
+            z: self.z * other.z,
+            alpha: self.alpha * other.alpha,
+        }
+    }
+}
+
+impl Mul<f32> for Xyz {
+    type Output = Xyz;
+
+    fn mul(self, c: f32) -> Xyz {
+        Xyz {
+            x: self.x * c,
+            y: self.y * c,
+            z: self.z * c,
+            alpha: self.alpha * c,
+        }
+    }
+}
+
+impl Div<Xyz> for Xyz {
+    type Output = Xyz;
+
+    fn div(self, other: Xyz) -> Xyz {
+        Xyz {
+            x: self.x / other.x,
+            y: self.y / other.y,
+            z: self.z / other.z,
+            alpha: self.alpha / other.alpha,
+        }
+    }
+}
+
+impl Div<f32> for Xyz {
+    type Output = Xyz;
+
+    fn div(self, c: f32) -> Xyz {
+        Xyz {
+            x: self.x / c,
+            y: self.y / c,
+            z: self.z / c,
+            alpha: self.alpha / c,
+        }
     }
 }
 


### PR DESCRIPTION
This implements `Add`, `Sub`, `Mul`  and `Div` as simple component wise operations, and closes #2. This is not necessarily the same thing as blending, depending on which color space we are talking about.

Hue based color spaces does only implement `Add` and `Sub` for now, since multiplication of angles isn't well defined. This may change in the future, as the behavior of the hue types solidifies.