### PR TITLE
Implement Gradient slicing and exact size iteration

### DIFF
--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -288,7 +288,8 @@ impl<'a, C: Mix + Clone> MaybeSlice<'a, C> {
 
 #[cfg(test)]
 mod test {
-    use super::Range;
+    use super::{Range, Gradient};
+    use Rgb;
 
     #[test]
     fn range_clamp() {
@@ -306,7 +307,18 @@ mod test {
 
         assert_eq!(range.constrain(&(3.0..5.0).into()), (1.0..1.0).into());
         assert_eq!(range.constrain(&(0.2..5.0).into()), (0.2..1.0).into());
-        
+
         assert_eq!(range.constrain(&(0.2..0.8).into()), (0.2..0.8).into());
+    }
+
+    #[test]
+    fn simple_slice() {
+        let g1 = Gradient::new(vec![Rgb::linear_rgb(1.0, 0.0, 0.0), Rgb::linear_rgb(0.0, 0.0, 1.0)]);
+        let g2 = g1.slice(..0.5);
+
+        let v1: Vec<_> = g1.take(10).take(5).collect();
+        let v2: Vec<_> = g2.take(5).collect();
+
+        assert_eq!(v1, v2);
     }
 }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -116,4 +116,10 @@ impl<'a, C: Mix + Clone> Iterator for Take<'a, C> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len - self.current, Some(self.len - self.current))
+    }
 }
+
+impl<'a, C: Mix + Clone> ExactSizeIterator for Take<'a, C> { }

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -12,7 +12,7 @@ use Mix;
 ///number of evenly spaced points using the `take` method. Any point outside
 ///the domain of the gradient will have the same color as the closest control
 ///point.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Gradient<C: Mix + Clone>(Vec<(f32, C)>);
 
 impl<C: Mix + Clone> Gradient<C> {
@@ -82,22 +82,36 @@ impl<C: Mix + Clone> Gradient<C> {
 
     ///Take `n` evenly spaced colors from the gradient, as an iterator.
     pub fn take(&self, n: usize) -> Take<C> {
-        let &(min, _) = self.0.get(0).expect("a Gradient must contain at least one color");
-        let &(max, _) = self.0.last().expect("a Gradient must contain at least one color");
+        let (min, max) = self.domain();
 
         Take {
-            gradient: self,
+            gradient: MaybeSlice::NotSlice(self),
             from: min,
             diff: max - min,
             len: n,
             current: 0,
         }
     }
+
+    ///Slice this gradient to limit its domain.
+    pub fn slice<R: Into<Range>>(&self, range: R) -> Slice<C> {
+        Slice {
+            gradient: self,
+            range: range.into(),
+        }
+    }
+
+    ///Get the limits of this gradient's domain.
+    pub fn domain(&self) -> (f32, f32) {
+        let &(min, _) = self.0.get(0).expect("a Gradient must contain at least one color");
+        let &(max, _) = self.0.last().expect("a Gradient must contain at least one color");
+        (min, max)
+    }
 }
 
 ///An iterator over interpolated colors.
 pub struct Take<'a, C: Mix + Clone + 'a> {
-    gradient: &'a Gradient<C>,
+    gradient: MaybeSlice<'a, C>,
     from: f32,
     diff: f32,
     len: usize,
@@ -123,3 +137,176 @@ impl<'a, C: Mix + Clone> Iterator for Take<'a, C> {
 }
 
 impl<'a, C: Mix + Clone> ExactSizeIterator for Take<'a, C> { }
+
+
+///A slice of a Gradient that limits its domain.
+#[derive(Clone, Debug)]
+pub struct Slice<'a, C: Mix + Clone + 'a> {
+    gradient: &'a Gradient<C>,
+    range: Range,
+}
+
+impl<'a, C: Mix + Clone> Slice<'a, C> {
+    ///Get a color from the gradient slice. The color of the closest domain
+    ///limit will be returned if `i` is outside the domain.
+    pub fn get(&self, i: f32) -> C {
+        self.gradient.get(self.range.clamp(i))
+    }
+
+    ///Take `n` evenly spaced colors from the gradient slice, as an iterator.
+    pub fn take(&self, n: usize) -> Take<C> {
+        let (min, max) = self.domain();
+
+        Take {
+            gradient: MaybeSlice::Slice(self.clone()),
+            from: min,
+            diff: max - min,
+            len: n,
+            current: 0,
+        }
+    }
+
+    ///Slice this gradient slice to further limit its domain. Ranges outside
+    ///the domain will be clamped to the nearest domain limit.
+    pub fn slice<R: Into<Range>>(&self, range: R) -> Slice<C> {
+        Slice {
+            gradient: self.gradient,
+            range: self.range.constrain(&range.into())
+        }
+    }
+
+    ///Get the limits of this gradient slice's domain.
+    pub fn domain(&self) -> (f32, f32) {
+        if let Range { from: Some(from), to: Some(to) } = self.range {
+            (from, to)
+        } else {
+            let (from, to) = self.gradient.domain();
+            (self.range.from.unwrap_or(from), self.range.to.unwrap_or(to))
+        }
+    }
+}
+
+///A domain range for gradient slices.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Range {
+    from: Option<f32>,
+    to: Option<f32>,
+}
+
+impl Range {
+    fn clamp(&self, mut x: f32) -> f32 {
+        x = self.from.unwrap_or(x).max(x);
+        self.to.unwrap_or(x).min(x)
+    }
+
+    fn constrain(&self, other: &Range) -> Range {
+        if let (Some(f), Some(t)) = (other.from, self.to) {
+            if f >= t {
+                return Range {
+                    from: self.to,
+                    to: self.to,
+                };
+            }
+        }
+
+        
+        if let (Some(t), Some(f)) = (other.to, self.from) {
+            if t <= f {
+                return Range {
+                    from: self.from,
+                    to: self.from,
+                };
+            }
+        }
+        
+        Range {
+            from: match (self.from, other.from) {
+                (Some(s), Some(o)) => Some(s.max(o)),
+                (Some(s), None) => Some(s),
+                (None, Some(o)) => Some(o),
+                (None, None) => None,
+            },
+            to: match (self.to, other.to) {
+                (Some(s), Some(o)) => Some(s.min(o)),
+                (Some(s), None) => Some(s),
+                (None, Some(o)) => Some(o),
+                (None, None) => None,
+            },
+        }
+    }
+}
+
+impl From<::std::ops::Range<f32>> for Range {
+    fn from(range: ::std::ops::Range<f32>) -> Range {
+        Range {
+            from: Some(range.start),
+            to: Some(range.end),
+        }
+    }
+}
+
+impl From<::std::ops::RangeFrom<f32>> for Range {
+    fn from(range: ::std::ops::RangeFrom<f32>) -> Range {
+        Range {
+            from: Some(range.start),
+            to: None,
+        }
+    }
+}
+
+impl From<::std::ops::RangeTo<f32>> for Range {
+    fn from(range: ::std::ops::RangeTo<f32>) -> Range {
+        Range {
+            from: None,
+            to: Some(range.end),
+        }
+    }
+}
+
+impl From<::std::ops::RangeFull> for Range {
+    fn from(_range: ::std::ops::RangeFull) -> Range {
+        Range {
+            from: None,
+            to: None,
+        }
+    }
+}
+
+enum MaybeSlice<'a, C: Mix + Clone + 'a> {
+    NotSlice(&'a Gradient<C>),
+    Slice(Slice<'a, C>),
+}
+
+impl<'a, C: Mix + Clone> MaybeSlice<'a, C> {
+    fn get(&self, i: f32) -> C {
+        match *self {
+            MaybeSlice::NotSlice(g) => g.get(i),
+            MaybeSlice::Slice(ref s) => s.get(i),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Range;
+
+    #[test]
+    fn range_clamp() {
+        let range: Range = (0.0..1.0).into();
+        assert_eq!(range.clamp(-1.0), 0.0);
+        assert_eq!(range.clamp(2.0), 1.0);
+        assert_eq!(range.clamp(0.5), 0.5);
+    }
+
+    #[test]
+    fn range_constrain() {
+        let range: Range = (0.0..1.0).into();
+        assert_eq!(range.constrain(&(-3.0..-5.0).into()), (0.0..0.0).into());
+        assert_eq!(range.constrain(&(-3.0..0.8).into()), (0.0..0.8).into());
+
+        assert_eq!(range.constrain(&(3.0..5.0).into()), (1.0..1.0).into());
+        assert_eq!(range.constrain(&(0.2..5.0).into()), (0.2..1.0).into());
+        
+        assert_eq!(range.constrain(&(0.2..0.8).into()), (0.2..0.8).into());
+    }
+}


### PR DESCRIPTION
This adds some missing features to the `Gradient` type:

 * Implement `ExactSizeIterator` for `Take`.
 * Make it possible to slice `Gradient`, and thereby close #4.