### PR TITLE
Convert all colors to be generic over floats, f32 and f64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ license = "MIT OR Apache-2.0"
 [features]
 strict = []
 
+[dependencies]
+num = "0.1"
+
 [dev-dependencies]
 image = "0.4"
 approx = "0.1"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ extern crate palette;
 use palette::{Rgb, Lch, Hue};
 
 let lch_color = Lch::from(Rgb::srgb(0.8, 0.2, 0.1));
-let new_color: Rgb = lch_color.shift_hue(180.0.into()).into();
+let new_color: Rgb<f32> = lch_color.shift_hue(180.0.into()).into();
 ```
 
 This results in the following two colors:

--- a/examples/readme_examples.rs
+++ b/examples/readme_examples.rs
@@ -1,7 +1,9 @@
 extern crate image;
 extern crate palette;
+extern crate num;
 
 use image::{RgbImage, GenericImage};
+use num::traits::Float;
 
 use palette::{Rgb, Gradient, Mix};
 
@@ -11,7 +13,7 @@ mod color_spaces {
 
     pub fn run() {
         let lch_color = Lch::from(Rgb::srgb(0.8, 0.2, 0.1));
-        let new_color: Rgb = lch_color.shift_hue(180.0.into()).into();
+        let new_color: Rgb<f32> = lch_color.shift_hue(180.0.into()).into();
 
         display_colors("examples/readme_color_spaces.png", &[Rgb::srgb(0.8, 0.2, 0.1).to_srgb(), new_color.to_srgb()]);
     }
@@ -67,18 +69,18 @@ fn display_colors(filename: &str, colors: &[[u8; 3]]) {
     }
 }
 
-fn display_gradients<A: Mix + Clone, B: Mix + Clone>(filename: &str, grad1: Gradient<A>, grad2: Gradient<B>) where 
-    Rgb: From<A>,
-    Rgb: From<B>
+fn display_gradients<T: Float, A: Mix<T> + Clone, B: Mix<T> + Clone>(filename: &str, grad1: Gradient<T, A>, grad2: Gradient<T, B>)
+    where Rgb<T>: From<A>,
+        Rgb<T>: From<B>
 {
     let mut image = RgbImage::new(256, 64);
 
     for (x, _, pixel) in image.sub_image(0, 0, 256, 32).pixels_mut() {
-        pixel.data = Rgb::from(grad1.get(x as f32 / 255.0)).to_srgb();
+        pixel.data = Rgb::from(grad1.get(T::from(x).unwrap() / T::from(255.0).unwrap())).to_srgb();
     }
 
     for (x, _, pixel) in image.sub_image(0, 32, 256, 32).pixels_mut() {
-        pixel.data = Rgb::from(grad2.get(x as f32 / 255.0)).to_srgb();
+        pixel.data = Rgb::from(grad2.get(T::from(x).unwrap() / T::from(255.0).unwrap())).to_srgb();
     }
 
     match image.save(filename) {

--- a/src/hues.rs
+++ b/src/hues.rs
@@ -1,4 +1,6 @@
-use std::f32::consts::PI;
+use num::traits::Float;
+
+use std::f64::consts::PI;
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub};
 
@@ -12,81 +14,91 @@ macro_rules! make_hues {
         ///also have some surprising effects if it's expected to act as a
         ///linear number.
         #[derive(Clone, Copy, Debug, Default)]
-        pub struct $name(f32);
+        pub struct $name<T:Float = f32>(T);
 
-        impl $name {
+        impl<T:Float> $name<T> {
             ///Create a new hue from radians, instead of degrees.
-            pub fn from_radians(radians: f32) -> $name {
-                $name(radians * 180.0 / PI)
+            pub fn from_radians(radians: T) -> $name<T> {
+                $name(radians * T::from(180.0).unwrap() / T::from(PI).unwrap())
             }
 
             ///Convert the hue to radians.
-            pub fn to_radians(self) -> f32 {
-                normalize_angle(self.0) * PI / 180.0
+            pub fn to_radians(self) -> T {
+                normalize_angle(self.0) * T::from(PI).unwrap() / T::from(180.0).unwrap()
             }
-        }
 
-        impl From<f32> for $name {
-            fn from(degrees: f32) -> $name {
-                $name(degrees)
-            }
-        }
-
-        impl Into<f32> for $name {
-            fn into(self) -> f32 {
+            ///Returns the saved Hue value
+            pub fn to_float(self) -> T {
                 normalize_angle(self.0)
             }
         }
 
-        impl PartialEq for $name {
-            fn eq(&self, other: &$name) -> bool {
-                let hue_s: f32 = (*self).into();
-                let hue_o: f32 = (*other).into();
+        impl<T:Float> From<T> for $name<T> {
+            fn from(degrees: T) -> $name<T> {
+                $name(degrees)
+            }
+        }
+
+        impl Into<f64> for $name<f64> {
+            fn into(self) -> f64 {
+                normalize_angle(self.0) as f64
+            }
+        }
+
+        impl Into<f32> for $name<f32> {
+            fn into(self) -> f32 {
+                normalize_angle(self.0) as f32
+            }
+        }
+        impl Into<f32> for $name<f64> {
+            fn into(self) -> f32 {
+                normalize_angle(self.0) as f32
+            }
+        }
+
+        impl<T:Float> PartialEq for $name<T> {
+            fn eq(&self, other: &$name<T>) -> bool {
+                let hue_s: T = (*self).to_float();
+                let hue_o: T = (*other).to_float();
                 hue_s.eq(&hue_o)
             }
         }
 
-        impl PartialEq<f32> for $name {
-            fn eq(&self, other: &f32) -> bool {
-                let hue: f32 = (*self).into();
+        impl<T:Float> PartialEq<T> for $name<T> {
+            fn eq(&self, other: &T) -> bool {
+                let hue: T = (*self).to_float();
                 hue.eq(&normalize_angle(*other))
             }
         }
 
-        impl PartialEq<$name> for f32 {
-            fn eq(&self, other: &$name) -> bool {
-                other.eq(self)
-            }
-        }
+        impl<T:Float> Add<$name<T>> for $name<T> {
+            type Output = $name<T>;
 
-        impl Add<$name> for $name {
-            type Output = $name;
-
-            fn add(self, other: $name) -> $name {
+            fn add(self, other: $name<T>) -> $name<T> {
                 $name(self.0 + other.0)
             }
         }
 
-        impl Add<f32> for $name {
-            type Output = $name;
+        impl<T:Float> Add<T> for $name<T> {
+            type Output = $name<T>;
 
-            fn add(self, other: f32) -> $name {
+            fn add(self, other: T) -> $name<T> {
                 $name(self.0 + other)
             }
         }
 
-        impl Sub<$name> for $name {
-            type Output = $name;
+        impl<T:Float> Sub<$name<T>> for $name<T> {
+            type Output = $name<T>;
 
-            fn sub(self, other: $name) -> $name {
+            fn sub(self, other: $name<T>) -> $name<T> {
                 $name(self.0 - other.0)
             }
         }
 
-        impl Sub<f32> for $name {
-            type Output = $name;
+        impl<T:Float> Sub<T> for $name<T> {
+            type Output = $name<T>;
 
-            fn sub(self, other: f32) -> $name {
+            fn sub(self, other: T) -> $name<T> {
                 $name(self.0 - other)
             }
         }
@@ -108,13 +120,13 @@ make_hues! {
     struct RgbHue;
 }
 
-fn normalize_angle(mut deg: f32) -> f32 {
-    while deg > 180.0 {
-        deg -= 360.0;
+fn normalize_angle<T: Float>(mut deg: T) -> T {
+    while deg > T::from(180.0).unwrap() {
+        deg = deg - T::from(360.0).unwrap();
     }
 
-    while deg <= -180.0 {
-        deg += 360.0;
+    while deg <= -T::from(180.0).unwrap() {
+        deg = deg - T::from(360.0).unwrap();
     }
 
     deg

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -1,3 +1,5 @@
+use num::traits::Float;
+
 use std::ops::{Add, Sub};
 
 use {Color, ColorSpace, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
@@ -10,72 +12,72 @@ use {Color, ColorSpace, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Lab, Hsv, Hsl, 
 ///[HSV](struct.Hsv.html). This gives it the same ability to directly change
 ///the hue and colorfulness of a color, while preserving other visual aspects.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Lch {
+pub struct Lch<T: Float = f32> {
     ///L* is the lightness of the color. 0.0 gives absolute black and 1.0
     ///give the brightest white.
-    pub l: f32,
+    pub l: T,
 
     ///C* is the colorfulness of the color. It's similar to saturation. 0.0
     ///gives gray scale colors, and numbers around 1.0-1.41421356 gives fully
     ///saturated colors. The upper limit of 1.41421356 (or `sqrt(2.0)`) should
     ///include the whole L*a*b* space and some more.
-    pub chroma: f32,
+    pub chroma: T,
 
     ///The hue of the color, in degrees. Decides if it's red, blue, purple,
     ///etc.
-    pub hue: LabHue,
+    pub hue: LabHue<T>,
 
     ///The transparency of the color. 0.0 is completely transparent and 1.0 is
     ///completely opaque.
-    pub alpha: f32,
+    pub alpha: T,
 }
 
-impl Lch {
+impl<T: Float> Lch<T> {
     ///CIE L*C*h°.
-    pub fn lch(l: f32, chroma: f32, hue: LabHue) -> Lch {
+    pub fn lch(l: T, chroma: T, hue: LabHue<T>) -> Lch<T> {
         Lch {
             l: l,
             chroma: chroma,
             hue: hue,
-            alpha: 1.0
+            alpha: T::one(),
         }
     }
 
     ///CIE L*C*h° and transparency.
-    pub fn lcha(l: f32, chroma: f32, hue: LabHue, alpha: f32) -> Lch {
+    pub fn lcha(l: T, chroma: T, hue: LabHue<T>, alpha: T) -> Lch<T> {
         Lch {
             l: l,
             chroma: chroma,
             hue: hue,
-            alpha: alpha
+            alpha: alpha,
         }
     }
 }
 
-impl ColorSpace for Lch {
+impl<T: Float> ColorSpace for Lch<T> {
     fn is_valid(&self) -> bool {
-        self.l >= 0.0 && self.l <= 1.0 &&
-        self.chroma >= 0.0 && self.chroma <= 1.41421356 && //should include all of L*a*b*, but will also overshoot...
-        self.alpha >= 0.0 && self.alpha <= 1.0
+        self.l >= T::zero() && self.l <= T::one() &&
+        self.chroma >= T::zero() && self.chroma <= T::from(1.41421356).unwrap() && //should include all of L*a*b*, but will also overshoot...
+        self.alpha >= T::zero() && self.alpha <= T::one()
     }
 
-    fn clamp(&self) -> Lch {
+    fn clamp(&self) -> Lch<T> {
         let mut c = *self;
         c.clamp_self();
         c
     }
 
     fn clamp_self(&mut self) {
-        self.l = clamp(self.l, 0.0, 1.0);
-        self.chroma = clamp(self.chroma, 0.0, 1.41421356); //should include all of L*a*b*, but will also overshoot...
-        self.alpha = clamp(self.alpha, 0.0, 1.0);
+        self.l = clamp(self.l, T::zero(), T::one());
+        self.chroma = clamp(self.chroma, T::zero(), T::from(1.41421356).unwrap()); //should include all of L*a*b*, but will also overshoot...
+        self.alpha = clamp(self.alpha, T::zero(), T::one());
     }
 }
 
-impl Mix for Lch {
-    fn mix(&self, other: &Lch, factor: f32) -> Lch {
-        let factor = clamp(factor, 0.0, 1.0);
-        let hue_diff: f32 = (other.hue - self.hue).into();
+impl<T: Float> Mix<T> for Lch<T> {
+    fn mix(&self, other: &Lch<T>, factor: T) -> Lch<T> {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff: T = (other.hue - self.hue).to_float();
         Lch {
             l: self.l + factor * (other.l - self.l),
             chroma: self.chroma + factor * (other.chroma - self.chroma),
@@ -85,8 +87,8 @@ impl Mix for Lch {
     }
 }
 
-impl Shade for Lch {
-    fn lighten(&self, amount: f32) -> Lch {
+impl<T: Float> Shade<T> for Lch<T> {
+    fn lighten(&self, amount: T) -> Lch<T> {
         Lch {
             l: self.l + amount,
             chroma: self.chroma,
@@ -96,11 +98,11 @@ impl Shade for Lch {
     }
 }
 
-impl GetHue for Lch {
-    type Hue = LabHue;
+impl<T: Float> GetHue for Lch<T> {
+    type Hue = LabHue<T>;
 
-    fn get_hue(&self) -> Option<LabHue> {
-        if self.chroma <= 0.0 {
+    fn get_hue(&self) -> Option<LabHue<T>> {
+        if self.chroma <= T::zero() {
             None
         } else {
             Some(self.hue)
@@ -108,8 +110,8 @@ impl GetHue for Lch {
     }
 }
 
-impl Hue for Lch {
-    fn with_hue(&self, hue: LabHue) -> Lch {
+impl<T: Float> Hue for Lch<T> {
+    fn with_hue(&self, hue: LabHue<T>) -> Lch<T> {
         Lch {
             l: self.l,
             chroma: self.chroma,
@@ -118,7 +120,7 @@ impl Hue for Lch {
         }
     }
 
-    fn shift_hue(&self, amount: LabHue) -> Lch {
+    fn shift_hue(&self, amount: LabHue<T>) -> Lch<T> {
         Lch {
             l: self.l,
             chroma: self.chroma,
@@ -128,27 +130,27 @@ impl Hue for Lch {
     }
 }
 
-impl Saturate for Lch {
-    fn saturate(&self, factor: f32) -> Lch {
+impl<T: Float> Saturate<T> for Lch<T> {
+    fn saturate(&self, factor: T) -> Lch<T> {
         Lch {
             l: self.l,
-            chroma: self.chroma * (1.0 + factor),
+            chroma: self.chroma * (T::one() + factor),
             hue: self.hue,
             alpha: self.alpha,
         }
     }
 }
 
-impl Default for Lch {
-    fn default() -> Lch {
-        Lch::lch(0.0, 0.0, 0.0.into())
+impl<T: Float> Default for Lch<T> {
+    fn default() -> Lch<T> {
+        Lch::lch(T::zero(), T::zero(), LabHue::from(T::zero()))
     }
 }
 
-impl Add<Lch> for Lch {
-    type Output = Lch;
+impl<T: Float> Add<Lch<T>> for Lch<T> {
+    type Output = Lch<T>;
 
-    fn add(self, other: Lch) -> Lch {
+    fn add(self, other: Lch<T>) -> Lch<T> {
         Lch {
             l: self.l + other.l,
             chroma: self.chroma + other.chroma,
@@ -158,10 +160,10 @@ impl Add<Lch> for Lch {
     }
 }
 
-impl Add<f32> for Lch {
-    type Output = Lch;
+impl<T: Float> Add<T> for Lch<T> {
+    type Output = Lch<T>;
 
-    fn add(self, c: f32) -> Lch {
+    fn add(self, c: T) -> Lch<T> {
         Lch {
             l: self.l + c,
             chroma: self.chroma + c,
@@ -171,10 +173,10 @@ impl Add<f32> for Lch {
     }
 }
 
-impl Sub<Lch> for Lch {
-    type Output = Lch;
+impl<T: Float> Sub<Lch<T>> for Lch<T> {
+    type Output = Lch<T>;
 
-    fn sub(self, other: Lch) -> Lch {
+    fn sub(self, other: Lch<T>) -> Lch<T> {
         Lch {
             l: self.l - other.l,
             chroma: self.chroma - other.chroma,
@@ -184,10 +186,10 @@ impl Sub<Lch> for Lch {
     }
 }
 
-impl Sub<f32> for Lch {
-    type Output = Lch;
+impl<T: Float> Sub<T> for Lch<T> {
+    type Output = Lch<T>;
 
-    fn sub(self, c: f32) -> Lch {
+    fn sub(self, c: T) -> Lch<T> {
         Lch {
             l: self.l - c,
             chroma: self.chroma - c,
@@ -199,43 +201,43 @@ impl Sub<f32> for Lch {
 
 from_color!(to Lch from Rgb, Luma, Xyz, Lab, Hsv, Hsl);
 
-impl From<Lab> for Lch {
-    fn from(lab: Lab) -> Lch {
+impl<T: Float> From<Lab<T>> for Lch<T> {
+    fn from(lab: Lab<T>) -> Lch<T> {
         Lch {
             l: lab.l,
             chroma: (lab.a * lab.a + lab.b * lab.b).sqrt(),
-            hue: lab.get_hue().unwrap_or(0.0.into()),
+            hue: lab.get_hue().unwrap_or(LabHue::from(T::zero())),
             alpha: lab.alpha,
         }
     }
 }
 
-impl From<Rgb> for Lch {
-    fn from(rgb: Rgb) -> Lch {
+impl<T: Float> From<Rgb<T>> for Lch<T> {
+    fn from(rgb: Rgb<T>) -> Lch<T> {
         Lab::from(rgb).into()
     }
 }
 
-impl From<Luma> for Lch {
-    fn from(luma: Luma) -> Lch {
+impl<T: Float> From<Luma<T>> for Lch<T> {
+    fn from(luma: Luma<T>) -> Lch<T> {
         Lab::from(luma).into()
     }
 }
 
-impl From<Xyz> for Lch {
-    fn from(xyz: Xyz) -> Lch {
+impl<T: Float> From<Xyz<T>> for Lch<T> {
+    fn from(xyz: Xyz<T>) -> Lch<T> {
         Lab::from(xyz).into()
     }
 }
 
-impl From<Hsv> for Lch {
-    fn from(hsv: Hsv) -> Lch {
+impl<T: Float> From<Hsv<T>> for Lch<T> {
+    fn from(hsv: Hsv<T>) -> Lch<T> {
         Lab::from(hsv).into()
     }
 }
 
-impl From<Hsl> for Lch {
-    fn from(hsl: Hsl) -> Lch {
+impl<T: Float> From<Hsl<T>> for Lch<T> {
+    fn from(hsl: Hsl<T>) -> Lch<T> {
         Lab::from(hsl).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 #[cfg(test)]
 #[macro_use]
 extern crate approx;
+extern crate num;
+
+use num::traits::Float;
 
 pub use gradient::Gradient;
 pub use rgb::{Rgb, RgbPixel};
@@ -37,8 +40,8 @@ pub use hues::{LabHue, RgbHue};
 
 macro_rules! from_color {
     (to $to:ident from $($from:ident),+) => (
-        impl From<Color> for $to {
-            fn from(color: Color) -> $to {
+        impl<T:Float> From<Color<T>> for $to<T> {
+            fn from(color: Color<T>) -> $to<T> {
                 match color {
                     Color::$to(c) => c,
                     $(Color::$from(c) => c.into(),)+
@@ -81,7 +84,7 @@ macro_rules! make_color {
         #[$variant_comment:meta]
         $variant:ident {$(
             #[$ctor_comment:meta]
-            $ctor_name:ident $(<$($ty_params:ident: $ty_param_traits:ident),*>)* ($($ctor_field:ident : $ctor_ty:ty),*);
+            $ctor_name:ident $( <$( $ty_params:ident: $ty_param_traits:ident $( <$( $ty_inner_traits:ident ),*> )*),*> )* ($($ctor_field:ident : $ctor_ty:ty),*);
         )+}
     )+) => (
 
@@ -101,60 +104,60 @@ macro_rules! make_color {
         ///but it can easily be converted to a fixed color space in those
         ///cases.
         #[derive(Clone, Copy, Debug)]
-        pub enum Color {
-            $(#[$variant_comment] $variant($variant)),+
+        pub enum Color<T:Float = f32> {
+            $(#[$variant_comment] $variant($variant<T>)),+
         }
 
         $(
-            impl Color {
+            impl<T:Float> Color<T> {
                 $(
                     #[$ctor_comment]
-                    pub fn $ctor_name$(<$($ty_params : $ty_param_traits),*>)*($($ctor_field: $ctor_ty),*) -> Color {
+                    pub fn $ctor_name$(<$($ty_params : $ty_param_traits$( <$( $ty_inner_traits ),*> )*),*>)*($($ctor_field: $ctor_ty),*) -> Color<T> {
                         Color::$variant($variant::$ctor_name($($ctor_field),*))
                     }
                 )+
             }
         )+
 
-        impl Mix for Color {
-            fn mix(&self, other: &Color, factor: f32) -> Color {
+        impl<T:Float> Mix<T> for Color<T> {
+            fn mix(&self, other: &Color<T>, factor: T) -> Color<T> {
                 Rgb::from(*self).mix(&Rgb::from(*other), factor).into()
             }
         }
 
-        impl Shade for Color {
-            fn lighten(&self, amount: f32) -> Color {
+        impl<T:Float> Shade<T> for Color<T> {
+            fn lighten(&self, amount: T) -> Color<T> {
                 Lab::from(*self).lighten(amount).into()
             }
         }
 
-        impl GetHue for Color {
-            type Hue = LabHue;
+        impl<T:Float> GetHue for Color<T> {
+            type Hue = LabHue<T>;
 
-            fn get_hue(&self) -> Option<LabHue> {
+            fn get_hue(&self) -> Option<LabHue<T>> {
                 Lch::from(*self).get_hue()
             }
         }
 
-        impl Hue for Color {
-            fn with_hue(&self, hue: LabHue) -> Color {
+        impl<T:Float> Hue for Color<T> {
+            fn with_hue(&self, hue: LabHue<T>) -> Color<T> {
                 Lch::from(*self).with_hue(hue).into()
             }
 
-            fn shift_hue(&self, amount: LabHue) -> Color {
+            fn shift_hue(&self, amount: LabHue<T>) -> Color<T> {
                 Lch::from(*self).shift_hue(amount).into()
             }
         }
 
-        impl Saturate for Color {
-            fn saturate(&self, factor: f32) -> Color {
+        impl<T:Float> Saturate<T> for Color<T> {
+            fn saturate(&self, factor: T) -> Color<T> {
                 Lch::from(*self).saturate(factor).into()
             }
         }
 
         $(
-            impl From<$variant> for Color {
-                fn from(color: $variant) -> Color {
+            impl<T:Float> From<$variant<T>> for Color<T> {
+                fn from(color: $variant<T>) -> Color<T> {
                     Color::$variant(color)
                 }
             }
@@ -162,7 +165,7 @@ macro_rules! make_color {
     )
 }
 
-fn clamp(v: f32, min: f32, max: f32) -> f32 {
+fn clamp<T:Float>(v: T, min: T, max: T) -> T {
     if v < min {
         min
     } else if v > max {
@@ -176,10 +179,10 @@ make_color! {
     ///Linear luminance.
     Luma {
         ///Linear luminance.
-        y(luma: f32);
+        y(luma: T);
 
         ///Linear luminance with transparency.
-        ya(luma: f32, alpha: f32);
+        ya(luma: T, alpha: T);
 
         ///Linear luminance from an 8 bit value.
         y8(luma: u8);
@@ -191,10 +194,10 @@ make_color! {
     ///Linear RGB.
     Rgb {
         ///Linear RGB.
-        linear_rgb(red: f32, green: f32, blue: f32);
+        linear_rgb(red: T, green: T, blue: T);
 
         ///Linear RGB and transparency.
-        linear_rgba(red: f32, green: f32, blue: f32, alpha: f32);
+        linear_rgba(red: T, green: T, blue: T, alpha: T);
 
         ///Linear RGB from 8 bit values.
         linear_rgb8(red: u8, green: u8, blue: u8);
@@ -203,13 +206,13 @@ make_color! {
         linear_rgba8(red: u8, green: u8, blue: u8, alpha: u8);
 
         ///Linear RGB from a linear pixel value.
-        linear_pixel<P: RgbPixel>(pixel: &P);
+        linear_pixel<P: RgbPixel<T> >(pixel: &P);
 
         ///Linear RGB from sRGB.
-        srgb(red: f32, green: f32, blue: f32);
+        srgb(red: T, green: T, blue: T);
 
         ///Linear RGB from sRGB with transparency.
-        srgba(red: f32, green: f32, blue: f32, alpha: f32);
+        srgba(red: T, green: T, blue: T, alpha: T);
 
         ///Linear RGB from 8 bit sRGB.
         srgb8(red: u8, green: u8, blue: u8);
@@ -218,67 +221,67 @@ make_color! {
         srgba8(red: u8, green: u8, blue: u8, alpha: u8);
 
         ///Linear RGB from an sRGB pixel value.
-        srgb_pixel<P: RgbPixel>(pixel: &P);
+        srgb_pixel<P: RgbPixel<T> >(pixel: &P);
 
         ///Linear RGB from gamma corrected RGB.
-        gamma_rgb(red: f32, green: f32, blue: f32, gamma: f32);
+        gamma_rgb(red: T, green: T, blue: T, gamma: T);
 
         ///Linear RGB from gamma corrected RGB with transparency.
-        gamma_rgba(red: f32, green: f32, blue: f32, alpha: f32, gamma: f32);
+        gamma_rgba(red: T, green: T, blue: T, alpha: T, gamma: T);
 
         ///Linear RGB from 8 bit gamma corrected RGB.
-        gamma_rgb8(red: u8, green: u8, blue: u8, gamma: f32);
+        gamma_rgb8(red: u8, green: u8, blue: u8, gamma: T);
 
         ///Linear RGB from 8 bit gamma corrected RGB with transparency.
-        gamma_rgba8(red: u8, green: u8, blue: u8, alpha: u8, gamma: f32);
+        gamma_rgba8(red: u8, green: u8, blue: u8, alpha: u8, gamma: T);
 
         ///Linear RGB from a gamma corrected pixel value.
-        gamma_pixel<P: RgbPixel>(pixel: &P, gamma: f32);
+        gamma_pixel<P: RgbPixel<T> >(pixel: &P, gamma: T);
     }
 
     ///CIE 1931 XYZ.
     Xyz {
         ///CIE XYZ.
-        xyz(x: f32, y: f32, z: f32);
+        xyz(x: T, y: T, z: T);
 
         ///CIE XYZ and transparency.
-        xyza(x: f32, y: f32, z: f32, alpha: f32);
+        xyza(x: T, y: T, z: T, alpha: T);
     }
 
     ///CIE L*a*b* (CIELAB).
     Lab {
         ///CIE L*a*b*.
-        lab(l: f32, a: f32, b: f32);
+        lab(l: T, a: T, b: T);
 
         ///CIE L*a*b* and transparency.
-        laba(l: f32, a: f32, b: f32, alpha: f32);
+        laba(l: T, a: T, b: T, alpha: T);
     }
 
     ///CIE L*C*h°, a polar version of CIE L*a*b*.
     Lch {
         ///CIE L*C*h°.
-        lch(l: f32, chroma: f32, hue: LabHue);
+        lch(l: T, chroma: T, hue: LabHue<T>);
 
         ///CIE L*C*h° and transparency.
-        lcha(l: f32, chroma: f32, hue: LabHue, alpha: f32);
+        lcha(l: T, chroma: T, hue: LabHue<T>, alpha: T);
     }
 
     ///Linear HSV, a cylindrical version of RGB.
     Hsv {
         ///Linear HSV.
-        hsv(hue: RgbHue, saturation: f32, value: f32);
+        hsv(hue: RgbHue<T>, saturation: T, value: T);
 
         ///Linear HSV and transparency.
-        hsva(hue: RgbHue, saturation: f32, value: f32, alpha: f32);
+        hsva(hue: RgbHue<T>, saturation: T, value: T, alpha: T);
     }
 
     ///Linear HSL, a cylindrical version of RGB.
     Hsl {
         ///Linear HSL.
-        hsl(hue: RgbHue, saturation: f32, lightness: f32);
+        hsl(hue: RgbHue<T>, saturation: T, lightness: T);
 
         ///Linear HSL and transparency.
-        hsla(hue: RgbHue, saturation: f32, lightness: f32, alpha: f32);
+        hsla(hue: RgbHue<T>, saturation: T, lightness: T, alpha: T);
     }
 }
 
@@ -307,13 +310,13 @@ pub trait ColorSpace {
 ///assert_eq!(a.mix(&b, 0.5), Rgb::linear_rgb(0.5, 0.5, 0.5));
 ///assert_eq!(a.mix(&b, 1.0), b);
 ///```
-pub trait Mix {
+pub trait Mix<T:Float> {
     ///Mix the color with an other color, by `factor`.
     ///
     ///`factor` sould be between `0.0` and `1.0`, where `0.0` will result in
     ///the same color as `self` and `1.0` will result in the same color as
     ///`other`.
-    fn mix(&self, other: &Self, factor: f32) -> Self;
+    fn mix(&self, other: &Self, factor: T) -> Self;
 }
 
 ///The `Shade` trait allows a color to be lightened or darkened.
@@ -326,12 +329,12 @@ pub trait Mix {
 ///
 ///assert_eq!(a.lighten(0.1), b.darken(0.1));
 ///```
-pub trait Shade: Sized {
+pub trait Shade<T:Float>: Sized {
     ///Lighten the color by `amount`.
-    fn lighten(&self, amount: f32) -> Self;
+    fn lighten(&self, amount: T) -> Self;
 
     ///Darken the color by `amount`.
-    fn darken(&self, amount: f32) -> Self {
+    fn darken(&self, amount: T) -> Self {
         self.lighten(-amount)
     }
 }
@@ -341,10 +344,10 @@ pub trait Shade: Sized {
 ///```
 ///use palette::{Rgb, GetHue};
 ///
-///let red = Rgb::linear_rgb(1.0, 0.0, 0.0);
-///let green = Rgb::linear_rgb(0.0, 1.0, 0.0);
-///let blue = Rgb::linear_rgb(0.0, 0.0, 1.0);
-///let gray = Rgb::linear_rgb(0.5, 0.5, 0.5);
+///let red = Rgb::linear_rgb(1.0_f32, 0.0, 0.0);
+///let green = Rgb::linear_rgb(0.0_f32, 1.0, 0.0);
+///let blue = Rgb::linear_rgb(0.0_f32, 0.0, 1.0);
+///let gray = Rgb::linear_rgb(0.5_f32, 0.5, 0.5);
 ///
 ///assert_eq!(red.get_hue(), Some(0.0.into()));
 ///assert_eq!(green.get_hue(), Some(120.0.into()));
@@ -387,12 +390,12 @@ pub trait Hue: GetHue {
 ///
 ///assert_eq!(a.saturate(1.0), b.desaturate(0.5));
 ///```
-pub trait Saturate: Sized {
+pub trait Saturate<T: Float>: Sized {
     ///Increase the saturation by `factor`.
-    fn saturate(&self, factor: f32) -> Self;
+    fn saturate(&self, factor: T) -> Self;
 
     ///Decrease the saturation by `factor`.
-    fn desaturate(&self, factor: f32) -> Self {
+    fn desaturate(&self, factor: T) -> Self {
         self.saturate(-factor)
     }
 }

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -1,3 +1,5 @@
+use num::traits::Float;
+
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Color, Rgb, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
@@ -10,26 +12,26 @@ use {Color, Rgb, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
 ///XYZ](struct.Xyz.html). The lack of any form of hue representation limits
 ///the set of operations that can be performed on it.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Luma {
+pub struct Luma<T: Float = f32> {
     ///The lightness of the color. 0.0 is black and 1.0 is white.
-    pub luma: f32,
+    pub luma: T,
 
     ///The transparency of the color. 0.0 is completely transparent and 1.0 is
     ///completely opaque.
-    pub alpha: f32,
+    pub alpha: T,
 }
 
-impl Luma {
+impl<T: Float> Luma<T> {
     ///Linear luminance.
-    pub fn y(luma: f32) -> Luma {
+    pub fn y(luma: T) -> Luma<T> {
         Luma {
             luma: luma,
-            alpha: 0.0,
+            alpha: T::zero(),
         }
     }
 
     ///Linear luminance with transparency.
-    pub fn ya(luma: f32, alpha: f32) -> Luma {
+    pub fn ya(luma: T, alpha: T) -> Luma<T> {
         Luma {
             luma: luma,
             alpha: alpha,
@@ -37,43 +39,43 @@ impl Luma {
     }
 
     ///Linear luminance from an 8 bit value.
-    pub fn y8(luma: u8) -> Luma {
+    pub fn y8(luma: u8) -> Luma<T> {
         Luma {
-            luma: luma as f32 / 255.0,
-            alpha: 0.0,
+            luma: T::from(luma).unwrap() / T::from(255.0).unwrap(),
+            alpha: T::zero(),
         }
     }
 
     ///Linear luminance and transparency from 8 bit values.
-    pub fn ya8(luma: u8, alpha: u8) -> Luma {
+    pub fn ya8(luma: u8, alpha: u8) -> Luma<T> {
         Luma {
-            luma: luma as f32 / 255.0,
-            alpha: alpha as f32 / 255.0,
+            luma: T::from(luma).unwrap() / T::from(255.0).unwrap(),
+            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
         }
     }
 }
 
-impl ColorSpace for Luma {
+impl<T: Float> ColorSpace for Luma<T> {
     fn is_valid(&self) -> bool {
-        self.luma >= 0.0 && self.luma <= 1.0 &&
-        self.alpha >= 0.0 && self.alpha <= 1.0
+        self.luma >= T::zero() && self.luma <= T::one() && self.alpha >= T::zero() &&
+        self.alpha <= T::one()
     }
 
-    fn clamp(&self) -> Luma {
+    fn clamp(&self) -> Luma<T> {
         let mut c = *self;
         c.clamp_self();
         c
     }
 
     fn clamp_self(&mut self) {
-        self.luma = clamp(self.luma, 0.0, 1.0);
-        self.alpha = clamp(self.alpha, 0.0, 1.0);
+        self.luma = clamp(self.luma, T::zero(), T::one());
+        self.alpha = clamp(self.alpha, T::zero(), T::one());
     }
 }
 
-impl Mix for Luma {
-    fn mix(&self, other: &Luma, factor: f32) -> Luma {
-        let factor = clamp(factor, 0.0, 1.0);
+impl<T: Float> Mix<T> for Luma<T> {
+    fn mix(&self, other: &Luma<T>, factor: T) -> Luma<T> {
+        let factor = clamp(factor, T::zero(), T::one());
 
         Luma {
             luma: self.luma + factor * (other.luma - self.luma),
@@ -82,25 +84,25 @@ impl Mix for Luma {
     }
 }
 
-impl Shade for Luma {
-    fn lighten(&self, amount: f32) -> Luma {
+impl<T: Float> Shade<T> for Luma<T> {
+    fn lighten(&self, amount: T) -> Luma<T> {
         Luma {
-            luma: (self.luma + amount).max(0.0),
+            luma: (self.luma + amount).max(T::zero()),
             alpha: self.alpha,
         }
     }
 }
 
-impl Default for Luma {
-    fn default() -> Luma {
-        Luma::y(0.0)
+impl<T: Float> Default for Luma<T> {
+    fn default() -> Luma<T> {
+        Luma::y(T::zero())
     }
 }
 
-impl Add<Luma> for Luma {
-    type Output = Luma;
+impl<T: Float> Add<Luma<T>> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn add(self, other: Luma) -> Luma {
+    fn add(self, other: Luma<T>) -> Luma<T> {
         Luma {
             luma: self.luma + other.luma,
             alpha: self.alpha + other.alpha,
@@ -108,10 +110,10 @@ impl Add<Luma> for Luma {
     }
 }
 
-impl Add<f32> for Luma {
-    type Output = Luma;
+impl<T: Float> Add<T> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn add(self, c: f32) -> Luma {
+    fn add(self, c: T) -> Luma<T> {
         Luma {
             luma: self.luma + c,
             alpha: self.alpha + c,
@@ -119,10 +121,10 @@ impl Add<f32> for Luma {
     }
 }
 
-impl Sub<Luma> for Luma {
-    type Output = Luma;
+impl<T: Float> Sub<Luma<T>> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn sub(self, other: Luma) -> Luma {
+    fn sub(self, other: Luma<T>) -> Luma<T> {
         Luma {
             luma: self.luma - other.luma,
             alpha: self.alpha - other.alpha,
@@ -130,10 +132,10 @@ impl Sub<Luma> for Luma {
     }
 }
 
-impl Sub<f32> for Luma {
-    type Output = Luma;
+impl<T: Float> Sub<T> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn sub(self, c: f32) -> Luma {
+    fn sub(self, c: T) -> Luma<T> {
         Luma {
             luma: self.luma - c,
             alpha: self.alpha - c,
@@ -141,10 +143,10 @@ impl Sub<f32> for Luma {
     }
 }
 
-impl Mul<Luma> for Luma {
-    type Output = Luma;
+impl<T: Float> Mul<Luma<T>> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn mul(self, other: Luma) -> Luma {
+    fn mul(self, other: Luma<T>) -> Luma<T> {
         Luma {
             luma: self.luma * other.luma,
             alpha: self.alpha * other.alpha,
@@ -152,10 +154,10 @@ impl Mul<Luma> for Luma {
     }
 }
 
-impl Mul<f32> for Luma {
-    type Output = Luma;
+impl<T: Float> Mul<T> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn mul(self, c: f32) -> Luma {
+    fn mul(self, c: T) -> Luma<T> {
         Luma {
             luma: self.luma * c,
             alpha: self.alpha * c,
@@ -163,10 +165,10 @@ impl Mul<f32> for Luma {
     }
 }
 
-impl Div<Luma> for Luma {
-    type Output = Luma;
+impl<T: Float> Div<Luma<T>> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn div(self, other: Luma) -> Luma {
+    fn div(self, other: Luma<T>) -> Luma<T> {
         Luma {
             luma: self.luma / other.luma,
             alpha: self.alpha / other.alpha,
@@ -174,10 +176,10 @@ impl Div<Luma> for Luma {
     }
 }
 
-impl Div<f32> for Luma {
-    type Output = Luma;
+impl<T: Float> Div<T> for Luma<T> {
+    type Output = Luma<T>;
 
-    fn div(self, c: f32) -> Luma {
+    fn div(self, c: T) -> Luma<T> {
         Luma {
             luma: self.luma / c,
             alpha: self.alpha / c,
@@ -187,44 +189,44 @@ impl Div<f32> for Luma {
 
 from_color!(to Luma from Rgb, Xyz, Lab, Lch, Hsv, Hsl);
 
-impl From<Rgb> for Luma {
-    fn from(rgb: Rgb) -> Luma {
+impl<T: Float> From<Rgb<T>> for Luma<T> {
+    fn from(rgb: Rgb<T>) -> Luma<T> {
         Luma {
-            luma: rgb.red * 0.2126 + rgb.green * 0.7152 + rgb.blue * 0.0722,
+            luma: rgb.red * T::from(0.2126).unwrap() + rgb.green * T::from(0.7152).unwrap() + rgb.blue * T::from(0.0722).unwrap(),
             alpha: rgb.alpha
         }
     }
 }
 
-impl From<Xyz> for Luma {
-    fn from(xyz: Xyz) -> Luma {
+impl<T: Float> From<Xyz<T>> for Luma<T> {
+    fn from(xyz: Xyz<T>) -> Luma<T> {
         Luma {
             luma: xyz.y,
-            alpha: xyz.alpha
+            alpha: xyz.alpha,
         }
     }
 }
 
-impl From<Lab> for Luma {
-    fn from(lab: Lab) -> Luma {
+impl<T: Float> From<Lab<T>> for Luma<T> {
+    fn from(lab: Lab<T>) -> Luma<T> {
         Xyz::from(lab).into()
     }
 }
 
-impl From<Lch> for Luma {
-    fn from(lch: Lch) -> Luma {
+impl<T: Float> From<Lch<T>> for Luma<T> {
+    fn from(lch: Lch<T>) -> Luma<T> {
         Xyz::from(lch).into()
     }
 }
 
-impl From<Hsv> for Luma {
-    fn from(hsv: Hsv) -> Luma {
+impl<T: Float> From<Hsv<T>> for Luma<T> {
+    fn from(hsv: Hsv<T>) -> Luma<T> {
         Rgb::from(hsv).into()
     }
 }
 
-impl From<Hsl> for Luma {
-    fn from(hsl: Hsl) -> Luma {
+impl<T: Float> From<Hsl<T>> for Luma<T> {
+    fn from(hsl: Hsl<T>) -> Luma<T> {
         Rgb::from(hsl).into()
     }
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,3 +1,5 @@
+use num::traits::Float;
+
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Color, Luma, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, RgbHue, clamp};
@@ -14,38 +16,38 @@ use {Color, Luma, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, RgbHu
 ///meaning that gamma correction is required when converting to and from
 ///a displayable RGB, such as sRGB.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Rgb {
+pub struct Rgb<T: Float> {
     ///The amount of red light, where 0.0 is no red light and 1.0 is the
     ///highest displayable amount.
-    pub red: f32,
+    pub red: T,
 
     ///The amount of green light, where 0.0 is no green light and 1.0 is the
     ///highest displayable amount.
-    pub green: f32,
+    pub green: T,
 
     ///The amount of blue light, where 0.0 is no blue light and 1.0 is the
     ///highest displayable amount.
-    pub blue: f32,
+    pub blue: T,
 
     ///The transparency of the color. 0.0 is completely transparent and 1.0 is
     ///completely opaque.
-    pub alpha: f32,
+    pub alpha: T,
 }
 
 ///Creation from linear RGB.
-impl Rgb {
+impl<T: Float> Rgb<T> {
     ///Linear RGB.
-    pub fn linear_rgb(red: f32, green: f32, blue: f32) -> Rgb {
+    pub fn linear_rgb(red: T, green: T, blue: T) -> Rgb<T> {
         Rgb {
             red: red,
             green: green,
             blue: blue,
-            alpha: 1.0,
+            alpha: T::one(),
         }
     }
 
     ///Linear RGB with transparency.
-    pub fn linear_rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Rgb {
+    pub fn linear_rgba(red: T, green: T, blue: T, alpha: T) -> Rgb<T> {
         Rgb {
             red: red,
             green: green,
@@ -55,46 +57,46 @@ impl Rgb {
     }
 
     ///Linear RGB from 8 bit values.
-    pub fn linear_rgb8(red: u8, green: u8, blue: u8) -> Rgb {
+    pub fn linear_rgb8(red: u8, green: u8, blue: u8) -> Rgb<T> {
         Rgb {
-            red: red as f32 / 255.0,
-            green: green as f32 / 255.0,
-            blue: blue as f32 / 255.0,
-            alpha: 1.0,
+            red: T::from(red).unwrap() / T::from(255.0).unwrap(),
+            green: T::from(green).unwrap() / T::from(255.0).unwrap(),
+            blue: T::from(blue).unwrap() / T::from(255.0).unwrap(),
+            alpha: T::one(),
         }
     }
 
     ///Linear RGB with transparency from 8 bit values.
-    pub fn linear_rgba8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgb {
+    pub fn linear_rgba8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgb<T> {
         Rgb {
-            red: red as f32 / 255.0,
-            green: green as f32 / 255.0,
-            blue: blue as f32 / 255.0,
-            alpha: alpha as f32 / 255.0,
+            red: T::from(red).unwrap() / T::from(255.0).unwrap(),
+            green: T::from(green).unwrap() / T::from(255.0).unwrap(),
+            blue: T::from(blue).unwrap() / T::from(255.0).unwrap(),
+            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
         }
     }
 
     ///Linear RGB from a linear pixel value.
-    pub fn linear_pixel<P: RgbPixel>(pixel: &P) -> Rgb {
+    pub fn linear_pixel<P: RgbPixel<T>>(pixel: &P) -> Rgb<T> {
         let (r, g, b, a) = pixel.to_rgba();
         Rgb::linear_rgba(r, g, b, a)
     }
 }
 
 ///Creation from sRGB.
-impl Rgb {
+impl<T: Float> Rgb<T> {
     ///Linear RGB from sRGB.
-    pub fn srgb(red: f32, green: f32, blue: f32) -> Rgb {
+    pub fn srgb(red: T, green: T, blue: T) -> Rgb<T> {
         Rgb {
             red: from_srgb(red),
             green: from_srgb(green),
             blue: from_srgb(blue),
-            alpha: 1.0,
+            alpha: T::one(),
         }
     }
 
     ///Linear RGB from sRGB with transparency.
-    pub fn srgba(red: f32, green: f32, blue: f32, alpha: f32) -> Rgb {
+    pub fn srgba(red: T, green: T, blue: T, alpha: T) -> Rgb<T> {
         Rgb {
             red: from_srgb(red),
             green: from_srgb(green),
@@ -104,46 +106,46 @@ impl Rgb {
     }
 
     ///Linear RGB from 8 bit sRGB.
-    pub fn srgb8(red: u8, green: u8, blue: u8) -> Rgb {
+    pub fn srgb8(red: u8, green: u8, blue: u8) -> Rgb<T> {
         Rgb {
-            red: from_srgb(red as f32 / 255.0),
-            green: from_srgb(green as f32 / 255.0),
-            blue: from_srgb(blue as f32 / 255.0),
-            alpha: 1.0,
+            red: from_srgb(T::from(red).unwrap() / T::from(255.0).unwrap()),
+            green: from_srgb(T::from(green).unwrap() / T::from(255.0).unwrap()),
+            blue: from_srgb(T::from(blue).unwrap() / T::from(255.0).unwrap()),
+            alpha: T::one(),
         }
     }
 
     ///Linear RGB from 8 bit sRGB with transparency.
-    pub fn srgba8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgb {
+    pub fn srgba8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgb<T> {
         Rgb {
-            red: from_srgb(red as f32 / 255.0),
-            green: from_srgb(green as f32 / 255.0),
-            blue: from_srgb(blue as f32 / 255.0),
-            alpha: alpha as f32 / 255.0,
+            red: from_srgb(T::from(red).unwrap() / T::from(255.0).unwrap()),
+            green: from_srgb(T::from(green).unwrap() / T::from(255.0).unwrap()),
+            blue: from_srgb(T::from(blue).unwrap() / T::from(255.0).unwrap()),
+            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
         }
     }
 
     ///Linear RGB from an sRGB pixel value.
-    pub fn srgb_pixel<P: RgbPixel>(pixel: &P) -> Rgb {
+    pub fn srgb_pixel<P: RgbPixel<T>>(pixel: &P) -> Rgb<T> {
         let (r, g, b, a) = pixel.to_rgba();
         Rgb::srgba(r, g, b, a)
     }
 }
 
 ///Creation from gamma corrected RGB.
-impl Rgb {
+impl<T: Float> Rgb<T> {
     ///Linear RGB from gamma corrected RGB.
-    pub fn gamma_rgb(red: f32, green: f32, blue: f32, gamma: f32) -> Rgb {
+    pub fn gamma_rgb(red: T, green: T, blue: T, gamma: T) -> Rgb<T> {
         Rgb {
             red: from_gamma(red, gamma),
             green: from_gamma(green, gamma),
             blue: from_gamma(blue, gamma),
-            alpha: 1.0,
+            alpha: T::one(),
         }
     }
 
     ///Linear RGB from gamma corrected RGB with transparency.
-    pub fn gamma_rgba(red: f32, green: f32, blue: f32, alpha: f32, gamma: f32) -> Rgb {
+    pub fn gamma_rgba(red: T, green: T, blue: T, alpha: T, gamma: T) -> Rgb<T> {
         Rgb {
             red: from_gamma(red, gamma),
             green: from_gamma(green, gamma),
@@ -153,34 +155,34 @@ impl Rgb {
     }
 
     ///Linear RGB from 8 bit gamma corrected RGB.
-    pub fn gamma_rgb8(red: u8, green: u8, blue: u8, gamma: f32) -> Rgb {
+    pub fn gamma_rgb8(red: u8, green: u8, blue: u8, gamma: T) -> Rgb<T> {
         Rgb {
-            red: from_gamma(red as f32 / 255.0, gamma),
-            green: from_gamma(green as f32 / 255.0, gamma),
-            blue: from_gamma(blue as f32 / 255.0, gamma),
-            alpha: 1.0,
+            red: from_gamma(T::from(red).unwrap() / T::from(255.0).unwrap(), gamma),
+            green: from_gamma(T::from(green).unwrap() / T::from(255.0).unwrap(), gamma),
+            blue: from_gamma(T::from(blue).unwrap() / T::from(255.0).unwrap(), gamma),
+            alpha: T::one(),
         }
     }
 
     ///Linear RGB from 8 bit gamma corrected RGB with transparency.
-    pub fn gamma_rgba8(red: u8, green: u8, blue: u8, alpha: u8, gamma: f32) -> Rgb {
+    pub fn gamma_rgba8(red: u8, green: u8, blue: u8, alpha: u8, gamma: T) -> Rgb<T> {
         Rgb {
-            red: from_gamma(red as f32 / 255.0, gamma),
-            green: from_gamma(green as f32 / 255.0, gamma),
-            blue: from_gamma(blue as f32 / 255.0, gamma),
-            alpha: alpha as f32 / 255.0,
+            red: from_gamma(T::from(red).unwrap() / T::from(255.0).unwrap(), gamma),
+            green: from_gamma(T::from(green).unwrap() / T::from(255.0).unwrap(), gamma),
+            blue: from_gamma(T::from(blue).unwrap() / T::from(255.0).unwrap(), gamma),
+            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
         }
     }
 
     ///Linear RGB from a gamma corrected pixel value.
-    pub fn gamma_pixel<P: RgbPixel>(pixel: &P, gamma: f32) -> Rgb {
+    pub fn gamma_pixel<P: RgbPixel<T>>(pixel: &P, gamma: T) -> Rgb<T> {
         let (r, g, b, a) = pixel.to_rgba();
         Rgb::gamma_rgba(r, g, b, a, gamma)
     }
 }
 
 ///Conversion to "pixel space".
-impl Rgb {
+impl<T: Float> Rgb<T> {
     ///Convert to a linear RGB pixel. `Rgb` is already assumed to be linear,
     ///so the components will just be clamped to [0.0, 1.0] before conversion.
     ///
@@ -191,12 +193,12 @@ impl Rgb {
     ///assert_eq!((c.red, c.green, c.blue), c.to_linear());
     ///assert_eq!((0.5, 0.3, 0.1), c.to_linear());
     ///```
-    pub fn to_linear<P: RgbPixel>(&self) -> P {
+    pub fn to_linear<P: RgbPixel<T>>(&self) -> P {
         P::from_rgba(
-            clamp(self.red, 0.0, 1.0),
-            clamp(self.green, 0.0, 1.0),
-            clamp(self.blue, 0.0, 1.0),
-            clamp(self.alpha, 0.0, 1.0),
+            clamp(self.red, T::zero(), T::one()),
+            clamp(self.green, T::zero(), T::one()),
+            clamp(self.blue, T::zero(), T::one()),
+            clamp(self.alpha, T::zero(), T::one())
         )
     }
 
@@ -208,12 +210,12 @@ impl Rgb {
     ///let c = Rgb::srgb(0.5, 0.3, 0.1);
     ///assert_eq!((0.5, 0.3, 0.1), c.to_srgb());
     ///```
-    pub fn to_srgb<P: RgbPixel>(&self) -> P {
+    pub fn to_srgb<P: RgbPixel<T>>(&self) -> P {
         P::from_rgba(
-            clamp(to_srgb(self.red), 0.0, 1.0),
-            clamp(to_srgb(self.green), 0.0, 1.0),
-            clamp(to_srgb(self.blue), 0.0, 1.0),
-            clamp(self.alpha, 0.0, 1.0),
+            clamp(to_srgb(self.red), T::zero(), T::one()),
+            clamp(to_srgb(self.green), T::zero(), T::one()),
+            clamp(to_srgb(self.blue), T::zero(), T::one()),
+            clamp(self.alpha, T::zero(), T::one())
         )
     }
 
@@ -222,44 +224,43 @@ impl Rgb {
     ///```
     ///use palette::Rgb;
     ///
-    ///let c = Rgb::gamma_rgb8(128, 64, 32, 2.2);
+    ///let c = Rgb::<f32>::gamma_rgb8(128, 64, 32, 2.2);
     ///assert_eq!((128, 64, 32), c.to_gamma(2.2));
     ///```
-    pub fn to_gamma<P: RgbPixel>(&self, gamma: f32) -> P {
+    pub fn to_gamma<P: RgbPixel<T>>(&self, gamma: T) -> P {
         P::from_rgba(
-            clamp(to_gamma(self.red, gamma), 0.0, 1.0),
-            clamp(to_gamma(self.green, gamma), 0.0, 1.0),
-            clamp(to_gamma(self.blue, gamma), 0.0, 1.0),
-            clamp(self.alpha, 0.0, 1.0),
-        )
+            clamp(to_gamma(self.red, gamma), T::zero(), T::one()),
+            clamp(to_gamma(self.green, gamma), T::zero(), T::one()),
+            clamp(to_gamma(self.blue, gamma), T::zero(), T::one()),
+            clamp(self.alpha, T::zero(), T::one()))
     }
 }
 
-impl ColorSpace for Rgb {
+impl<T: Float> ColorSpace for Rgb<T> {
     fn is_valid(&self) -> bool {
-        self.red >= 0.0 && self.red <= 1.0 &&
-        self.green >= 0.0 && self.green <= 1.0 &&
-        self.blue >= 0.0 && self.blue <= 1.0 &&
-        self.alpha >= 0.0 && self.alpha <= 1.0
+        self.red >= T::zero() && self.red <= T::one() &&
+        self.green >= T::zero() && self.green <= T::one() &&
+        self.blue >= T::zero() && self.blue <= T::one() &&
+        self.alpha >= T::zero() && self.alpha <= T::one()
     }
 
-    fn clamp(&self) -> Rgb {
+    fn clamp(&self) -> Rgb<T> {
         let mut c = *self;
         c.clamp_self();
         c
     }
 
     fn clamp_self(&mut self) {
-        self.red = clamp(self.red, 0.0, 1.0);
-        self.green = clamp(self.green, 0.0, 1.0);
-        self.blue = clamp(self.blue, 0.0, 1.0);
-        self.alpha = clamp(self.alpha, 0.0, 1.0);
+        self.red = clamp(self.red, T::zero(), T::one());
+        self.green = clamp(self.green, T::zero(), T::one());
+        self.blue = clamp(self.blue, T::zero(), T::one());
+        self.alpha = clamp(self.alpha, T::zero(), T::one());
     }
 }
 
-impl Mix for Rgb {
-    fn mix(&self, other: &Rgb, factor: f32) -> Rgb {
-        let factor = clamp(factor, 0.0, 1.0);
+impl<T: Float> Mix<T> for Rgb<T> {
+    fn mix(&self, other: &Rgb<T>, factor: T) -> Rgb<T> {
+        let factor = clamp(factor, T::zero(), T::one());
 
         Rgb {
             red: self.red + factor * (other.red - self.red),
@@ -270,8 +271,8 @@ impl Mix for Rgb {
     }
 }
 
-impl Shade for Rgb {
-    fn lighten(&self, amount: f32) -> Rgb {
+impl<T: Float> Shade<T> for Rgb<T> {
+    fn lighten(&self, amount: T) -> Rgb<T> {
         Rgb {
             red: self.red + amount,
             green: self.green + amount,
@@ -281,30 +282,30 @@ impl Shade for Rgb {
     }
 }
 
-impl GetHue for Rgb {
-    type Hue = RgbHue;
+impl<T: Float> GetHue for Rgb<T> {
+    type Hue = RgbHue<T>;
 
-    fn get_hue(&self) -> Option<RgbHue> {
-        const SQRT_3: f32 = 1.73205081;
+    fn get_hue(&self) -> Option<RgbHue<T>> {
+        let sqrt_3: T = T::from(1.73205081).unwrap();
 
         if self.red == self.green && self.red == self.blue {
             None
         } else {
-            Some(RgbHue::from_radians((SQRT_3 * (self.green - self.blue)).atan2(2.0 * self.red - self.green - self.blue)))
+            Some(RgbHue::from_radians((sqrt_3 * (self.green - self.blue)).atan2(T::from(2.0).unwrap() * self.red - self.green - self.blue)))
         }
     }
 }
 
-impl Default for Rgb {
-    fn default() -> Rgb {
-        Rgb::linear_rgb(0.0, 0.0, 0.0)
+impl<T: Float> Default for Rgb<T> {
+    fn default() -> Rgb<T> {
+        Rgb::linear_rgb(T::zero(), T::zero(), T::zero())
     }
 }
 
-impl Add<Rgb> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Add<Rgb<T>> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn add(self, other: Rgb) -> Rgb {
+    fn add(self, other: Rgb<T>) -> Rgb<T> {
         Rgb {
             red: self.red + other.red,
             green: self.green + other.green,
@@ -314,10 +315,10 @@ impl Add<Rgb> for Rgb {
     }
 }
 
-impl Add<f32> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Add<T> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn add(self, c: f32) -> Rgb {
+    fn add(self, c: T) -> Rgb<T> {
         Rgb {
             red: self.red + c,
             green: self.green + c,
@@ -327,10 +328,10 @@ impl Add<f32> for Rgb {
     }
 }
 
-impl Sub<Rgb> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Sub<Rgb<T>> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn sub(self, other: Rgb) -> Rgb {
+    fn sub(self, other: Rgb<T>) -> Rgb<T> {
         Rgb {
             red: self.red - other.red,
             green: self.green - other.green,
@@ -340,10 +341,10 @@ impl Sub<Rgb> for Rgb {
     }
 }
 
-impl Sub<f32> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Sub<T> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn sub(self, c: f32) -> Rgb {
+    fn sub(self, c: T) -> Rgb<T> {
         Rgb {
             red: self.red - c,
             green: self.green - c,
@@ -353,10 +354,10 @@ impl Sub<f32> for Rgb {
     }
 }
 
-impl Mul<Rgb> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Mul<Rgb<T>> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn mul(self, other: Rgb) -> Rgb {
+    fn mul(self, other: Rgb<T>) -> Rgb<T> {
         Rgb {
             red: self.red * other.red,
             green: self.green * other.green,
@@ -366,10 +367,10 @@ impl Mul<Rgb> for Rgb {
     }
 }
 
-impl Mul<f32> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Mul<T> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn mul(self, c: f32) -> Rgb {
+    fn mul(self, c: T) -> Rgb<T> {
         Rgb {
             red: self.red * c,
             green: self.green * c,
@@ -379,10 +380,10 @@ impl Mul<f32> for Rgb {
     }
 }
 
-impl Div<Rgb> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Div<Rgb<T>> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn div(self, other: Rgb) -> Rgb {
+    fn div(self, other: Rgb<T>) -> Rgb<T> {
         Rgb {
             red: self.red / other.red,
             green: self.green / other.green,
@@ -392,10 +393,10 @@ impl Div<Rgb> for Rgb {
     }
 }
 
-impl Div<f32> for Rgb {
-    type Output = Rgb;
+impl<T: Float> Div<T> for Rgb<T> {
+    type Output = Rgb<T>;
 
-    fn div(self, c: f32) -> Rgb {
+    fn div(self, c: T) -> Rgb<T> {
         Rgb {
             red: self.red / c,
             green: self.green / c,
@@ -407,8 +408,8 @@ impl Div<f32> for Rgb {
 
 from_color!(to Rgb from Xyz, Luma, Lab, Lch, Hsv, Hsl);
 
-impl From<Luma> for Rgb {
-    fn from(luma: Luma) -> Rgb {
+impl<T: Float> From<Luma<T>> for Rgb<T> {
+    fn from(luma: Luma<T>) -> Rgb<T> {
         Rgb {
             red: luma.luma,
             green: luma.luma,
@@ -418,48 +419,48 @@ impl From<Luma> for Rgb {
     }
 }
 
-impl From<Xyz> for Rgb {
-    fn from(xyz: Xyz) -> Rgb {
+impl<T: Float> From<Xyz<T>> for Rgb<T> {
+    fn from(xyz: Xyz<T>) -> Rgb<T> {
         Rgb {
-            red: xyz.x * 3.2406 + xyz.y * -1.5372 + xyz.z * -0.4986,
-            green: xyz.x * -0.9689 + xyz.y * 1.8758 + xyz.z * 0.0415,
-            blue: xyz.x * 0.0557 + xyz.y * -0.2040 + xyz.z * 1.0570,
+            red: xyz.x * T::from(3.2406).unwrap() + xyz.y * T::from(-1.5372).unwrap() + xyz.z * T::from(-0.4986).unwrap(),
+            green: xyz.x * T::from(-0.9689).unwrap() + xyz.y * T::from(1.8758).unwrap() + xyz.z * T::from(0.415).unwrap(),
+            blue: xyz.x * T::from(0.557).unwrap() + xyz.y * T::from(-0.2040).unwrap() + xyz.z * T::from(0.570).unwrap(),
             alpha: xyz.alpha,
         }
     }
 }
 
-impl From<Lab> for Rgb {
-    fn from(lab: Lab) -> Rgb {
+impl<T: Float> From<Lab<T>> for Rgb<T> {
+    fn from(lab: Lab<T>) -> Rgb<T> {
         Xyz::from(lab).into()
     }
 }
 
-impl From<Lch> for Rgb {
-    fn from(lch: Lch) -> Rgb {
+impl<T: Float> From<Lch<T>> for Rgb<T> {
+    fn from(lch: Lch<T>) -> Rgb<T> {
         Lab::from(lch).into()
     }
 }
 
-impl From<Hsv> for Rgb {
-    fn from(hsv: Hsv) -> Rgb {
+impl<T: Float> From<Hsv<T>> for Rgb<T> {
+    fn from(hsv: Hsv<T>) -> Rgb<T> {
         let c = hsv.value * hsv.saturation;
-        let h = ((Into::<f32>::into(hsv.hue) + 360.0) % 360.0) / 60.0;
-        let x = c * (1.0 - (h % 2.0 - 1.0).abs());
+        let h = ((hsv.hue.to_float() + T::from(360.0).unwrap()) % T::from(360.0).unwrap()) / T::from(60.0).unwrap();
+        let x = c * (T::one() - (h % T::from(2.0).unwrap() - T::one()).abs());
         let m = hsv.value - c;
 
-        let (red, green, blue) = if h >= 0.0 && h < 1.0 {
-            (c, x, 0.0)
-        } else if h >= 1.0 && h < 2.0 {
-            (x, c, 0.0)
-        } else if h >= 2.0 && h < 3.0 {
-            (0.0, c, x)
-        } else if h >= 3.0 && h < 4.0 {
-            (0.0, x, c)
-        } else if h >= 4.0 && h < 5.0 {
-            (x, 0.0, c)
+        let (red, green, blue) = if h >= T::zero() && h < T::one() {
+            (c, x, T::zero())
+        } else if h >= T::one() && h < T::from(2.0).unwrap() {
+            (x, c, T::zero())
+        } else if h >= T::from(2.0).unwrap() && h < T::from(3.0).unwrap() {
+            (T::zero(), c, x)
+        } else if h >= T::from(3.0).unwrap() && h < T::from(4.0).unwrap() {
+            (T::zero(), x, c)
+        } else if h >= T::from(4.0).unwrap() && h < T::from(5.0).unwrap() {
+            (x, T::zero(), c)
         } else {
-            (c, 0.0, x)
+            (c, T::zero(), x)
         };
 
 
@@ -472,25 +473,25 @@ impl From<Hsv> for Rgb {
     }
 }
 
-impl From<Hsl> for Rgb {
-    fn from(hsl: Hsl) -> Rgb {
-        let c = (1.0 - (2.0 * hsl.lightness - 1.0).abs()) * hsl.saturation;
-        let h = ((Into::<f32>::into(hsl.hue) + 360.0) % 360.0) / 60.0;
-        let x = c * (1.0 - (h % 2.0 - 1.0).abs());
-        let m = hsl.lightness - 0.5 * c;
+impl<T: Float> From<Hsl<T>> for Rgb<T> {
+    fn from(hsl: Hsl<T>) -> Rgb<T> {
+        let c = (T::one() - (T::from(2.0).unwrap() * hsl.lightness - T::one()).abs()) * hsl.saturation;
+        let h = ((hsl.hue.to_float() + T::from(360.0).unwrap()) % T::from(360.0).unwrap()) / T::from(60.0).unwrap();
+        let x = c * (T::one() - (h % T::from(2.0).unwrap() - T::one()).abs());
+        let m = hsl.lightness - T::from(0.5).unwrap() * c;
 
-        let (red, green, blue) = if h >= 0.0 && h < 1.0 {
-            (c, x, 0.0)
-        } else if h >= 1.0 && h < 2.0 {
-            (x, c, 0.0)
-        } else if h >= 2.0 && h < 3.0 {
-            (0.0, c, x)
-        } else if h >= 3.0 && h < 4.0 {
-            (0.0, x, c)
-        } else if h >= 4.0 && h < 5.0 {
-            (x, 0.0, c)
+        let (red, green, blue) = if h >= T::zero() && h < T::one() {
+            (c, x, T::zero())
+        } else if h >= T::one() && h < T::from(2.0).unwrap() {
+            (x, c, T::zero())
+        } else if h >= T::from(2.0).unwrap() && h < T::from(3.0).unwrap() {
+            (T::zero(), c, x)
+        } else if h >= T::from(3.0).unwrap() && h < T::from(4.0).unwrap() {
+            (T::zero(), x, c)
+        } else if h >= T::from(4.0).unwrap() && h < T::from(5.0).unwrap() {
+            (x, T::zero(), c)
         } else {
-            (c, 0.0, x)
+            (c, T::zero(), x)
         };
 
 
@@ -503,27 +504,27 @@ impl From<Hsl> for Rgb {
     }
 }
 
-fn from_srgb(x: f32) -> f32 {
-    if x <= 0.04045 {
-        x / 12.92
+fn from_srgb<T: Float>(x: T) -> T {
+    if x <= T::from(0.4045).unwrap() {
+        x / T::from(12.92).unwrap()
     } else {
-        ((x + 0.055) / 1.055).powf(2.4)
+        ((x + T::from(0.055).unwrap()) / T::from(1.055).unwrap()).powf(T::from(2.4).unwrap())
     }
 }
 
-fn to_srgb(x: f32) -> f32 {
-    if x <= 0.0031308 {
-        12.92 * x
+fn to_srgb<T: Float>(x: T) -> T {
+    if x <= T::from(0.031308).unwrap() {
+        T::from(12.92).unwrap() * x
     } else {
-        1.055 * x.powf(1.0 / 2.4) - 0.055
+        T::from(1.055).unwrap() * x.powf(T::from(1.0 / 2.4).unwrap()) - T::from(0.055).unwrap()
     }
 }
 
-fn from_gamma(x: f32, gamma: f32) -> f32 {
-    x.powf(1.0 / gamma)
+fn from_gamma<T: Float>(x: T, gamma: T) -> T {
+    x.powf(T::one() / gamma)
 }
 
-fn to_gamma(x: f32, gamma: f32) -> f32 {
+fn to_gamma<T: Float>(x: T, gamma: T) -> T {
     x.powf(gamma)
 }
 
@@ -531,96 +532,176 @@ fn to_gamma(x: f32, gamma: f32) -> f32 {
 ///
 ///It makes conversion from `Rgb` to various pixel representations easy and
 ///extensible.
-pub trait RgbPixel {
+pub trait RgbPixel<T: Float = f32> {
     ///Create an instance of `Self` from red, green, blue and alpha values.
     ///These can be assumed to already be gamma corrected and belongs to the
     ///range [0.0, 1.0].
-    fn from_rgba(red: f32, green: f32, blue: f32, alpha: f32) -> Self;
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> Self;
 
     ///Convert the red, green, blue and alpha values of `self` to values in
     ///the range [0.0, 1.0]. No gamma correction should be performed.
-    fn to_rgba(&self) -> (f32, f32, f32, f32);
+    fn to_rgba(&self) -> (T, T, T, T);
 }
 
-impl RgbPixel for (f32, f32, f32, f32) {
-    fn from_rgba(red: f32, green: f32, blue: f32, alpha: f32) -> (f32, f32, f32, f32) {
-        (red, green, blue, alpha)
+// }
+impl<T: Float> RgbPixel<T> for (f32, f32, f32, f32) {
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> (f32, f32, f32, f32) {
+        ( red.to_f32().unwrap(), green.to_f32().unwrap(), blue.to_f32().unwrap(), alpha.to_f32().unwrap() )
     }
 
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
-        self.clone()
-    }
-}
-
-impl RgbPixel for (f32, f32, f32) {
-    fn from_rgba(red: f32, green: f32, blue: f32, _alpha: f32) -> (f32, f32, f32) {
-        (red, green, blue)
-    }
-
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
-        let (r, g, b) = *self;
-        (r, g, b, 1.0)
-    }
-}
-
-impl RgbPixel for (u8, u8, u8, u8) {
-    fn from_rgba(red: f32, green: f32, blue: f32, alpha: f32) -> (u8, u8, u8, u8) {
-        ((red * 255.0) as u8, (green * 255.0) as u8, (blue * 255.0) as u8, (alpha * 255.0) as u8)
-    }
-
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
+    fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b, a) = *self;
-        (r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, a as f32 / 255.0)
+        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::from(a).unwrap() )
     }
 }
 
-impl RgbPixel for (u8, u8, u8) {
-    fn from_rgba(red: f32, green: f32, blue: f32, _alpha: f32) -> (u8, u8, u8) {
-        ((red * 255.0) as u8, (green * 255.0) as u8, (blue * 255.0) as u8)
+impl<T: Float> RgbPixel<T> for (f32, f32, f32) {
+    fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> (f32, f32, f32) {
+        ( red.to_f32().unwrap(), green.to_f32().unwrap(), blue.to_f32().unwrap() )
     }
 
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
+    fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b) = *self;
-        (r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0)
+        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::one() )
+    }
+}
+impl<T: Float> RgbPixel<T> for (f64, f64, f64, f64) {
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> (f64, f64, f64, f64) {
+        ( red.to_f64().unwrap(), green.to_f64().unwrap(), blue.to_f64().unwrap(), alpha.to_f64().unwrap() )
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        let (r, g, b, a) = *self;
+        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::from(a).unwrap() )
     }
 }
 
-impl RgbPixel for [f32; 4] {
-    fn from_rgba(red: f32, green: f32, blue: f32, alpha: f32) -> [f32; 4] {
-        [red, green, blue, alpha]
+impl<T: Float> RgbPixel<T> for (f64, f64, f64) {
+    fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> (f64, f64, f64) {
+        (red.to_f64().unwrap(), green.to_f64().unwrap(), blue.to_f64().unwrap())
     }
 
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
-        (self[0], self[1], self[2], self[3])
-    }
-}
-
-impl RgbPixel for [f32; 3] {
-    fn from_rgba(red: f32, green: f32, blue: f32, _alpha: f32) -> [f32; 3] {
-        [red, green, blue]
-    }
-
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
-        (self[0], self[1], self[2], 1.0)
+    fn to_rgba(&self) -> (T, T, T, T) {
+        let (r, g, b) = *self;
+        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::one() )
     }
 }
 
-impl RgbPixel for [u8; 4] {
-    fn from_rgba(red: f32, green: f32, blue: f32, alpha: f32) -> [u8; 4] {
-        [(red * 255.0) as u8, (green * 255.0) as u8, (blue * 255.0) as u8, (alpha * 255.0) as u8]
+impl<T: Float> RgbPixel<T> for (u8, u8, u8, u8) {
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> (u8, u8, u8, u8) {
+        (
+            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (alpha * T::from(255.0).unwrap()).to_u8().unwrap(),
+        )
     }
 
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
-        (self[0] as f32 / 255.0, self[1] as f32 / 255.0, self[2] as f32 / 255.0, self[3] as f32 / 255.0)
+    fn to_rgba(&self) -> (T, T, T, T) {
+        let (r, g, b, a) = *self;
+        (
+            T::from(r).unwrap() / T::from(255.0).unwrap(),
+            T::from(g).unwrap() / T::from(255.0).unwrap(),
+            T::from(b).unwrap() / T::from(255.0).unwrap(),
+            T::from(a).unwrap() / T::from(255.0).unwrap(),
+        )
     }
 }
 
-impl RgbPixel for [u8; 3] {
-    fn from_rgba(red: f32, green: f32, blue: f32, _alpha: f32) -> [u8; 3] {
-        [(red * 255.0) as u8, (green * 255.0) as u8, (blue * 255.0) as u8]
+impl<T: Float> RgbPixel<T> for (u8, u8, u8) {
+    fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> (u8, u8, u8) {
+        (
+            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
+        )
     }
 
-    fn to_rgba(&self) -> (f32, f32, f32, f32) {
-        (self[0] as f32 / 255.0, self[1] as f32 / 255.0, self[2] as f32 / 255.0, 1.0)
+    fn to_rgba(&self) -> (T, T, T, T) {
+        let (r, g, b) = *self;
+        (
+            T::from(r).unwrap() / T::from(255.0).unwrap(),
+            T::from(g).unwrap() / T::from(255.0).unwrap(),
+            T::from(b).unwrap() / T::from(255.0).unwrap(),
+            T::one(),
+        )
+    }
+}
+
+impl<T: Float> RgbPixel<T> for [f32; 4] {
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> [f32; 4] {
+        [ red.to_f32().unwrap(), green.to_f32().unwrap(), blue.to_f32().unwrap(), alpha.to_f32().unwrap() ]
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        ( T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::from(self[3]).unwrap() )
+    }
+}
+
+impl<T: Float> RgbPixel<T> for [f32; 3] {
+    fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> [f32; 3] {
+        [red.to_f32().unwrap(), green.to_f32().unwrap(), blue.to_f32().unwrap()]
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        (T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::one())
+    }
+}
+impl<T: Float> RgbPixel<T> for [f64; 4] {
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> [f64; 4] {
+        [red.to_f64().unwrap(), green.to_f64().unwrap(), blue.to_f64().unwrap(), alpha.to_f64().unwrap()]
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        (T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::from(self[3]).unwrap())
+    }
+}
+
+impl<T: Float> RgbPixel<T> for [f64; 3] {
+    fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> [f64; 3] {
+        [red.to_f64().unwrap(), green.to_f64().unwrap(), blue.to_f64().unwrap()]
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        (T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::one())
+    }
+}
+
+impl<T: Float> RgbPixel<T> for [u8; 4] {
+    fn from_rgba(red: T, green: T, blue: T, alpha: T) -> [u8; 4] {
+        [
+            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (alpha * T::from(255.0).unwrap()).to_u8().unwrap(),
+        ]
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        (
+            T::from(self[0]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[1]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[2]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[3]).unwrap() / T::from(255.0).unwrap(),
+        )
+    }
+}
+
+impl<T: Float> RgbPixel<T> for [u8; 3] {
+    fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> [u8; 3] {
+        [
+            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
+            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
+        ]
+    }
+
+    fn to_rgba(&self) -> (T, T, T, T) {
+        (
+            T::from(self[0]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[1]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[2]).unwrap() / T::from(255.0).unwrap(),
+            T::one(),
+        )
     }
 }

--- a/src/tristimulus.rs
+++ b/src/tristimulus.rs
@@ -1,3 +1,3 @@
-pub const X_N: f32 = 0.95047;
-pub const Y_N: f32 = 1.0;
-pub const Z_N: f32 = 1.08883;
+pub const X_N: f64 = 0.95047;
+pub const Y_N: f64 = 1.0;
+pub const Z_N: f64 = 1.08883;

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -1,3 +1,5 @@
+use num::traits::Float;
+
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Color, Rgb, Luma, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
@@ -15,36 +17,36 @@ use tristimulus::{X_N, Y_N, Z_N};
 ///Illuminant D65 as the white point, and the 2° standard colorimetric
 ///observer.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Xyz {
+pub struct Xyz<T: Float = f32> {
     ///X is the scale of what can be seen as a response curve for the cone
     ///cells in the human eye. It goes from 0.0 to 1.0.
-    pub x: f32,
+    pub x: T,
 
     ///Y is the luminance of the color, where 0.0 is black and 1.0 is white.
-    pub y: f32,
+    pub y: T,
 
     ///Z is the scale of what can be seen as the blue stimulation. It goes
     ///from 0.0 to 1.0.
-    pub z: f32,
+    pub z: T,
 
     ///The transparency of the color. 0.0 is completely transparent and 1.0 is
     ///completely opaque.
-    pub alpha: f32,
+    pub alpha: T,
 }
 
-impl Xyz {
+impl<T: Float> Xyz<T> {
     ///CIE XYZ.
-    pub fn xyz(x: f32, y: f32, z: f32) -> Xyz {
+    pub fn xyz(x: T, y: T, z: T) -> Xyz<T> {
         Xyz {
             x: x,
             y: y,
             z: z,
-            alpha: 1.0,
+            alpha: T::one(),
         }
     }
 
     ///CIE XYZ and transparency.
-    pub fn xyza(x: f32, y: f32, z: f32, alpha: f32) -> Xyz {
+    pub fn xyza(x: T, y: T, z: T, alpha: T) -> Xyz<T> {
         Xyz {
             x: x,
             y: y,
@@ -54,31 +56,30 @@ impl Xyz {
     }
 }
 
-impl ColorSpace for Xyz {
+impl<T: Float> ColorSpace for Xyz<T> {
     fn is_valid(&self) -> bool {
-        self.x >= 0.0 && self.x <= 1.0 &&
-        self.y >= 0.0 && self.y <= 1.0 &&
-        self.z >= 0.0 && self.z <= 1.0 &&
-        self.alpha >= 0.0 && self.alpha <= 1.0
+        self.x >= T::zero() && self.x <= T::one() && self.y >= T::zero() &&
+        self.y <= T::one() && self.z >= T::zero() && self.z <= T::one() &&
+        self.alpha >= T::zero() && self.alpha <= T::one()
     }
 
-    fn clamp(&self) -> Xyz {
+    fn clamp(&self) -> Xyz<T> {
         let mut c = *self;
         c.clamp_self();
         c
     }
 
     fn clamp_self(&mut self) {
-        self.x = clamp(self.x, 0.0, 1.0);
-        self.y = clamp(self.y, 0.0, 1.0);
-        self.z = clamp(self.z, 0.0, 1.0);
-        self.alpha = clamp(self.alpha, 0.0, 1.0);
+        self.x = clamp(self.x, T::zero(), T::one());
+        self.y = clamp(self.y, T::zero(), T::one());
+        self.z = clamp(self.z, T::zero(), T::one());
+        self.alpha = clamp(self.alpha, T::zero(), T::one());
     }
 }
 
-impl Mix for Xyz {
-    fn mix(&self, other: &Xyz, factor: f32) -> Xyz {
-        let factor = clamp(factor, 0.0, 1.0);
+impl<T: Float> Mix<T> for Xyz<T> {
+    fn mix(&self, other: &Xyz<T>, factor: T) -> Xyz<T> {
+        let factor = clamp(factor, T::zero(), T::one());
 
         Xyz {
             x: self.x + factor * (other.x - self.x),
@@ -89,8 +90,8 @@ impl Mix for Xyz {
     }
 }
 
-impl Shade for Xyz {
-    fn lighten(&self, amount: f32) -> Xyz {
+impl<T: Float> Shade<T> for Xyz<T> {
+    fn lighten(&self, amount: T) -> Xyz<T> {
         Xyz {
             x: self.x,
             y: self.y + amount,
@@ -100,16 +101,16 @@ impl Shade for Xyz {
     }
 }
 
-impl Default for Xyz {
-    fn default() -> Xyz {
-        Xyz::xyz(0.0, 0.0, 0.0)
+impl<T: Float> Default for Xyz<T> {
+    fn default() -> Xyz<T> {
+        Xyz::xyz(T::zero(), T::zero(), T::zero())
     }
 }
 
-impl Add<Xyz> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Add<Xyz<T>> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn add(self, other: Xyz) -> Xyz {
+    fn add(self, other: Xyz<T>) -> Xyz<T> {
         Xyz {
             x: self.x + other.x,
             y: self.y + other.y,
@@ -119,10 +120,10 @@ impl Add<Xyz> for Xyz {
     }
 }
 
-impl Add<f32> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Add<T> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn add(self, c: f32) -> Xyz {
+    fn add(self, c: T) -> Xyz<T> {
         Xyz {
             x: self.x + c,
             y: self.y + c,
@@ -132,10 +133,10 @@ impl Add<f32> for Xyz {
     }
 }
 
-impl Sub<Xyz> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Sub<Xyz<T>> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn sub(self, other: Xyz) -> Xyz {
+    fn sub(self, other: Xyz<T>) -> Xyz<T> {
         Xyz {
             x: self.x - other.x,
             y: self.y - other.y,
@@ -145,10 +146,10 @@ impl Sub<Xyz> for Xyz {
     }
 }
 
-impl Sub<f32> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Sub<T> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn sub(self, c: f32) -> Xyz {
+    fn sub(self, c: T) -> Xyz<T> {
         Xyz {
             x: self.x - c,
             y: self.y - c,
@@ -158,10 +159,10 @@ impl Sub<f32> for Xyz {
     }
 }
 
-impl Mul<Xyz> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Mul<Xyz<T>> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn mul(self, other: Xyz) -> Xyz {
+    fn mul(self, other: Xyz<T>) -> Xyz<T> {
         Xyz {
             x: self.x * other.x,
             y: self.y * other.y,
@@ -171,10 +172,10 @@ impl Mul<Xyz> for Xyz {
     }
 }
 
-impl Mul<f32> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Mul<T> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn mul(self, c: f32) -> Xyz {
+    fn mul(self, c: T) -> Xyz<T> {
         Xyz {
             x: self.x * c,
             y: self.y * c,
@@ -184,10 +185,10 @@ impl Mul<f32> for Xyz {
     }
 }
 
-impl Div<Xyz> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Div<Xyz<T>> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn div(self, other: Xyz) -> Xyz {
+    fn div(self, other: Xyz<T>) -> Xyz<T> {
         Xyz {
             x: self.x / other.x,
             y: self.y / other.y,
@@ -197,10 +198,10 @@ impl Div<Xyz> for Xyz {
     }
 }
 
-impl Div<f32> for Xyz {
-    type Output = Xyz;
+impl<T: Float> Div<T> for Xyz<T> {
+    type Output = Xyz<T>;
 
-    fn div(self, c: f32) -> Xyz {
+    fn div(self, c: T) -> Xyz<T> {
         Xyz {
             x: self.x / c,
             y: self.y / c,
@@ -212,66 +213,71 @@ impl Div<f32> for Xyz {
 
 from_color!(to Xyz from Rgb, Luma, Lab, Lch, Hsv, Hsl);
 
-impl From<Rgb> for Xyz {
-    fn from(rgb: Rgb) -> Xyz {
+impl<T: Float> From<Rgb<T>> for Xyz<T> {
+    fn from(rgb: Rgb<T>) -> Xyz<T> {
         Xyz {
-            x: rgb.red * 0.4124 + rgb.green * 0.3576 + rgb.blue * 0.1805,
-            y: rgb.red * 0.2126 + rgb.green * 0.7152 + rgb.blue * 0.0722,
-            z: rgb.red * 0.0193 + rgb.green * 0.1192 + rgb.blue * 0.9505,
+            x: rgb.red * T::from(0.4124).unwrap() + rgb.green * T::from(0.3576).unwrap() + rgb.blue * T::from(0.1805).unwrap(),
+            y: rgb.red * T::from(0.2126).unwrap() + rgb.green * T::from(0.7152).unwrap() + rgb.blue * T::from(0.0722).unwrap(),
+            z: rgb.red * T::from(0.0193).unwrap() + rgb.green * T::from(0.1192).unwrap() + rgb.blue * T::from(0.9505).unwrap(),
             alpha: rgb.alpha,
         }
     }
 }
 
-impl From<Luma> for Xyz {
-    fn from(luma: Luma) -> Xyz {
+impl<T: Float> From<Luma<T>> for Xyz<T> {
+    fn from(luma: Luma<T>) -> Xyz<T> {
         Xyz {
-            x: 0.0,
+            x: T::zero(),
             y: luma.luma,
-            z: 0.0,
+            z: T::zero(),
             alpha: luma.alpha,
         }
     }
 }
 
-impl From<Lab> for Xyz {
-    fn from(lab: Lab) -> Xyz {
+impl<T: Float> From<Lab<T>> for Xyz<T> {
+    fn from(lab: Lab<T>) -> Xyz<T> {
         Xyz {
-            x: X_N * f_inv((1.0 / 116.0) * (lab.l * 100.0 + 16.0) + (1.0 / 500.0) * lab.a * 128.0),
-            y: Y_N * f_inv((1.0 / 116.0) * (lab.l * 100.0 + 16.0)),
-            z: Z_N * f_inv((1.0 / 116.0) * (lab.l * 100.0 + 16.0) - (1.0 / 200.0) * lab.b * 128.0),
+            x: T::from(X_N).unwrap() * f_inv((T::one() / T::from(116.0).unwrap()) *
+                (lab.l * T::from(100.0).unwrap() + T::from(16.0).unwrap()) +
+                (T::one() / T::from(500.0).unwrap()) * lab.a * T::from(128.0).unwrap()),
+            y: T::from(Y_N).unwrap() * f_inv((T::one() / T::from(116.0).unwrap()) *
+                (lab.l * T::from(100.0).unwrap() + T::from(16.0).unwrap())),
+            z: T::from(Z_N).unwrap() * f_inv((T::one() / T::from(116.0).unwrap()) *
+                (lab.l * T::from(100.0).unwrap() + T::from(16.0).unwrap()) -
+                (T::one() / T::from(200.0).unwrap()) * lab.b * T::from(128.0).unwrap()),
             alpha: lab.alpha,
         }
     }
 }
 
-impl From<Lch> for Xyz {
-    fn from(lch: Lch) -> Xyz {
+impl<T: Float> From<Lch<T>> for Xyz<T> {
+    fn from(lch: Lch<T>) -> Xyz<T> {
         Lab::from(lch).into()
     }
 }
 
-impl From<Hsv> for Xyz {
-    fn from(hsv: Hsv) -> Xyz {
+impl<T: Float> From<Hsv<T>> for Xyz<T> {
+    fn from(hsv: Hsv<T>) -> Xyz<T> {
         Rgb::from(hsv).into()
     }
 }
 
-impl From<Hsl> for Xyz {
-    fn from(hsl: Hsl) -> Xyz {
+impl<T: Float> From<Hsl<T>> for Xyz<T> {
+    fn from(hsl: Hsl<T>) -> Xyz<T> {
         Rgb::from(hsl).into()
     }
 }
 
 
-fn f_inv(t: f32) -> f32 {
+fn f_inv<T: Float>(t: T) -> T {
     //(6/29)^2
-    const C_6_O_29_P_2: f32 = 0.04280618311;
+    let c_6_o_29_p_2: T = T::from(0.04280618311).unwrap();
 
-    if t > 6.0 / 29.0 {
+    if t > T::from(6.0 / 29.0).unwrap() {
         t * t * t
     } else {
-        3.0 * C_6_O_29_P_2 * (t - (4.0 / 29.0))
+        T::from(3.0).unwrap() * c_6_o_29_p_2 * (t - T::from(4.0 / 29.0).unwrap())
     }
 }
 


### PR DESCRIPTION
**Convert all colors to be generic over floats**

Change all colors (Color, Rgb, Hsl, Hsv, Lab, Xyz) and traits (Mix and Saturation etc) to be generic over floats and closes #13.

**_This is a breaking change. Type f32 or f64 must be explicitly annotated._**

```
// OLD
let new_color: Rgb = lch_color.shift_hue(180.0.into()).into();

// NEW
let new_color: Rgb<f32> = lch_color.shift_hue(180.0.into()).into();
```

Since Rust defaults to f64, most of the color types will default to f64. For example Rgb::linear_rgb(1.0, 0.0, 0.0) will be inferred as Rgb\<f64\>. To use f32, constants must be explicitly set like rgb::linear_rgb(1.0_f32, 0.0, 0.0) or the type explicitly annotated.

T::from( constant ).unwrap() etc is used in a number of places to convert constants to num::Float trait ( via the num::Numcast trait).

For Hues, the Into<T> trait is not generic over floats due to unwrap() and possibility of runtime panic and is separately implemented for f32 and f64 for Hue\<32\> and Hue\<64\>. Also the Partial Eq trait could not be implemented for Hues as float and was removed.

The RgbPixel could not be made generic for [T;3] and (T,T,T) and is separately implemented for f32, f64 and u8.

Using associated typed for Mix and Saturation is not ergonomic and the trait was made generic over float.