### PR TITLE
Extract the alpha component as a wrapper type

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ extern crate palette;
 use palette::{Rgb, Hsv, Gradient};
 
 let grad1 = Gradient::new(vec![
-    Rgb::rgb(1.0, 0.1, 0.1),
-    Rgb::rgb(0.1, 1.0, 1.0)
+    Rgb::new(1.0, 0.1, 0.1),
+    Rgb::new(0.1, 1.0, 1.0)
 ]);
 
 let grad2 = Gradient::new(vec![
-    Hsv::from(Rgb::rgb(1.0, 0.1, 0.1)),
-    Hsv::from(Rgb::rgb(0.1, 1.0, 1.0))
+    Hsv::from(Rgb::new(1.0, 0.1, 0.1)),
+    Hsv::from(Rgb::new(0.1, 1.0, 1.0))
 ]);
 ```
 

--- a/examples/gradient.rs
+++ b/examples/gradient.rs
@@ -9,30 +9,30 @@ use image::{RgbImage, GenericImage};
 fn main() {
     //A gradient of evenly spaced colors
     let grad1 = Gradient::new(vec![
-        Rgb::rgb(1.0, 0.1, 0.1),
-        Rgb::rgb(0.1, 0.1, 1.0),
-        Rgb::rgb(0.1, 1.0, 0.1)
+        Rgb::new(1.0, 0.1, 0.1),
+        Rgb::new(0.1, 0.1, 1.0),
+        Rgb::new(0.1, 1.0, 0.1)
     ]);
 
     //The same colors as in grad1, but with the blue point shifted down
     let grad2 = Gradient::with_domain(vec![
-        (0.0, Rgb::rgb(1.0, 0.1, 0.1)),
-        (0.25, Rgb::rgb(0.1, 0.1, 1.0)),
-        (1.0, Rgb::rgb(0.1, 1.0, 0.1))
+        (0.0, Rgb::new(1.0, 0.1, 0.1)),
+        (0.25, Rgb::new(0.1, 0.1, 1.0)),
+        (1.0, Rgb::new(0.1, 1.0, 0.1))
     ]);
 
     //The same colors and offsets as in grad1, but in a color space where the hue is a component
     let grad3 = Gradient::new(vec![
-        Lch::from(Rgb::rgb(1.0, 0.1, 0.1)),
-        Lch::from(Rgb::rgb(0.1, 0.1, 1.0)),
-        Lch::from(Rgb::rgb(0.1, 1.0, 0.1))
+        Lch::from(Rgb::new(1.0, 0.1, 0.1)),
+        Lch::from(Rgb::new(0.1, 0.1, 1.0)),
+        Lch::from(Rgb::new(0.1, 1.0, 0.1))
     ]);
 
     //The same colors and and color space as in grad3, but with the blue point shifted down
     let grad4 = Gradient::with_domain(vec![
-        (0.0, Lch::from(Rgb::rgb(1.0, 0.1, 0.1))),
-        (0.25, Lch::from(Rgb::rgb(0.1, 0.1, 1.0))),
-        (1.0, Lch::from(Rgb::rgb(0.1, 1.0, 0.1)))
+        (0.0, Lch::from(Rgb::new(1.0, 0.1, 0.1))),
+        (0.25, Lch::from(Rgb::new(0.1, 0.1, 1.0))),
+        (1.0, Lch::from(Rgb::new(0.1, 1.0, 0.1)))
     ]);
 
     let mut image = RgbImage::new(256, 128);

--- a/examples/readme_examples.rs
+++ b/examples/readme_examples.rs
@@ -5,7 +5,7 @@ extern crate num;
 use image::{RgbImage, GenericImage};
 use num::traits::Float;
 
-use palette::{Rgb, Gradient, Mix};
+use palette::{Rgba, Gradient, Mix};
 use palette::pixel::Srgb;
 
 mod color_spaces {
@@ -48,13 +48,13 @@ mod gradients {
 
     pub fn run() {
         let grad1 = Gradient::new(vec![
-            Rgb::rgb(1.0, 0.1, 0.1),
-            Rgb::rgb(0.1, 1.0, 1.0)
+            Rgb::new(1.0, 0.1, 0.1),
+            Rgb::new(0.1, 1.0, 1.0)
         ]);
 
         let grad2 = Gradient::new(vec![
-            Hsv::from(Rgb::rgb(1.0, 0.1, 0.1)),
-            Hsv::from(Rgb::rgb(0.1, 1.0, 1.0))
+            Hsv::from(Rgb::new(1.0, 0.1, 0.1)),
+            Hsv::from(Rgb::new(0.1, 1.0, 1.0))
         ]);
 
         display_gradients("examples/readme_gradients.png", grad1, grad2);
@@ -76,8 +76,8 @@ fn display_colors(filename: &str, colors: &[[u8; 3]]) {
 }
 
 fn display_gradients<T: Float, A: Mix<Scalar=T> + Clone, B: Mix<Scalar=T> + Clone>(filename: &str, grad1: Gradient<A>, grad2: Gradient<B>) where
-    Rgb<T>: From<A>,
-    Rgb<T>: From<B>,
+    Rgba<T>: From<A>,
+    Rgba<T>: From<B>,
 {
     let mut image = RgbImage::new(256, 64);
 

--- a/examples/shade.rs
+++ b/examples/shade.rs
@@ -8,7 +8,7 @@ use image::{RgbImage, GenericImage};
 
 fn main() {
     //The same color in linear RGB, CIE L*a*b*, and HSV
-    let rgb = Rgb::rgb(0.5, 0.0, 0.0);
+    let rgb = Rgb::new(0.5, 0.0, 0.0);
     let lab = Lab::from(rgb);
     let hsv = Hsv::from(rgb);
 

--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -1,0 +1,193 @@
+use std::ops::{Deref, DerefMut, Add, Sub, Mul, Div};
+
+use num::Float;
+
+use {Mix, Shade, GetHue, Hue, Saturate};
+
+///An alpha component wrapper for colors.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Alpha<C, T: Float> {
+    ///The color.
+    pub color: C,
+
+    ///The transparency component. 0.0 is fully transparent and 1.0 is fully
+    ///opaque.
+    pub alpha: T,
+}
+
+impl<C, T: Float> Deref for Alpha<C, T> {
+    type Target = C;
+
+    fn deref(&self) -> &C {
+        &self.color
+    }
+}
+
+impl<C, T: Float> DerefMut for Alpha<C, T> {
+    fn deref_mut(&mut self) -> &mut C {
+        &mut self.color
+    }
+}
+
+impl<C: Mix> Mix for Alpha<C, C::Scalar> {
+    type Scalar = C::Scalar;
+    
+    fn mix(&self, other: &Alpha<C, C::Scalar>, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+        Alpha {
+            color: self.color.mix(&other.color, factor),
+            alpha: self.alpha + factor * (other.alpha - self.alpha),
+        }
+    }
+}
+
+impl<C: Shade> Shade for Alpha<C, C::Scalar> {
+    type Scalar = C::Scalar;
+
+    fn lighten(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+        Alpha {
+            color: self.color.lighten(amount),
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl<C: GetHue, T: Float> GetHue for Alpha<C, T> {
+    type Hue = C::Hue;
+
+    fn get_hue(&self) -> Option<C::Hue> {
+        self.color.get_hue()
+    }
+}
+
+impl<C: Hue, T: Float> Hue for Alpha<C, T> {
+    fn with_hue(&self, hue: C::Hue) -> Alpha<C, T> {
+        Alpha {
+            color: self.color.with_hue(hue),
+            alpha: self.alpha,
+        }
+    }
+
+    fn shift_hue(&self, amount: C::Hue) -> Alpha<C, T> {
+        Alpha {
+            color: self.color.shift_hue(amount),
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
+    type Scalar = C::Scalar;
+
+    fn saturate(&self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+        Alpha {
+            color: self.color.saturate(factor),
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl<C: Default, T: Float> Default for Alpha<C, T> {
+    fn default() -> Alpha<C, T> {
+        Alpha {
+            color: C::default(),
+            alpha: T::one(),
+        }
+    }
+}
+
+impl<C: Add, T: Float> Add for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn add(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color + other.color,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl<T: Float + Clone, C: Add<T>> Add<T> for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn add(self, c: T) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color + c.clone(),
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl<C: Sub, T: Float> Sub for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn sub(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color - other.color,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl<T: Float + Clone, C: Sub<T>> Sub<T> for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn sub(self, c: T) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color - c.clone(),
+            alpha: self.alpha - c,
+        }
+    }
+}
+
+impl<C: Mul, T: Float> Mul for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn mul(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color * other.color,
+            alpha: self.alpha * other.alpha,
+        }
+    }
+}
+
+impl<T: Float + Clone, C: Mul<T>> Mul<T> for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn mul(self, c: T) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color * c.clone(),
+            alpha: self.alpha * c,
+        }
+    }
+}
+
+impl<C: Div, T: Float> Div for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn div(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color / other.color,
+            alpha: self.alpha / other.alpha,
+        }
+    }
+}
+
+impl<T: Float + Clone, C: Div<T>> Div<T> for Alpha<C, T> {
+    type Output = Alpha<C::Output, T>;
+
+    fn div(self, c: T) -> Alpha<C::Output, T> {
+        Alpha {
+            color: self.color / c.clone(),
+            alpha: self.alpha / c,
+        }
+    }
+}
+
+impl<C, T: Float> From<C> for Alpha<C, T> {
+    fn from(color: C) -> Alpha<C, T> {
+        Alpha {
+            color: color,
+            alpha: T::one(),
+        }
+    }
+}

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -314,7 +314,7 @@ mod test {
 
     #[test]
     fn simple_slice() {
-        let g1 = Gradient::new(vec![Rgb::rgb(1.0, 0.0, 0.0), Rgb::rgb(0.0, 0.0, 1.0)]);
+        let g1 = Gradient::new(vec![Rgb::new(1.0, 0.0, 0.0), Rgb::new(0.0, 0.0, 1.0)]);
         let g2 = g1.slice(..0.5);
 
         let v1: Vec<_> = g1.take(10).take(5).collect();

--- a/src/pixel/gamma_rgb.rs
+++ b/src/pixel/gamma_rgb.rs
@@ -1,6 +1,6 @@
 use num::Float;
 
-use {Rgb, clamp};
+use {Alpha, Rgb, Rgba, clamp};
 
 use pixel::RgbPixel;
 
@@ -96,7 +96,7 @@ impl<T: Float> GammaRgb<T> {
     }
 
     ///Convert linear color components to gamma encoding.
-    pub fn from_linear<C: Into<Rgb<T>>>(color: C, gamma: T) -> GammaRgb<T> {
+    pub fn from_linear<C: Into<Rgba<T>>>(color: C, gamma: T) -> GammaRgb<T> {
         let rgb = color.into();
         GammaRgb {
             red: to_gamma(rgb.red, gamma),
@@ -108,17 +108,19 @@ impl<T: Float> GammaRgb<T> {
     }
 
     ///Decode this color to a linear representation.
-    pub fn to_linear(&self) -> Rgb<T> {
-        Rgb {
-            red: from_gamma(self.red, self.gamma),
-            green: from_gamma(self.green, self.gamma),
-            blue: from_gamma(self.blue, self.gamma),
+    pub fn to_linear(&self) -> Rgba<T> {
+        Alpha {
+            color: Rgb {
+                red: from_gamma(self.red, self.gamma),
+                green: from_gamma(self.green, self.gamma),
+                blue: from_gamma(self.blue, self.gamma),
+            },
             alpha: self.alpha,
         }
     }
 
     ///Shortcut to convert a linear color to a gamma encoded pixel.
-    pub fn linear_to_pixel<C: Into<Rgb<T>>, P: RgbPixel<T>>(color: C, gamma: T) -> P {
+    pub fn linear_to_pixel<C: Into<Rgba<T>>, P: RgbPixel<T>>(color: C, gamma: T) -> P {
         GammaRgb::from_linear(color, gamma).to_pixel()
     }
 }

--- a/src/pixel/srgb.rs
+++ b/src/pixel/srgb.rs
@@ -1,6 +1,6 @@
 use num::Float;
 
-use {Color, Rgb, clamp};
+use {Color, Alpha, Rgb, Rgba, clamp};
 
 use pixel::RgbPixel;
 
@@ -85,7 +85,7 @@ impl<T: Float> Srgb<T> {
     }
 
     ///Convert linear color components to sRGB encoding.
-    pub fn from_linear<C: Into<Rgb<T>>>(color: C) -> Srgb<T> {
+    pub fn from_linear<C: Into<Rgba<T>>>(color: C) -> Srgb<T> {
         let rgb = color.into();
         Srgb {
             red: to_srgb(rgb.red),
@@ -96,24 +96,32 @@ impl<T: Float> Srgb<T> {
     }
 
     ///Decode this color to a linear representation.
-    pub fn to_linear(&self) -> Rgb<T> {
-        Rgb {
-            red: from_srgb(self.red),
-            green: from_srgb(self.green),
-            blue: from_srgb(self.blue),
+    pub fn to_linear(&self) -> Rgba<T> {
+        Alpha {
+            color: Rgb {
+                red: from_srgb(self.red),
+                green: from_srgb(self.green),
+                blue: from_srgb(self.blue),
+            },
             alpha: self.alpha,
         }
     }
 
     ///Shortcut to convert a linear color to an sRGB encoded pixel.
-    pub fn linear_to_pixel<C: Into<Rgb<T>>, P: RgbPixel<T>>(color: C) -> P {
+    pub fn linear_to_pixel<C: Into<Rgba<T>>, P: RgbPixel<T>>(color: C) -> P {
         Srgb::from_linear(color).to_pixel()
     }
 }
 
 impl<T: Float> From<Rgb<T>> for Srgb<T> {
     fn from(rgb: Rgb<T>) -> Srgb<T> {
-        Srgb::from_linear(rgb)
+        Rgba::from(rgb).into()
+    }
+}
+
+impl<T: Float> From<Rgba<T>> for Srgb<T> {
+    fn from(rgba: Rgba<T>) -> Srgb<T> {
+        Srgb::from_linear(rgba)
     }
 }
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -2,10 +2,13 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Luma, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, RgbHue, clamp};
+use {Color, Alpha, Luma, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, RgbHue, clamp};
 use pixel::{RgbPixel, Srgb, GammaRgb};
 
-///Linear RGB with an alpha component.
+///Linear RGB with an alpha component. See the [`Rgba` implementation in `Alpha`](struct.Alpha.html#Rgba).
+pub type Rgba<T = f32> = Alpha<Rgb<T>, T>;
+
+///Linear RGB.
 ///
 ///RGB is probably the most common color space, when it comes to computer
 ///graphics, and it's defined as an additive mixture of red, green and blue
@@ -30,58 +33,31 @@ pub struct Rgb<T: Float = f32> {
     ///The amount of blue light, where 0.0 is no blue light and 1.0 is the
     ///highest displayable amount.
     pub blue: T,
-
-    ///The transparency of the color. 0.0 is completely transparent and 1.0 is
-    ///completely opaque.
-    pub alpha: T,
 }
 
-///Creation from linear RGB.
 impl<T: Float> Rgb<T> {
     ///Linear RGB.
-    pub fn rgb(red: T, green: T, blue: T) -> Rgb<T> {
+    pub fn new(red: T, green: T, blue: T) -> Rgb<T> {
         Rgb {
             red: red,
             green: green,
             blue: blue,
-            alpha: T::one(),
-        }
-    }
-
-    ///Linear RGB with transparency.
-    pub fn rgba(red: T, green: T, blue: T, alpha: T) -> Rgb<T> {
-        Rgb {
-            red: red,
-            green: green,
-            blue: blue,
-            alpha: alpha,
         }
     }
 
     ///Linear RGB from 8 bit values.
-    pub fn rgb8(red: u8, green: u8, blue: u8) -> Rgb<T> {
+    pub fn new_u8(red: u8, green: u8, blue: u8) -> Rgb<T> {
         Rgb {
             red: T::from(red).unwrap() / T::from(255.0).unwrap(),
             green: T::from(green).unwrap() / T::from(255.0).unwrap(),
             blue: T::from(blue).unwrap() / T::from(255.0).unwrap(),
-            alpha: T::one(),
-        }
-    }
-
-    ///Linear RGB with transparency from 8 bit values.
-    pub fn rgba8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgb<T> {
-        Rgb {
-            red: T::from(red).unwrap() / T::from(255.0).unwrap(),
-            green: T::from(green).unwrap() / T::from(255.0).unwrap(),
-            blue: T::from(blue).unwrap() / T::from(255.0).unwrap(),
-            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
         }
     }
 
     ///Linear RGB from a linear pixel value.
     pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> Rgb<T> {
-        let (r, g, b, a) = pixel.to_rgba();
-        Rgb::rgba(r, g, b, a)
+        let (r, g, b, _) = pixel.to_rgba();
+        Rgb::new(r, g, b)
     }
 
     ///Convert to a linear RGB pixel. `Rgb` is already assumed to be linear,
@@ -90,9 +66,53 @@ impl<T: Float> Rgb<T> {
     ///```
     ///use palette::Rgb;
     ///
-    ///let c = Rgb::rgb(0.5, 0.3, 0.1);
+    ///let c = Rgb::new(0.5, 0.3, 0.1);
     ///assert_eq!((c.red, c.green, c.blue), c.to_pixel());
     ///assert_eq!((0.5, 0.3, 0.1), c.to_pixel());
+    ///```
+    pub fn to_pixel<P: RgbPixel<T>>(&self) -> P {
+        P::from_rgba(
+            clamp(self.red, T::zero(), T::one()),
+            clamp(self.green, T::zero(), T::one()),
+            clamp(self.blue, T::zero(), T::one()),
+            T::one(),
+        )
+    }
+}
+
+///<span id="Rgba"></span>[`Rgba`](type.Rgba.html) implementations.
+impl<T: Float> Alpha<Rgb<T>, T> {
+    ///Linear RGB with transparency.
+    pub fn new(red: T, green: T, blue: T, alpha: T) -> Rgba<T> {
+        Alpha {
+            color: Rgb::new(red, green, blue),
+            alpha: alpha,
+        }
+    }
+
+    ///Linear RGB with transparency from 8 bit values.
+    pub fn new_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgba<T> {
+        Alpha {
+            color: Rgb::new_u8(red, green, blue),
+            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
+        }
+    }
+
+    ///Linear RGB from a linear pixel value.
+    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> Rgba<T> {
+        let (r, g, b, a) = pixel.to_rgba();
+        Rgba::new(r, g, b, a)
+    }
+
+    ///Convert to a linear RGB pixel. `Rgb` is already assumed to be linear,
+    ///so the components will just be clamped to [0.0, 1.0] before conversion.
+    ///
+    ///```
+    ///use palette::Rgba;
+    ///
+    ///let c = Rgba::new(0.5, 0.3, 0.1, 0.5);
+    ///assert_eq!((c.red, c.green, c.blue, c.alpha), c.to_pixel());
+    ///assert_eq!((0.5, 0.3, 0.1, 0.5), c.to_pixel());
     ///```
     pub fn to_pixel<P: RgbPixel<T>>(&self) -> P {
         P::from_rgba(
@@ -108,8 +128,7 @@ impl<T: Float> ColorSpace for Rgb<T> {
     fn is_valid(&self) -> bool {
         self.red >= T::zero() && self.red <= T::one() &&
         self.green >= T::zero() && self.green <= T::one() &&
-        self.blue >= T::zero() && self.blue <= T::one() &&
-        self.alpha >= T::zero() && self.alpha <= T::one()
+        self.blue >= T::zero() && self.blue <= T::one()
     }
 
     fn clamp(&self) -> Rgb<T> {
@@ -122,7 +141,6 @@ impl<T: Float> ColorSpace for Rgb<T> {
         self.red = clamp(self.red, T::zero(), T::one());
         self.green = clamp(self.green, T::zero(), T::one());
         self.blue = clamp(self.blue, T::zero(), T::one());
-        self.alpha = clamp(self.alpha, T::zero(), T::one());
     }
 }
 
@@ -136,7 +154,6 @@ impl<T: Float> Mix for Rgb<T> {
             red: self.red + factor * (other.red - self.red),
             green: self.green + factor * (other.green - self.green),
             blue: self.blue + factor * (other.blue - self.blue),
-            alpha: self.alpha + factor * (other.alpha - self.alpha),
         }
     }
 }
@@ -149,7 +166,6 @@ impl<T: Float> Shade for Rgb<T> {
             red: self.red + amount,
             green: self.green + amount,
             blue: self.blue + amount,
-            alpha: self.alpha,
         }
     }
 }
@@ -170,7 +186,7 @@ impl<T: Float> GetHue for Rgb<T> {
 
 impl<T: Float> Default for Rgb<T> {
     fn default() -> Rgb<T> {
-        Rgb::rgb(T::zero(), T::zero(), T::zero())
+        Rgb::new(T::zero(), T::zero(), T::zero())
     }
 }
 
@@ -182,7 +198,6 @@ impl<T: Float> Add<Rgb<T>> for Rgb<T> {
             red: self.red + other.red,
             green: self.green + other.green,
             blue: self.blue + other.blue,
-            alpha: self.alpha + other.alpha,
         }
     }
 }
@@ -195,7 +210,6 @@ impl<T: Float> Add<T> for Rgb<T> {
             red: self.red + c,
             green: self.green + c,
             blue: self.blue + c,
-            alpha: self.alpha + c,
         }
     }
 }
@@ -208,7 +222,6 @@ impl<T: Float> Sub<Rgb<T>> for Rgb<T> {
             red: self.red - other.red,
             green: self.green - other.green,
             blue: self.blue - other.blue,
-            alpha: self.alpha - other.alpha,
         }
     }
 }
@@ -221,7 +234,6 @@ impl<T: Float> Sub<T> for Rgb<T> {
             red: self.red - c,
             green: self.green - c,
             blue: self.blue - c,
-            alpha: self.alpha - c,
         }
     }
 }
@@ -234,7 +246,6 @@ impl<T: Float> Mul<Rgb<T>> for Rgb<T> {
             red: self.red * other.red,
             green: self.green * other.green,
             blue: self.blue * other.blue,
-            alpha: self.alpha * other.alpha,
         }
     }
 }
@@ -247,7 +258,6 @@ impl<T: Float> Mul<T> for Rgb<T> {
             red: self.red * c,
             green: self.green * c,
             blue: self.blue * c,
-            alpha: self.alpha * c,
         }
     }
 }
@@ -260,7 +270,6 @@ impl<T: Float> Div<Rgb<T>> for Rgb<T> {
             red: self.red / other.red,
             green: self.green / other.green,
             blue: self.blue / other.blue,
-            alpha: self.alpha / other.alpha,
         }
     }
 }
@@ -273,12 +282,13 @@ impl<T: Float> Div<T> for Rgb<T> {
             red: self.red / c,
             green: self.green / c,
             blue: self.blue / c,
-            alpha: self.alpha / c,
         }
     }
 }
 
 from_color!(to Rgb from Xyz, Luma, Lab, Lch, Hsv, Hsl);
+
+alpha_from!(Rgb {Xyz, Luma, Lab, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Luma<T>> for Rgb<T> {
     fn from(luma: Luma<T>) -> Rgb<T> {
@@ -286,7 +296,6 @@ impl<T: Float> From<Luma<T>> for Rgb<T> {
             red: luma.luma,
             green: luma.luma,
             blue: luma.luma,
-            alpha: luma.alpha,
         }
     }
 }
@@ -297,7 +306,6 @@ impl<T: Float> From<Xyz<T>> for Rgb<T> {
             red: xyz.x * T::from(3.2406).unwrap() + xyz.y * T::from(-1.5372).unwrap() + xyz.z * T::from(-0.4986).unwrap(),
             green: xyz.x * T::from(-0.9689).unwrap() + xyz.y * T::from(1.8758).unwrap() + xyz.z * T::from(0.0415).unwrap(),
             blue: xyz.x * T::from(0.0557).unwrap() + xyz.y * T::from(-0.2040).unwrap() + xyz.z * T::from(1.0570).unwrap(),
-            alpha: xyz.alpha,
         }
     }
 }
@@ -340,7 +348,6 @@ impl<T: Float> From<Hsv<T>> for Rgb<T> {
             red: red + m,
             green: green + m,
             blue: blue + m,
-            alpha: hsv.alpha,
         }
     }
 }
@@ -371,19 +378,30 @@ impl<T: Float> From<Hsl<T>> for Rgb<T> {
             red: red + m,
             green: green + m,
             blue: blue + m,
-            alpha: hsl.alpha,
         }
     }
 }
 
 impl<T: Float> From<Srgb<T>> for Rgb<T> {
     fn from(srgb: Srgb<T>) -> Rgb<T> {
-        srgb.to_linear()
+        srgb.to_linear().into()
     }
 }
 
 impl<T: Float> From<GammaRgb<T>> for Rgb<T> {
     fn from(gamma_rgb: GammaRgb<T>) -> Rgb<T> {
+        gamma_rgb.to_linear().into()
+    }
+}
+
+impl<T: Float> From<Srgb<T>> for Alpha<Rgb<T>, T> {
+    fn from(srgb: Srgb<T>) -> Alpha<Rgb<T>, T> {
+        srgb.to_linear()
+    }
+}
+
+impl<T: Float> From<GammaRgb<T>> for Alpha<Rgb<T>, T> {
+    fn from(gamma_rgb: GammaRgb<T>) -> Alpha<Rgb<T>, T> {
         gamma_rgb.to_linear()
     }
 }


### PR DESCRIPTION
This closes #11 by adding a wrapper type that bolts the alpha component to any color. This works well because of how passive the alpha is in most of the calculations and conversions, and results in a relatively low amount of code duplication.

Each color space (and `Color`) has a sibling type alias with an `a` added to the name, such as `Rgba`. Those are alias for `Alpha<C<T>, T>`, where `C` is the color space type, and can be used more or less in the same way as their non-alpha variants. Conversion between alpha types and non-alpha types is as easy as always.

This is a breaking change, since the alpha component is removed from every color and constructors are moved and/or renamed. The new constructors follows the same convention as the constructors in `Srgb` and `GammaRgb`, which is `new` for float values and `new_u8` for `u8` values. The constructors on `Color` are roughly the same as before, with the exception of changing things like `rgb8` to `rgb_u8`.