### PR TITLE
Change Mix, Shade and Saturate to use an associated type

### DIFF
--- a/examples/readme_examples.rs
+++ b/examples/readme_examples.rs
@@ -69,7 +69,7 @@ fn display_colors(filename: &str, colors: &[[u8; 3]]) {
     }
 }
 
-fn display_gradients<T: Float, A: Mix<T> + Clone, B: Mix<T> + Clone>(filename: &str, grad1: Gradient<T, A>, grad2: Gradient<T, B>)
+fn display_gradients<T: Float, A: Mix<Scalar=T> + Clone, B: Mix<Scalar=T> + Clone>(filename: &str, grad1: Gradient<A>, grad2: Gradient<B>)
     where Rgb<T>: From<A>,
         Rgb<T>: From<B>
 {

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -75,7 +75,9 @@ impl<T: Float> ColorSpace for Hsl<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Hsl<T> {
+impl<T: Float> Mix for Hsl<T> {
+    type Scalar = T;
+
     fn mix(&self, other: &Hsl<T>, factor: T) -> Hsl<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_float();
@@ -89,7 +91,9 @@ impl<T: Float> Mix<T> for Hsl<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Hsl<T> {
+impl<T: Float> Shade for Hsl<T> {
+    type Scalar = T;
+
     fn lighten(&self, amount: T) -> Hsl<T> {
         Hsl {
             hue: self.hue,
@@ -132,7 +136,9 @@ impl<T: Float> Hue for Hsl<T> {
     }
 }
 
-impl<T: Float> Saturate<T> for Hsl<T> {
+impl<T: Float> Saturate for Hsl<T> {
+    type Scalar = T;
+
     fn saturate(&self, factor: T) -> Hsl<T> {
         Hsl {
             hue: self.hue,

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -74,7 +74,9 @@ impl<T: Float> ColorSpace for Hsv<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Hsv<T> {
+impl<T: Float> Mix for Hsv<T> {
+    type Scalar = T;
+    
     fn mix(&self, other: &Hsv<T>, factor: T) -> Hsv<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_float();
@@ -88,7 +90,9 @@ impl<T: Float> Mix<T> for Hsv<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Hsv<T> {
+impl<T: Float> Shade for Hsv<T> {
+    type Scalar = T;
+    
     fn lighten(&self, amount: T) -> Hsv<T> {
         Hsv {
             hue: self.hue,
@@ -131,7 +135,9 @@ impl<T: Float> Hue for Hsv<T> {
     }
 }
 
-impl<T: Float> Saturate<T> for Hsv<T> {
+impl<T: Float> Saturate for Hsv<T> {
+    type Scalar = T;
+
     fn saturate(&self, factor: T) -> Hsv<T> {
         Hsv {
             hue: self.hue,

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -77,7 +77,9 @@ impl<T: Float> ColorSpace for Lab<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Lab<T> {
+impl<T: Float> Mix for Lab<T> {
+    type Scalar = T;
+    
     fn mix(&self, other: &Lab<T>, factor: T) -> Lab<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -90,7 +92,9 @@ impl<T: Float> Mix<T> for Lab<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Lab<T> {
+impl<T: Float> Shade for Lab<T> {
+    type Scalar = T;
+    
     fn lighten(&self, amount: T) -> Lab<T> {
         Lab {
             l: self.l + amount,

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -74,7 +74,9 @@ impl<T: Float> ColorSpace for Lch<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Lch<T> {
+impl<T: Float> Mix for Lch<T> {
+    type Scalar = T;
+    
     fn mix(&self, other: &Lch<T>, factor: T) -> Lch<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_float();
@@ -87,7 +89,9 @@ impl<T: Float> Mix<T> for Lch<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Lch<T> {
+impl<T: Float> Shade for Lch<T> {
+    type Scalar = T;
+    
     fn lighten(&self, amount: T) -> Lch<T> {
         Lch {
             l: self.l + amount,
@@ -130,7 +134,9 @@ impl<T: Float> Hue for Lch<T> {
     }
 }
 
-impl<T: Float> Saturate<T> for Lch<T> {
+impl<T: Float> Saturate for Lch<T> {
+    type Scalar = T;
+
     fn saturate(&self, factor: T) -> Lch<T> {
         Lch {
             l: self.l,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,13 +119,17 @@ macro_rules! make_color {
             }
         )+
 
-        impl<T:Float> Mix<T> for Color<T> {
+        impl<T:Float> Mix for Color<T> {
+            type Scalar = T;
+
             fn mix(&self, other: &Color<T>, factor: T) -> Color<T> {
                 Rgb::from(*self).mix(&Rgb::from(*other), factor).into()
             }
         }
 
-        impl<T:Float> Shade<T> for Color<T> {
+        impl<T:Float> Shade for Color<T> {
+            type Scalar = T;
+
             fn lighten(&self, amount: T) -> Color<T> {
                 Lab::from(*self).lighten(amount).into()
             }
@@ -149,7 +153,9 @@ macro_rules! make_color {
             }
         }
 
-        impl<T:Float> Saturate<T> for Color<T> {
+        impl<T:Float> Saturate for Color<T> {
+            type Scalar = T;
+
             fn saturate(&self, factor: T) -> Color<T> {
                 Lch::from(*self).saturate(factor).into()
             }
@@ -310,13 +316,16 @@ pub trait ColorSpace {
 ///assert_eq!(a.mix(&b, 0.5), Rgb::linear_rgb(0.5, 0.5, 0.5));
 ///assert_eq!(a.mix(&b, 1.0), b);
 ///```
-pub trait Mix<T:Float> {
+pub trait Mix {
+    ///The type of the mixing factor.
+    type Scalar: Float;
+
     ///Mix the color with an other color, by `factor`.
     ///
     ///`factor` sould be between `0.0` and `1.0`, where `0.0` will result in
     ///the same color as `self` and `1.0` will result in the same color as
     ///`other`.
-    fn mix(&self, other: &Self, factor: T) -> Self;
+    fn mix(&self, other: &Self, factor: Self::Scalar) -> Self;
 }
 
 ///The `Shade` trait allows a color to be lightened or darkened.
@@ -329,12 +338,15 @@ pub trait Mix<T:Float> {
 ///
 ///assert_eq!(a.lighten(0.1), b.darken(0.1));
 ///```
-pub trait Shade<T:Float>: Sized {
+pub trait Shade: Sized {
+    ///The type of the lighten/darken amount.
+    type Scalar: Float;
+
     ///Lighten the color by `amount`.
-    fn lighten(&self, amount: T) -> Self;
+    fn lighten(&self, amount: Self::Scalar) -> Self;
 
     ///Darken the color by `amount`.
-    fn darken(&self, amount: T) -> Self {
+    fn darken(&self, amount: Self::Scalar) -> Self {
         self.lighten(-amount)
     }
 }
@@ -390,12 +402,15 @@ pub trait Hue: GetHue {
 ///
 ///assert_eq!(a.saturate(1.0), b.desaturate(0.5));
 ///```
-pub trait Saturate<T: Float>: Sized {
+pub trait Saturate: Sized {
+    ///The type of the (de)saturation factor.
+    type Scalar: Float;
+
     ///Increase the saturation by `factor`.
-    fn saturate(&self, factor: T) -> Self;
+    fn saturate(&self, factor: Self::Scalar) -> Self;
 
     ///Decrease the saturation by `factor`.
-    fn desaturate(&self, factor: T) -> Self {
+    fn desaturate(&self, factor: Self::Scalar) -> Self {
         self.saturate(-factor)
     }
 }

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -73,7 +73,9 @@ impl<T: Float> ColorSpace for Luma<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Luma<T> {
+impl<T: Float> Mix for Luma<T> {
+    type Scalar = T;
+
     fn mix(&self, other: &Luma<T>, factor: T) -> Luma<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -84,7 +86,9 @@ impl<T: Float> Mix<T> for Luma<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Luma<T> {
+impl<T: Float> Shade for Luma<T> {
+    type Scalar = T;
+
     fn lighten(&self, amount: T) -> Luma<T> {
         Luma {
             luma: (self.luma + amount).max(T::zero()),

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -258,7 +258,9 @@ impl<T: Float> ColorSpace for Rgb<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Rgb<T> {
+impl<T: Float> Mix for Rgb<T> {
+    type Scalar = T;
+
     fn mix(&self, other: &Rgb<T>, factor: T) -> Rgb<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -271,7 +273,9 @@ impl<T: Float> Mix<T> for Rgb<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Rgb<T> {
+impl<T: Float> Shade for Rgb<T> {
+    type Scalar = T;
+
     fn lighten(&self, amount: T) -> Rgb<T> {
         Rgb {
             red: self.red + amount,

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -77,7 +77,9 @@ impl<T: Float> ColorSpace for Xyz<T> {
     }
 }
 
-impl<T: Float> Mix<T> for Xyz<T> {
+impl<T: Float> Mix for Xyz<T> {
+    type Scalar = T;
+
     fn mix(&self, other: &Xyz<T>, factor: T) -> Xyz<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -90,7 +92,9 @@ impl<T: Float> Mix<T> for Xyz<T> {
     }
 }
 
-impl<T: Float> Shade<T> for Xyz<T> {
+impl<T: Float> Shade for Xyz<T> {
+    type Scalar = T;
+
     fn lighten(&self, amount: T) -> Xyz<T> {
         Xyz {
             x: self.x,


### PR DESCRIPTION
The `Mix`, `Shade` and `Saturate` traits are rewritten to have an associated `Scalar` type instead of a type parameter, as mentioned in [#17](https://github.com/Ogeon/palette/pull/17#discussion_r50449575). This removes the need for extra type parameters in some cases, like in `Gradient`.

This is a breaking change, since it removes a number of type parameters.