### PR TITLE
Fix or relax some color ranges and clamping

### DIFF
--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut, Add, Sub, Mul, Div};
 
 use num::Float;
 
-use {Mix, Shade, GetHue, Hue, Saturate};
+use {Mix, Shade, GetHue, Hue, Saturate, Limited, clamp};
 
 ///An alpha component wrapper for colors.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -83,6 +83,24 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
             color: self.color.saturate(factor),
             alpha: self.alpha,
         }
+    }
+}
+
+impl<C: Limited, T: Float> Limited for Alpha<C, T> {
+    fn is_valid(&self) -> bool {
+        self.color.is_valid() && self.alpha >= T::zero() && self.alpha <= T::one()
+    }
+
+    fn clamp(&self) -> Alpha<C, T> {
+        Alpha {
+            color: self.color.clamp(),
+            alpha: clamp(self.alpha, T::zero(), T::one()),
+        }
+    }
+
+    fn clamp_self(&mut self) {
+        self.color.clamp_self();
+        self.alpha = clamp(self.alpha, T::zero(), T::one());
     }
 }
 

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Lab, Lch, Hsv, ColorSpace, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
 
 ///Linear HSL with an alpha component. See the [`Hsla` implementation in `Alpha`](struct.Alpha.html#Hsla).
 pub type Hsla<T = f32> = Alpha<Hsl<T>, T>;
@@ -54,7 +54,7 @@ impl<T: Float> Alpha<Hsl<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Hsl<T> {
+impl<T: Float> Limited for Hsl<T> {
     fn is_valid(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::one() &&
         self.lightness >= T::zero() && self.lightness <= T::one()

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -290,7 +290,7 @@ impl<T: Float> From<Hsv<T>> for Hsl<T> {
 #[cfg(test)]
 mod test {
     use super::Hsl;
-    use ::{Rgb, Hsv};
+    use {Rgb, Hsv};
 
     #[test]
     fn red() {
@@ -340,5 +340,20 @@ mod test {
 
         assert_approx_eq!(a, b, [hue, saturation, lightness]);
         assert_approx_eq!(a, c, [hue, saturation, lightness]);
+    }
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Hsl;
+            limited {
+                saturation: 0.0 => 1.0,
+                lightness: 0.0 => 1.0
+            }
+            limited_min {}
+            unlimited {
+                hue: -360.0 => 360.0
+            }
+        }
     }
 }

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -337,4 +337,19 @@ mod test {
         assert_approx_eq!(a, b, [hue, saturation, value]);
         assert_approx_eq!(a, c, [hue, saturation, value]);
     }
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Hsv;
+            limited {
+                saturation: 0.0 => 1.0,
+                value: 0.0 => 1.0
+            }
+            limited_min {}
+            unlimited {
+                hue: -360.0 => 360.0
+            }
+        }
+    }
 }

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Lab, Lch, Hsl, ColorSpace, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
 
 ///Linear HSV with an alpha component. See the [`Hsva` implementation in `Alpha`](struct.Alpha.html#Hsva).
 pub type Hsva<T = f32> = Alpha<Hsv<T>, T>;
@@ -53,7 +53,7 @@ impl<T: Float> Alpha<Hsv<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Hsv<T> {
+impl<T: Float> Limited for Hsv<T> {
     fn is_valid(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::one() &&
         self.value >= T::zero() && self.value <= T::one()

--- a/src/hues.rs
+++ b/src/hues.rs
@@ -126,7 +126,7 @@ fn normalize_angle<T: Float>(mut deg: T) -> T {
     }
 
     while deg <= -T::from(180.0).unwrap() {
-        deg = deg - T::from(360.0).unwrap();
+        deg = deg + T::from(360.0).unwrap();
     }
 
     deg

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -307,4 +307,18 @@ mod test {
         let b = Lab::new(32.302586 / 100.0, 79.19668 / 128.0, -107.863686 / 128.0);
         assert_approx_eq!(a, b, [l, a, b]);
     }
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Lab;
+            limited {
+                l: 0.0 => 1.0,
+                a: -1.0 => 1.0,
+                b: -1.0 => 1.0
+            }
+            limited_min {}
+            unlimited {}
+        }
+    }
 }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, LabHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp};
 
 use tristimulus::{X_N, Y_N, Z_N};
 
@@ -55,7 +55,7 @@ impl<T: Float> Alpha<Lab<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Lab<T> {
+impl<T: Float> Limited for Lab<T> {
     fn is_valid(&self) -> bool {
         self.l >= T::zero() && self.l <= T::one() &&
         self.a >= -T::one() && self.a <= T::one() &&

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -235,3 +235,24 @@ impl<T: Float> From<Hsl<T>> for Lch<T> {
         Lab::from(hsl).into()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use Lch;
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Lch;
+            limited {
+                l: 0.0 => 1.0
+            }
+            limited_min {
+                chroma: 0.0 => 2.0
+            }
+            unlimited {
+                hue: -360.0 => 360.0
+            }
+        }
+    }
+}

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, ColorSpace, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
+use {Color, Alpha, Limited, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
 
 ///CIE L*C*h° with an alpha component. See the [`Lcha` implementation in `Alpha`](struct.Alpha.html#Lcha).
 pub type Lcha<T = f32> = Alpha<Lch<T>, T>;
@@ -52,7 +52,7 @@ impl<T: Float> Alpha<Lch<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Lch<T> {
+impl<T: Float> Limited for Lch<T> {
     fn is_valid(&self) -> bool {
         self.l >= T::zero() && self.l <= T::one() &&
         self.chroma >= T::zero() && self.chroma <= T::from(1.41421356).unwrap() //should include all of L*a*b*, but will also overshoot...

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -55,7 +55,7 @@ impl<T: Float> Alpha<Lch<T>, T> {
 impl<T: Float> Limited for Lch<T> {
     fn is_valid(&self) -> bool {
         self.l >= T::zero() && self.l <= T::one() &&
-        self.chroma >= T::zero() && self.chroma <= T::from(1.41421356).unwrap() //should include all of L*a*b*, but will also overshoot...
+        self.chroma >= T::zero()
     }
 
     fn clamp(&self) -> Lch<T> {
@@ -66,7 +66,7 @@ impl<T: Float> Limited for Lch<T> {
 
     fn clamp_self(&mut self) {
         self.l = clamp(self.l, T::zero(), T::one());
-        self.chroma = clamp(self.chroma, T::zero(), T::from(1.41421356).unwrap()); //should include all of L*a*b*, but will also overshoot...
+        self.chroma = self.chroma.max(T::zero())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,8 +320,8 @@ make_color! {
     }
 }
 
-///Common functionality for color spaces.
-pub trait ColorSpace {
+///A trait for clamping and checking if colors are within their ranges.
+pub trait Limited {
     ///Check if the color's components are within the expected ranges.
     fn is_valid(&self) -> bool;
 

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
+use {Color, Alpha, Rgb, Xyz, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp};
 
 ///Linear luminance with an alpha component. See the [`Lumaa` implementation in `Alpha`](struct.Alpha.html#Lumaa).
 pub type Lumaa<T = f32> = Alpha<Luma<T>, T>;
@@ -55,7 +55,7 @@ impl<T: Float> Alpha<Luma<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Luma<T> {
+impl<T: Float> Limited for Luma<T> {
     fn is_valid(&self) -> bool {
         self.luma >= T::zero() && self.luma <= T::one()
     }

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -222,3 +222,20 @@ impl<T: Float> From<Hsl<T>> for Luma<T> {
         Rgb::from(hsl).into()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use Luma;
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Luma;
+            limited {
+                luma: 0.0 => 1.0
+            }
+            limited_min {}
+            unlimited {}
+        }
+    }
+}

--- a/src/pixel/mod.rs
+++ b/src/pixel/mod.rs
@@ -2,6 +2,8 @@
 
 use num::Float;
 
+use clamp;
+
 pub use self::srgb::Srgb;
 pub use self::gamma_rgb::GammaRgb;
 
@@ -69,40 +71,44 @@ impl<T: Float> RgbPixel<T> for (f64, f64, f64) {
 
 impl<T: Float> RgbPixel<T> for (u8, u8, u8, u8) {
     fn from_rgba(red: T, green: T, blue: T, alpha: T) -> (u8, u8, u8, u8) {
+        let c255 = T::from(255.0).unwrap();
         (
-            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (alpha * T::from(255.0).unwrap()).to_u8().unwrap(),
+            clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(blue * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(alpha * c255, T::zero(), c255).to_u8().unwrap(),
         )
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b, a) = *self;
+        let c255 = T::from(255.0).unwrap();
         (
-            T::from(r).unwrap() / T::from(255.0).unwrap(),
-            T::from(g).unwrap() / T::from(255.0).unwrap(),
-            T::from(b).unwrap() / T::from(255.0).unwrap(),
-            T::from(a).unwrap() / T::from(255.0).unwrap(),
+            T::from(r).unwrap() / c255,
+            T::from(g).unwrap() / c255,
+            T::from(b).unwrap() / c255,
+            T::from(a).unwrap() / c255,
         )
     }
 }
 
 impl<T: Float> RgbPixel<T> for (u8, u8, u8) {
     fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> (u8, u8, u8) {
+        let c255 = T::from(255.0).unwrap();
         (
-            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
+            clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(blue * c255, T::zero(), c255).to_u8().unwrap(),
         )
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b) = *self;
+        let c255 = T::from(255.0).unwrap();
         (
-            T::from(r).unwrap() / T::from(255.0).unwrap(),
-            T::from(g).unwrap() / T::from(255.0).unwrap(),
-            T::from(b).unwrap() / T::from(255.0).unwrap(),
+            T::from(r).unwrap() / c255,
+            T::from(g).unwrap() / c255,
+            T::from(b).unwrap() / c255,
             T::one(),
         )
     }
@@ -149,38 +155,42 @@ impl<T: Float> RgbPixel<T> for [f64; 3] {
 
 impl<T: Float> RgbPixel<T> for [u8; 4] {
     fn from_rgba(red: T, green: T, blue: T, alpha: T) -> [u8; 4] {
+        let c255 = T::from(255.0).unwrap();
         [
-            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (alpha * T::from(255.0).unwrap()).to_u8().unwrap(),
+            clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(blue * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(alpha * c255, T::zero(), c255).to_u8().unwrap(),
         ]
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
+        let c255 = T::from(255.0).unwrap();
         (
-            T::from(self[0]).unwrap() / T::from(255.0).unwrap(),
-            T::from(self[1]).unwrap() / T::from(255.0).unwrap(),
-            T::from(self[2]).unwrap() / T::from(255.0).unwrap(),
-            T::from(self[3]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[0]).unwrap() / c255,
+            T::from(self[1]).unwrap() / c255,
+            T::from(self[2]).unwrap() / c255,
+            T::from(self[3]).unwrap() / c255,
         )
     }
 }
 
 impl<T: Float> RgbPixel<T> for [u8; 3] {
     fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> [u8; 3] {
+        let c255 = T::from(255.0).unwrap();
         [
-            (red * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (green * T::from(255.0).unwrap()).to_u8().unwrap(),
-            (blue * T::from(255.0).unwrap()).to_u8().unwrap(),
+            clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
+            clamp(blue * c255, T::zero(), c255).to_u8().unwrap(),
         ]
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
+        let c255 = T::from(255.0).unwrap();
         (
-            T::from(self[0]).unwrap() / T::from(255.0).unwrap(),
-            T::from(self[1]).unwrap() / T::from(255.0).unwrap(),
-            T::from(self[2]).unwrap() / T::from(255.0).unwrap(),
+            T::from(self[0]).unwrap() / c255,
+            T::from(self[1]).unwrap() / c255,
+            T::from(self[2]).unwrap() / c255,
             T::one(),
         )
     }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -405,3 +405,22 @@ impl<T: Float> From<GammaRgb<T>> for Alpha<Rgb<T>, T> {
         gamma_rgb.to_linear()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use Rgb;
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Rgb;
+            limited {
+                red: 0.0 => 1.0,
+                green: 0.0 => 1.0,
+                blue: 0.0 => 1.0
+            }
+            limited_min {}
+            unlimited {}
+        }
+    }
+}

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Luma, Xyz, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, GetHue, RgbHue, clamp};
+use {Color, Alpha, Luma, Xyz, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, RgbHue, clamp};
 use pixel::{RgbPixel, Srgb, GammaRgb};
 
 ///Linear RGB with an alpha component. See the [`Rgba` implementation in `Alpha`](struct.Alpha.html#Rgba).
@@ -124,7 +124,7 @@ impl<T: Float> Alpha<Rgb<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Rgb<T> {
+impl<T: Float> Limited for Rgb<T> {
     fn is_valid(&self) -> bool {
         self.red >= T::zero() && self.red <= T::one() &&
         self.green >= T::zero() && self.green <= T::one() &&

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Lab, Lch, Hsv, Hsl, ColorSpace, Mix, Shade, clamp};
+use {Color, Alpha, Rgb, Luma, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp};
 
 use tristimulus::{X_N, Y_N, Z_N};
 
@@ -55,7 +55,7 @@ impl<T: Float> Alpha<Xyz<T>, T> {
     }
 }
 
-impl<T: Float> ColorSpace for Xyz<T> {
+impl<T: Float> Limited for Xyz<T> {
     fn is_valid(&self) -> bool {
         self.x >= T::zero() && self.x <= T::one() &&
         self.y >= T::zero() && self.y <= T::one() &&

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -22,14 +22,14 @@ pub type Xyza<T = f32> = Alpha<Xyz<T>, T>;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Xyz<T: Float = f32> {
     ///X is the scale of what can be seen as a response curve for the cone
-    ///cells in the human eye. It goes from 0.0 to 1.0.
+    ///cells in the human eye. It goes from 0.0 to 0.95047.
     pub x: T,
 
     ///Y is the luminance of the color, where 0.0 is black and 1.0 is white.
     pub y: T,
 
     ///Z is the scale of what can be seen as the blue stimulation. It goes
-    ///from 0.0 to 1.0.
+    ///from 0.0 to 1.08883.
     pub z: T,
 }
 
@@ -57,9 +57,9 @@ impl<T: Float> Alpha<Xyz<T>, T> {
 
 impl<T: Float> Limited for Xyz<T> {
     fn is_valid(&self) -> bool {
-        self.x >= T::zero() && self.x <= T::one() &&
-        self.y >= T::zero() && self.y <= T::one() &&
-        self.z >= T::zero() && self.z <= T::one()
+        self.x >= T::zero() && self.x <= T::from(X_N).unwrap() &&
+        self.y >= T::zero() && self.y <= T::from(Y_N).unwrap() &&
+        self.z >= T::zero() && self.z <= T::from(Z_N).unwrap()
     }
 
     fn clamp(&self) -> Xyz<T> {
@@ -69,9 +69,9 @@ impl<T: Float> Limited for Xyz<T> {
     }
 
     fn clamp_self(&mut self) {
-        self.x = clamp(self.x, T::zero(), T::one());
-        self.y = clamp(self.y, T::zero(), T::one());
-        self.z = clamp(self.z, T::zero(), T::one());
+        self.x = clamp(self.x, T::zero(), T::from(X_N).unwrap());
+        self.y = clamp(self.y, T::zero(), T::from(Y_N).unwrap());
+        self.z = clamp(self.z, T::zero(), T::from(Z_N).unwrap());
     }
 }
 

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -275,7 +275,8 @@ fn f_inv<T: Float>(t: T) -> T {
 #[cfg(test)]
 mod test {
     use super::Xyz;
-    use ::Rgb;
+    use Rgb;
+    use tristimulus::{X_N, Y_N, Z_N};
 
     #[test]
     fn red() {
@@ -296,5 +297,19 @@ mod test {
         let a = Xyz::from(Rgb::new(0.0, 0.0, 1.0));
         let b = Xyz::new(0.18050, 0.07220, 0.95050);
         assert_approx_eq!(a, b, [x, y, z]);
+    }
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Xyz;
+            limited {
+                x: 0.0 => X_N,
+                y: 0.0 => Y_N,
+                z: 0.0 => Z_N
+            }
+            limited_min {}
+            unlimited {}
+        }
     }
 }


### PR DESCRIPTION
The `ColorSpace` trait has been repurposed as a trait for checking limits and clamping, and is now called `Limited`. The limits of `Xyz` has been changed to use the white point as its maximum (closing #10), and the maximum of `Lch.chroma` has been removed, since it's not very well defined. The ranges of `Lch` stays as they are, for the sake of consistency.

Extra clamping is also added when converting RGB colors to `u8` based pixel representation, to prevent float shenanigans when multiplying values with 255.0. It's impossible to know what a type `T` will do when it's asked to convert `255.12312312` or whatever to `u8`. This closes #19.

This is a breaking change, since it changes the ranges of some color spaces and renames the `ColorSpace` trait to `Limited`.