### PR TITLE
Offer both 0 centered and positive hue -> float conversion

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -77,7 +77,7 @@ impl<T: Float> Mix for Hsl<T> {
 
     fn mix(&self, other: &Hsl<T>, factor: T) -> Hsl<T> {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_float();
+        let hue_diff: T = (other.hue - self.hue).to_degrees();
 
         Hsl {
             hue: self.hue + factor * hue_diff,

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -76,7 +76,7 @@ impl<T: Float> Mix for Hsv<T> {
     
     fn mix(&self, other: &Hsv<T>, factor: T) -> Hsv<T> {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_float();
+        let hue_diff: T = (other.hue - self.hue).to_degrees();
 
         Hsv {
             hue: self.hue + factor * hue_diff,

--- a/src/hues.rs
+++ b/src/hues.rs
@@ -156,3 +156,23 @@ fn normalize_angle_positive<T: Float>(mut deg: T) -> T {
 
     deg
 }
+
+#[cfg(test)]
+mod test {
+    use RgbHue;
+
+    #[test]
+    fn float_conversion() {
+        for i in -180..180 {
+            let hue = RgbHue::from(4.0 * i as f32);
+
+            let degs = hue.to_degrees();
+            assert!(degs > -180.0 && degs <= 180.0);
+
+            let pos_degs = hue.to_positive_degrees();
+            assert!(pos_degs >= 0.0 && pos_degs < 360.0);
+
+            assert_eq!(RgbHue::from(degs), RgbHue::from(pos_degs));
+        }
+    }
+}

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -75,7 +75,7 @@ impl<T: Float> Mix for Lch<T> {
     
     fn mix(&self, other: &Lch<T>, factor: T) -> Lch<T> {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_float();
+        let hue_diff: T = (other.hue - self.hue).to_degrees();
         Lch {
             l: self.l + factor * (other.l - self.l),
             chroma: self.chroma + factor * (other.chroma - self.chroma),

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -325,7 +325,7 @@ impl<T: Float> From<Lch<T>> for Rgb<T> {
 impl<T: Float> From<Hsv<T>> for Rgb<T> {
     fn from(hsv: Hsv<T>) -> Rgb<T> {
         let c = hsv.value * hsv.saturation;
-        let h = ((hsv.hue.to_float() + T::from(360.0).unwrap()) % T::from(360.0).unwrap()) / T::from(60.0).unwrap();
+        let h = hsv.hue.to_positive_degrees() / T::from(60.0).unwrap();
         let x = c * (T::one() - (h % T::from(2.0).unwrap() - T::one()).abs());
         let m = hsv.value - c;
 
@@ -355,7 +355,7 @@ impl<T: Float> From<Hsv<T>> for Rgb<T> {
 impl<T: Float> From<Hsl<T>> for Rgb<T> {
     fn from(hsl: Hsl<T>) -> Rgb<T> {
         let c = (T::one() - (T::from(2.0).unwrap() * hsl.lightness - T::one()).abs()) * hsl.saturation;
-        let h = ((hsl.hue.to_float() + T::from(360.0).unwrap()) % T::from(360.0).unwrap()) / T::from(60.0).unwrap();
+        let h = hsl.hue.to_positive_degrees() / T::from(60.0).unwrap();
         let x = c * (T::one() - (h % T::from(2.0).unwrap() - T::one()).abs());
         let m = hsl.lightness - T::from(0.5).unwrap() * c;
 


### PR DESCRIPTION
This is a compromise for the 0 centered vs all positive hue representation problem, where both alternatives are offered, but the current 0 centered behavior is kept as the default. The argument for this decision is that both variants are useful in different situations, and there is no obvious reason why one would be better than the other. The default is kept because it's consistent with how the trigonometric functions in `libstd` works. It's not the strongest reason, but it's as good as any.

Changes in this PR:

 * Rename `to_float` to `to_degrees`.
 * Add `to_positive_degrees` and `to_positive_radians`.
 * Mention the ranges in the descriptions of the conversion functions.

This is a breaking change, since it renames `to_float` to `to_degrees`. It closes #15.