### PR TITLE
Add Cie Yxy (xyY) Color Space

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
 
 ///Linear HSL with an alpha component. See the [`Hsla` implementation in `Alpha`](struct.Alpha.html#Hsla).
 pub type Hsla<T = f32> = Alpha<Hsl<T>, T>;
@@ -195,9 +195,9 @@ impl<T: Float> Sub<T> for Hsl<T> {
     }
 }
 
-from_color!(to Hsl from Rgb, Luma, Xyz, Lab, Lch, Hsv);
+from_color!(to Hsl from Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv);
 
-alpha_from!(Hsl {Rgb, Xyz, Luma, Lab, Lch, Hsv, Color});
+alpha_from!(Hsl {Rgb, Xyz, Yxy, Luma, Lab, Lch, Hsv, Color});
 
 impl<T: Float> From<Rgb<T>> for Hsl<T> {
     fn from(rgb: Rgb<T>) -> Hsl<T> {
@@ -253,6 +253,12 @@ impl<T: Float> From<Luma<T>> for Hsl<T> {
 impl<T: Float> From<Xyz<T>> for Hsl<T> {
     fn from(xyz: Xyz<T>) -> Hsl<T> {
         Rgb::from(xyz).into()
+    }
+}
+
+impl<T: Float> From<Yxy<T>> for Hsl<T> {
+    fn from(yxy: Yxy<T>) -> Hsl<T> {
+        Rgb::from(yxy).into()
     }
 }
 

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
 
 ///Linear HSV with an alpha component. See the [`Hsva` implementation in `Alpha`](struct.Alpha.html#Hsva).
 pub type Hsva<T = f32> = Alpha<Hsv<T>, T>;
@@ -73,7 +73,7 @@ impl<T: Float> Limited for Hsv<T> {
 
 impl<T: Float> Mix for Hsv<T> {
     type Scalar = T;
-    
+
     fn mix(&self, other: &Hsv<T>, factor: T) -> Hsv<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
@@ -88,7 +88,7 @@ impl<T: Float> Mix for Hsv<T> {
 
 impl<T: Float> Shade for Hsv<T> {
     type Scalar = T;
-    
+
     fn lighten(&self, amount: T) -> Hsv<T> {
         Hsv {
             hue: self.hue,
@@ -194,9 +194,9 @@ impl<T: Float> Sub<T> for Hsv<T> {
     }
 }
 
-from_color!(to Hsv from Rgb, Luma, Xyz, Lab, Lch, Hsl);
+from_color!(to Hsv from Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl);
 
-alpha_from!(Hsv {Rgb, Xyz, Luma, Lab, Lch, Hsl, Color});
+alpha_from!(Hsv {Rgb, Xyz, Yxy, Luma, Lab, Lch, Hsl, Color});
 
 
 impl<T: Float> From<Rgb<T>> for Hsv<T> {
@@ -252,6 +252,12 @@ impl<T: Float> From<Luma<T>> for Hsv<T> {
 impl<T: Float> From<Xyz<T>> for Hsv<T> {
     fn from(xyz: Xyz<T>) -> Hsv<T> {
         Rgb::from(xyz).into()
+    }
+}
+
+impl<T: Float> From<Yxy<T>> for Hsv<T> {
+    fn from(yxy: Yxy<T>) -> Hsv<T> {
+        Rgb::from(yxy).into()
     }
 }
 

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp};
 
 use tristimulus::{X_N, Y_N, Z_N};
 
@@ -77,7 +77,7 @@ impl<T: Float> Limited for Lab<T> {
 
 impl<T: Float> Mix for Lab<T> {
     type Scalar = T;
-    
+
     fn mix(&self, other: &Lab<T>, factor: T) -> Lab<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -91,7 +91,7 @@ impl<T: Float> Mix for Lab<T> {
 
 impl<T: Float> Shade for Lab<T> {
     type Scalar = T;
-    
+
     fn lighten(&self, amount: T) -> Lab<T> {
         Lab {
             l: self.l + amount,
@@ -215,9 +215,9 @@ impl<T: Float> Div<T> for Lab<T> {
     }
 }
 
-from_color!(to Lab from Rgb, Luma, Xyz, Lch, Hsv, Hsl);
+from_color!(to Lab from Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl);
 
-alpha_from!(Lab {Rgb, Xyz, Luma, Lch, Hsv, Hsl, Color});
+alpha_from!(Lab {Rgb, Xyz, Yxy, Luma, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Xyz<T>> for Lab<T> {
     fn from(xyz: Xyz<T>) -> Lab<T> {
@@ -231,6 +231,12 @@ impl<T: Float> From<Xyz<T>> for Lab<T> {
                 (f(xyz.y / T::from(Y_N).unwrap()) - f(xyz.z / T::from(Z_N).unwrap()))) /
                T::from(128.0).unwrap(),
         }
+    }
+}
+
+impl<T: Float> From<Yxy<T>> for Lab<T> {
+    fn from(yxy: Yxy<T>) -> Lab<T> {
+        Xyz::from(yxy).into()
     }
 }
 

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Limited, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
+use {Color, Alpha, Limited, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Yxy, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
 
 ///CIE L*C*h° with an alpha component. See the [`Lcha` implementation in `Alpha`](struct.Alpha.html#Lcha).
 pub type Lcha<T = f32> = Alpha<Lch<T>, T>;
@@ -72,7 +72,7 @@ impl<T: Float> Limited for Lch<T> {
 
 impl<T: Float> Mix for Lch<T> {
     type Scalar = T;
-    
+
     fn mix(&self, other: &Lch<T>, factor: T) -> Lch<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
@@ -86,7 +86,7 @@ impl<T: Float> Mix for Lch<T> {
 
 impl<T: Float> Shade for Lch<T> {
     type Scalar = T;
-    
+
     fn lighten(&self, amount: T) -> Lch<T> {
         Lch {
             l: self.l + amount,
@@ -192,9 +192,9 @@ impl<T: Float> Sub<T> for Lch<T> {
     }
 }
 
-from_color!(to Lch from Rgb, Luma, Xyz, Lab, Hsv, Hsl);
+from_color!(to Lch from Rgb, Luma, Xyz, Yxy, Lab, Hsv, Hsl);
 
-alpha_from!(Lch {Rgb, Xyz, Luma, Lab, Hsv, Hsl, Color});
+alpha_from!(Lch {Rgb, Xyz, Yxy, Luma, Lab, Hsv, Hsl, Color});
 
 impl<T: Float> From<Lab<T>> for Lch<T> {
     fn from(lab: Lab<T>) -> Lch<T> {
@@ -221,6 +221,12 @@ impl<T: Float> From<Luma<T>> for Lch<T> {
 impl<T: Float> From<Xyz<T>> for Lch<T> {
     fn from(xyz: Xyz<T>) -> Lch<T> {
         Lab::from(xyz).into()
+    }
+}
+
+impl<T: Float> From<Yxy<T>> for Lch<T> {
+    fn from(yxy: Yxy<T>) -> Lch<T> {
+        Lab::from(yxy).into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub use lab::{Lab, Laba};
 pub use lch::{Lch, Lcha};
 pub use hsv::{Hsv, Hsva};
 pub use hsl::{Hsl, Hsla};
+pub use yxy::{Yxy, Yxya};
 
 pub use hues::{LabHue, RgbHue};
 
@@ -278,6 +279,7 @@ pub mod pixel;
 mod alpha;
 mod rgb;
 mod luma;
+mod yxy;
 mod xyz;
 mod lab;
 mod lch;
@@ -439,6 +441,12 @@ make_color! {
     Xyz {
         ///CIE XYZ.
         xyz(x: T, y: T, z: T)[alpha: T] => new;
+    }
+
+    ///CIE 1931 Yxy.
+    Yxy {
+        ///CIE Yxy.
+        yxy(x: T, y: T, luma: T)[alpha: T] => new;
     }
 
     ///CIE L*a*b* (CIELAB).

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Xyz, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp};
+use {Color, Alpha, Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp};
 
 ///Linear luminance with an alpha component. See the [`Lumaa` implementation in `Alpha`](struct.Alpha.html#Lumaa).
 pub type Lumaa<T = f32> = Alpha<Luma<T>, T>;
@@ -179,9 +179,9 @@ impl<T: Float> Div<T> for Luma<T> {
     }
 }
 
-from_color!(to Luma from Rgb, Xyz, Lab, Lch, Hsv, Hsl);
+from_color!(to Luma from Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl);
 
-alpha_from!(Luma {Rgb, Xyz, Lab, Lch, Hsv, Hsl, Color});
+alpha_from!(Luma {Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Rgb<T>> for Luma<T> {
     fn from(rgb: Rgb<T>) -> Luma<T> {
@@ -195,6 +195,14 @@ impl<T: Float> From<Xyz<T>> for Luma<T> {
     fn from(xyz: Xyz<T>) -> Luma<T> {
         Luma {
             luma: xyz.y,
+        }
+    }
+}
+
+impl<T: Float> From<Yxy<T>> for Luma<T> {
+    fn from(yxy: Yxy<T>) -> Luma<T> {
+        Luma {
+            luma: yxy.luma,
         }
     }
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -2,7 +2,7 @@ use num::traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Luma, Xyz, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, RgbHue, clamp};
+use {Color, Alpha, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, RgbHue, clamp};
 use pixel::{RgbPixel, Srgb, GammaRgb};
 
 ///Linear RGB with an alpha component. See the [`Rgba` implementation in `Alpha`](struct.Alpha.html#Rgba).
@@ -286,9 +286,9 @@ impl<T: Float> Div<T> for Rgb<T> {
     }
 }
 
-from_color!(to Rgb from Xyz, Luma, Lab, Lch, Hsv, Hsl);
+from_color!(to Rgb from Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl);
 
-alpha_from!(Rgb {Xyz, Luma, Lab, Lch, Hsv, Hsl, Color});
+alpha_from!(Rgb {Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Luma<T>> for Rgb<T> {
     fn from(luma: Luma<T>) -> Rgb<T> {
@@ -307,6 +307,12 @@ impl<T: Float> From<Xyz<T>> for Rgb<T> {
             green: xyz.x * T::from(-0.9689).unwrap() + xyz.y * T::from(1.8758).unwrap() + xyz.z * T::from(0.0415).unwrap(),
             blue: xyz.x * T::from(0.0557).unwrap() + xyz.y * T::from(-0.2040).unwrap() + xyz.z * T::from(1.0570).unwrap(),
         }
+    }
+}
+
+impl<T: Float> From<Yxy<T>> for Rgb<T> {
+    fn from(yxy: Yxy<T>) -> Rgb<T> {
+        Xyz::from(yxy).into()
     }
 }
 

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -1,0 +1,320 @@
+use num::traits::Float;
+
+use std::ops::{Add, Sub, Mul, Div};
+
+use {Color, Alpha, Rgb, Luma, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, Xyz};
+
+const D65_X: f64 = 0.312727;
+const D65_Y: f64 = 0.329023;
+
+///CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation in `Alpha`](struct.Alpha.html#Yxya).
+pub type Yxya<T = f32> = Alpha<Yxy<T>, T>;
+
+///The CIE 1931 Yxy (xyY)  color space.
+///
+///Yxy is a luminance-chromaticity color space derived from the CIE XYZ
+///color space. It is widely used to define colors. The chromacity diagrams
+///for the color spaces are a plot of this color space's x and y coordiantes.
+///
+///Conversions and operations on this color space assumes the CIE Standard
+///Illuminant D65 as the white point, and the 2° standard colorimetric
+///observer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Yxy<T: Float = f32> {
+
+    ///x chromacity co-ordinate derived from XYZ color space as X/(X+Y+Z).
+    ///Typical range is between 0 and 1
+    pub x: T,
+
+    ///y chromacity co-ordinate derived from XYZ color space as Y/(X+Y+Z).
+    ///Typical range is between 0 and 1
+    pub y: T,
+
+    ///luma (Y) was a measure of the brightness or luminance of a color.
+    ///It is the same as the Y from the XYZ color space. Its range is from
+    ///0 to 1, where 0 is black and 1 is white.
+    pub luma: T,
+}
+
+impl<T: Float> Yxy<T> {
+    ///CIE Yxy.
+    pub fn new(x: T, y: T, luma: T,) -> Yxy<T> {
+        Yxy {
+            x: x,
+            y: y,
+            luma: luma,
+        }
+    }
+}
+
+///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
+impl<T: Float> Alpha<Yxy<T>, T> {
+    ///CIE Yxy and transparency.
+    pub fn new(x: T, y: T, luma: T, alpha: T) -> Yxya<T> {
+        Alpha {
+            color: Yxy::new(x, y, luma),
+            alpha: alpha,
+        }
+    }
+}
+
+impl<T: Float> Limited for Yxy<T> {
+    fn is_valid(&self) -> bool {
+        self.x >= T::zero() && self.x <= T::one() &&
+        self.y >= T::zero() && self.y <= T::one() &&
+        self.luma >= T::zero() && self.luma <= T::one()
+    }
+
+    fn clamp(&self) -> Yxy<T> {
+        let mut c = *self;
+        c.clamp_self();
+        c
+    }
+
+    fn clamp_self(&mut self) {
+        self.x= clamp(self.x, T::zero(), T::one());
+        self.y = clamp(self.y, T::zero(), T::one());
+        self.luma = clamp(self.luma, T::zero(), T::one());
+    }
+}
+
+impl<T: Float> Mix for Yxy<T> {
+    type Scalar = T;
+
+    fn mix(&self, other: &Yxy<T>, factor: T) -> Yxy<T> {
+        let factor = clamp(factor, T::zero(), T::one());
+
+        Yxy {
+            x: self.x + factor * (other.x - self.x),
+            y: self.y + factor * (other.y - self.y),
+            luma: self.luma + factor * (other.luma - self.luma),
+        }
+    }
+}
+
+impl<T: Float> Shade for Yxy<T> {
+    type Scalar = T;
+
+    fn lighten(&self, amount: T) -> Yxy<T> {
+        Yxy {
+            x: self.x,
+            y: self.y,
+            luma: self.luma + amount,
+        }
+    }
+}
+
+impl<T: Float> Default for Yxy<T> {
+    fn default() -> Yxy<T> {
+        // The default for x and y are the white point x and y ( from the default D65).
+        // Since Y (luma) is 0.0, this makes the default color black just like for other colors.
+        // The reason for not using 0 for x and y is that this outside the usual color gamut and might
+        // cause scaling issues.
+        Yxy::new(T::from(D65_X).unwrap(), T::from(D65_Y).unwrap(), T::zero())
+    }
+}
+
+impl<T: Float> Add<Yxy<T>> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn add(self, other: Yxy<T>) -> Yxy<T> {
+        Yxy {
+            x: self.x + other.x,
+            y: self.y + other.y,
+            luma: self.luma + other.luma,
+        }
+    }
+}
+
+impl<T: Float> Add<T> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn add(self, c: T) -> Yxy<T> {
+        Yxy {
+            x: self.x + c,
+            y: self.y + c,
+            luma: self.luma + c,
+        }
+    }
+}
+
+impl<T: Float> Sub<Yxy<T>> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn sub(self, other: Yxy<T>) -> Yxy<T> {
+        Yxy {
+            x: self.x - other.x,
+            y: self.y - other.y,
+            luma: self.luma - other.luma,
+        }
+    }
+}
+
+impl<T: Float> Sub<T> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn sub(self, c: T) -> Yxy<T> {
+        Yxy {
+            x: self.x - c,
+            y: self.y - c,
+            luma: self.luma - c,
+        }
+    }
+}
+
+impl<T: Float> Mul<Yxy<T>> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn mul(self, other: Yxy<T>) -> Yxy<T> {
+        Yxy {
+            x: self.x * other.x,
+            y: self.y * other.y,
+            luma: self.luma * other.luma,
+        }
+    }
+}
+
+impl<T: Float> Mul<T> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn mul(self, c: T) -> Yxy<T> {
+        Yxy {
+            x: self.x * c,
+            y: self.y * c,
+            luma: self.luma * c,
+        }
+    }
+}
+
+impl<T: Float> Div<Yxy<T>> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn div(self, other: Yxy<T>) -> Yxy<T> {
+        Yxy {
+            x: self.x / other.x,
+            y: self.y / other.y,
+            luma: self.luma / other.luma,
+        }
+    }
+}
+
+impl<T: Float> Div<T> for Yxy<T> {
+    type Output = Yxy<T>;
+
+    fn div(self, c: T) -> Yxy<T> {
+        Yxy {
+            x: self.x / c,
+            y: self.y / c,
+            luma: self.luma / c,
+        }
+    }
+}
+
+from_color!(to Yxy from Xyz, Rgb, Luma, Lab, Lch, Hsv, Hsl);
+
+alpha_from!(Yxy {Xyz, Rgb, Luma, Lab, Lch, Hsv, Hsl, Color});
+
+impl<T: Float> From<Xyz<T>> for Yxy<T> {
+    fn from(xyz: Xyz<T>) -> Yxy<T> {
+        let mut yxy = Yxy::new(T::zero(), T::zero(), xyz.y);
+        let sum = xyz.x + xyz.y + xyz.z;
+        // If denominator is zero, NAN or INFINITE leave x and y at the default 0
+        if sum.is_normal() {
+            yxy.x = xyz.x / sum;
+            yxy.y = xyz.y / sum;
+        }
+        yxy
+    }
+}
+
+impl<T: Float> From<Luma<T>> for Yxy<T> {
+    fn from(luma: Luma<T>) -> Yxy<T> {
+        // Use the D65 white point Yxy values for x and y as D65 is used as the default
+        Yxy {
+            x: T::from(D65_X).unwrap(),
+            y: T::from(D65_Y).unwrap(),
+            luma: luma.luma,
+        }
+    }
+}
+
+impl<T: Float> From<Lab<T>> for Yxy<T> {
+    fn from(lab: Lab<T>) -> Yxy<T> {
+        Xyz::from(lab).into()
+    }
+}
+
+impl<T: Float> From<Lch<T>> for Yxy<T> {
+    fn from(lch: Lch<T>) -> Yxy<T> {
+        Lab::from(lch).into()
+    }
+}
+
+impl<T: Float> From<Rgb<T>> for Yxy<T> {
+    fn from(rgb: Rgb<T>) -> Yxy<T> {
+        Xyz::from(rgb).into()
+    }
+}
+
+
+impl<T: Float> From<Hsv<T>> for Yxy<T> {
+    fn from(hsv: Hsv<T>) -> Yxy<T> {
+        Rgb::from(hsv).into()
+    }
+}
+
+impl<T: Float> From<Hsl<T>> for Yxy<T> {
+    fn from(hsl: Hsl<T>) -> Yxy<T> {
+        Rgb::from(hsl).into()
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::Yxy;
+    use Rgb;
+    use Luma;
+
+    #[test]
+    fn luma() {
+        let a = Yxy::from(Luma::new(0.5));
+        let b = Yxy::new(0.312727, 0.329023, 0.5);
+        assert_approx_eq!(a, b, [x, y, luma]);
+    }
+
+    #[test]
+    fn red() {
+        let a = Yxy::from(Rgb::new(1.0, 0.0, 0.0));
+        let b = Yxy::new(0.64, 0.33, 0.212673);
+        assert_approx_eq!(a, b, [x, y, luma]);
+    }
+
+    #[test]
+    fn green() {
+        let a = Yxy::from(Rgb::new(0.0, 1.0, 0.0));
+        let b = Yxy::new(0.3, 0.6, 0.715152);
+        assert_approx_eq!(a, b, [x, y, luma]);
+    }
+
+    #[test]
+    fn blue() {
+        let a = Yxy::from(Rgb::new(0.0, 0.0, 1.0));
+        let b = Yxy::new(0.15, 0.06, 0.072175);
+        assert_approx_eq!(a, b, [x, y, luma]);
+    }
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Yxy;
+            limited {
+                x: 0.0 => 1.0,
+                y: 0.0 => 1.0,
+                luma: 0.0 => 1.0
+            }
+            limited_min {}
+            unlimited {}
+        }
+    }
+}


### PR DESCRIPTION
# Add Cie Yxy color space

### Breaking Change
Breaking change in the Luma Color to XYZ color conversion.  The previous conversion 
did not scale the X and Y values by the  luma amount as per the formula

Previous formula:
x = X_N
y = luma
z = Z_N

Corrected formula:
x = X_N * luma
y = luma
z = Z_N * luma

### Cie Yxy color space
Add support for the Cie Yxy color space and conversions to the
other color spaces.

Color Space is named Yxy and not Xyy. I have seen Yxy used in a few
places and it fits the rust style naming better. Easier to distinguish
Yxy and Xyz than Xyy and Xyz.

The brightness/ luminance component Y is named luma and the x and y
chromacity coordinates are named x and y.

The clamping for this color space defined to be between 0-1. In reality,
Y is bounded to 0-1 and x and y have no bounds. I have seen some rgb color
spaces have their blue points negative, but for most cases 0-1 is a good
rule of thumb to use.

The default value is (0.312727, 0.329023, 0.0) and not (0,0,0). The default for x and y 
are the white point D65 x and y values which is the default white point. Since Y (luma) is 0.0, this 
makes the default color black just like for other colors. The reason for not using 0 for 
x and y is that this outside the usual color gamut and might cause scaling issues.

The Luma to Yxy conversion also uses the x and y values from the D65 white point, 
for the same reasons mentioned above.

closes  #28