### PR TITLE
use flt() function

### DIFF
--- a/examples/color_scheme.rs
+++ b/examples/color_scheme.rs
@@ -2,7 +2,7 @@ extern crate palette;
 extern crate image;
 extern crate clap;
 
-use palette::{Color, Rgb, Hue, Shade};
+use palette::{Color, Hue, Shade};
 use palette::pixel::Srgb;
 
 use image::{RgbImage, GenericImage, SubImage};
@@ -156,7 +156,7 @@ fn blit_shades<I: GenericImage<Pixel=image::Rgb<u8>> + 'static>(color: Color, mu
     let height = canvas.height();
 
     let primary = Srgb::linear_to_pixel(color);
-    
+
     //Generate one lighter and two darker versions of the color
     let light = Srgb::linear_to_pixel(color.lighten(0.1));
     let dark1 = Srgb::linear_to_pixel(color.darken(0.1));

--- a/examples/readme_examples.rs
+++ b/examples/readme_examples.rs
@@ -3,7 +3,6 @@ extern crate palette;
 extern crate num;
 
 use image::{RgbImage, GenericImage};
-use num::traits::Float;
 
 use palette::{Rgba, Gradient, Mix};
 use palette::pixel::Srgb;
@@ -75,18 +74,18 @@ fn display_colors(filename: &str, colors: &[[u8; 3]]) {
     }
 }
 
-fn display_gradients<T: Float, A: Mix<Scalar=T> + Clone, B: Mix<Scalar=T> + Clone>(filename: &str, grad1: Gradient<A>, grad2: Gradient<B>) where
-    Rgba<T>: From<A>,
-    Rgba<T>: From<B>,
+fn display_gradients<A: Mix<Scalar=f64> + Clone, B: Mix<Scalar=f64> + Clone>(filename: &str, grad1: Gradient<A>, grad2: Gradient<B>) where
+    Rgba<f64>: From<A>,
+    Rgba<f64>: From<B>,
 {
     let mut image = RgbImage::new(256, 64);
 
     for (x, _, pixel) in image.sub_image(0, 0, 256, 32).pixels_mut() {
-        pixel.data = Srgb::linear_to_pixel(grad1.get(T::from(x).unwrap() / T::from(255.0).unwrap()));
+        pixel.data = Srgb::linear_to_pixel(grad1.get(x as f64 / 255.0));
     }
 
     for (x, _, pixel) in image.sub_image(0, 32, 256, 32).pixels_mut() {
-        pixel.data = Srgb::linear_to_pixel(grad2.get(T::from(x).unwrap() / T::from(255.0).unwrap()));
+        pixel.data = Srgb::linear_to_pixel(grad2.get(x as f64/ 255.0));
     }
 
     match image.save(filename) {

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -3,6 +3,8 @@
 use num::{Float, One, Zero, NumCast};
 use std::cmp::max;
 
+use flt;
+
 use Mix;
 
 ///A linear interpolation between colors.
@@ -22,10 +24,10 @@ impl<C: Mix + Clone> Gradient<C> {
     pub fn new<I: IntoIterator<Item = C>>(colors: I) -> Gradient<C> {
         let mut points: Vec<_> = colors.into_iter().map(|c| (C::Scalar::zero(), c)).collect();
         assert!(points.len() > 0);
-        let step_size = C::Scalar::one() / <C::Scalar as NumCast>::from(max(points.len() - 1, 1) as f64).unwrap();
+        let step_size = C::Scalar::one() / flt(max(points.len() - 1, 1) as f64);
 
         for (i, &mut (ref mut p, _)) in points.iter_mut().enumerate() {
-            *p = <C::Scalar as NumCast>::from(i).unwrap() * step_size;
+            *p = flt::<C::Scalar, _>(i) * step_size;
         }
 
         Gradient(points)
@@ -125,7 +127,7 @@ impl<'a, C: Mix + Clone> Iterator for Take<'a, C> {
 
     fn next(&mut self) -> Option<C> {
         if self.current < self.len {
-            let i = self.from + <C::Scalar as NumCast>::from(self.current).unwrap() * (self.diff / <C::Scalar as NumCast>::from(self.len).unwrap());
+            let i = self.from + (self.diff / flt(self.len)) * flt(self.current);
             self.current += 1;
             Some(self.gradient.get(i))
         } else {

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,8 +1,8 @@
-use num::traits::Float;
+use num::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp, flt};
 
 ///Linear HSL with an alpha component. See the [`Hsla` implementation in `Alpha`](struct.Alpha.html#Hsla).
 pub type Hsla<T = f32> = Alpha<Hsl<T>, T>;
@@ -218,22 +218,22 @@ impl<T: Float> From<Rgb<T>> for Hsl<T> {
         }
 
         let diff = val_max - val_min;
-        let lightness = (val_min + val_max) / T::from(2.0).unwrap();
+        let lightness = (val_min + val_max) / flt(2.0);
 
         let hue = if diff == T::zero() {
             T::zero()
         } else {
-            T::from(60.0).unwrap() * match chan_max {
-                Channel::Red => ((rgb.green - rgb.blue) / diff) % T::from(6.0).unwrap(),
-                Channel::Green => ((rgb.blue - rgb.red) / diff + T::from(2.0).unwrap()),
-                Channel::Blue => ((rgb.red - rgb.green) / diff + T::from(4.0).unwrap()),
+            flt::<T,_>(60.0) * match chan_max {
+                Channel::Red => ((rgb.green - rgb.blue) / diff) % flt(6.0),
+                Channel::Green => ((rgb.blue - rgb.red) / diff + flt(2.0)),
+                Channel::Blue => ((rgb.red - rgb.green) / diff + flt(4.0)),
             }
         };
 
         let saturation = if diff == T::zero() {
             T::zero()
         } else {
-            diff / (T::one() - (T::from(2.0).unwrap() * lightness - T::one()).abs())
+            diff / (T::one() - ( lightness * flt(2.0) - T::one()).abs())
         };
 
         Hsl {
@@ -276,19 +276,19 @@ impl<T: Float> From<Lch<T>> for Hsl<T> {
 
 impl<T: Float> From<Hsv<T>> for Hsl<T> {
     fn from(hsv: Hsv<T>) -> Hsl<T> {
-        let x = (T::from(2.0).unwrap() - hsv.saturation) * hsv.value;
+        let x = (flt::<T,_>(2.0) - hsv.saturation) * hsv.value;
         let saturation = if hsv.value == T::zero() {
             T::zero()
         } else if x < T::one() {
             hsv.saturation * hsv.value / x
         } else {
-            hsv.saturation * hsv.value / (T::from(2.0).unwrap() - x)
+            hsv.saturation * hsv.value / (flt::<T,_>(2.0) - x)
         };
 
         Hsl {
             hue: hsv.hue,
             saturation: saturation,
-            lightness: x / T::from(2.0).unwrap(),
+            lightness: x / flt(2.0),
         }
     }
 }

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -1,8 +1,8 @@
-use num::traits::Float;
+use num::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp, flt};
 
 ///Linear HSV with an alpha component. See the [`Hsva` implementation in `Alpha`](struct.Alpha.html#Hsva).
 pub type Hsva<T = f32> = Alpha<Hsv<T>, T>;
@@ -222,10 +222,10 @@ impl<T: Float> From<Rgb<T>> for Hsv<T> {
         let hue = if diff == T::zero() {
             T::zero()
         } else {
-            T::from(60.0).unwrap() * match chan_max {
-                Channel::Red => ((rgb.green - rgb.blue) / diff) % T::from(6.0).unwrap(),
-                Channel::Green => ((rgb.blue - rgb.red) / diff + T::from(2.0).unwrap()),
-                Channel::Blue => ((rgb.red - rgb.green) / diff + T::from(4.0).unwrap()),
+            flt::<T,_>(60.0) * match chan_max {
+                Channel::Red => ((rgb.green - rgb.blue) / diff) % flt(6.0),
+                Channel::Green => ((rgb.blue - rgb.red) / diff + flt(2.0)),
+                Channel::Blue => ((rgb.red - rgb.green) / diff + flt(4.0)),
             }
         };
 
@@ -275,7 +275,7 @@ impl<T: Float> From<Lch<T>> for Hsv<T> {
 
 impl<T: Float> From<Hsl<T>> for Hsv<T> {
     fn from(hsl: Hsl<T>) -> Hsv<T> {
-        let x = hsl.saturation * if hsl.lightness < T::from(0.5).unwrap() {
+        let x = hsl.saturation * if hsl.lightness < flt(0.5) {
             hsl.lightness
         } else {
             T::one() - hsl.lightness
@@ -283,7 +283,7 @@ impl<T: Float> From<Hsl<T>> for Hsv<T> {
 
         Hsv {
             hue: hsl.hue,
-            saturation: T::from(2.0).unwrap() * x / (hsl.lightness + x),
+            saturation: x * flt(2.0) / (hsl.lightness + x),
             value: hsl.lightness + x,
         }
     }

--- a/src/hues.rs
+++ b/src/hues.rs
@@ -1,8 +1,10 @@
-use num::traits::Float;
+use num::Float;
 
 use std::f64::consts::PI;
 use std::cmp::PartialEq;
 use std::ops::{Add, Sub};
+
+use flt;
 
 macro_rules! make_hues {
     ($($(#[$doc:meta])+ struct $name:ident;)+) => ($(
@@ -19,7 +21,7 @@ macro_rules! make_hues {
         impl<T:Float> $name<T> {
             ///Create a new hue from radians, instead of degrees.
             pub fn from_radians(radians: T) -> $name<T> {
-                $name(radians * T::from(180.0).unwrap() / T::from(PI).unwrap())
+                $name(radians * flt(180.0) / flt(PI))
             }
 
             ///Get the hue as degrees, in the range `(-180, 180]`.
@@ -29,7 +31,7 @@ macro_rules! make_hues {
 
             ///Convert the hue to radians, in the range `(-π, π]`.
             pub fn to_radians(self) -> T {
-                normalize_angle(self.0) * T::from(PI).unwrap() / T::from(180.0).unwrap()
+                normalize_angle(self.0) * flt(PI) / flt(180.0)
             }
 
             ///Convert the hue to positive degrees, in the range `[0, 360)`.
@@ -39,7 +41,7 @@ macro_rules! make_hues {
 
             ///Convert the hue to positive radians, in the range `[0, 2π)`.
             pub fn to_positive_radians(self) -> T {
-                normalize_angle_positive(self.0) * T::from(PI).unwrap() / T::from(180.0).unwrap()
+                normalize_angle_positive(self.0) * flt(PI) / flt(180.0)
             }
         }
 
@@ -131,8 +133,8 @@ make_hues! {
 }
 
 fn normalize_angle<T: Float>(mut deg: T) -> T {
-    let c180 = T::from(180.0).unwrap();
-    let c360 = T::from(360.0).unwrap();
+    let c180 = flt(180.0);
+    let c360 = flt(360.0);
     while deg > c180 {
         deg = deg - c360;
     }
@@ -145,7 +147,7 @@ fn normalize_angle<T: Float>(mut deg: T) -> T {
 }
 
 fn normalize_angle_positive<T: Float>(mut deg: T) -> T {
-    let c360 = T::from(360.0).unwrap();
+    let c360 = flt(360.0);
     while deg >= c360 {
         deg = deg - c360;
     }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,8 +1,8 @@
-use num::traits::Float;
+use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp};
+use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp, flt};
 
 use tristimulus::{X_N, Y_N, Z_N};
 
@@ -222,14 +222,9 @@ alpha_from!(Lab {Rgb, Xyz, Yxy, Luma, Lch, Hsv, Hsl, Color});
 impl<T: Float> From<Xyz<T>> for Lab<T> {
     fn from(xyz: Xyz<T>) -> Lab<T> {
         Lab {
-            l: (T::from(116.0).unwrap() * f(xyz.y / T::from(Y_N).unwrap()) -
-                T::from(16.0).unwrap()) / T::from(100.0).unwrap(),
-            a: (T::from(500.0).unwrap() *
-                (f(xyz.x / T::from(X_N).unwrap()) - f(xyz.y / T::from(Y_N).unwrap()))) /
-               T::from(128.0).unwrap(),
-            b: (T::from(200.0).unwrap() *
-                (f(xyz.y / T::from(Y_N).unwrap()) - f(xyz.z / T::from(Z_N).unwrap()))) /
-               T::from(128.0).unwrap(),
+            l: (f(xyz.y / flt(Y_N)) * flt(116.0) - flt(16.0)) / flt(100.0),
+            a: (f(xyz.x / flt(X_N)) - f(xyz.y / flt(Y_N))) * flt(500.0) / flt(128.0),
+            b: (f(xyz.y / flt(Y_N)) - f(xyz.z / flt(Z_N))) * flt(200.0) / flt(128.0),
         }
     }
 }
@@ -276,15 +271,14 @@ impl<T: Float> From<Hsl<T>> for Lab<T> {
 
 fn f<T: Float>(t: T) -> T {
     //(6/29)^3
-    let c_6_o_29_p_3: T = T::from(0.00885645167).unwrap();
+    let c_6_o_29_p_3: T = flt(0.00885645167);
     //(29/6)^2
-    let c_29_o_6_p_2: T = T::from(23.3611111111).unwrap();
+    let c_29_o_6_p_2: T = flt(23.3611111111);
 
     if t > c_6_o_29_p_3 {
-        t.powf(T::one() / T::from(3.0).unwrap())
+        t.powf(T::one() / flt(3.0))
     } else {
-        (T::one() / T::from(3.0).unwrap()) * c_29_o_6_p_2 * t +
-        (T::from(4.0).unwrap() / T::from(29.0).unwrap())
+        (T::one() / flt(3.0)) * c_29_o_6_p_2 * t + (flt::<T,_>(4.0) / flt(29.0))
     }
 }
 

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -1,4 +1,4 @@
-use num::traits::Float;
+use num::Float;
 
 use std::ops::{Add, Sub};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 extern crate approx;
 extern crate num;
 
-use num::traits::Float;
+use num::{Float, ToPrimitive, NumCast};
 
 use pixel::{Srgb, GammaRgb};
 
@@ -596,4 +596,9 @@ pub trait Saturate: Sized {
     fn desaturate(&self, factor: Self::Scalar) -> Self {
         self.saturate(-factor)
     }
+}
+
+///A convenience function to convert a constant number to Float Type
+fn flt<T: num::Float, P: ToPrimitive>(prim: P) -> T {
+    NumCast::from(prim).unwrap()
 }

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -1,8 +1,8 @@
-use num::traits::Float;
+use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp};
+use {Color, Alpha, Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, flt};
 
 ///Linear luminance with an alpha component. See the [`Lumaa` implementation in `Alpha`](struct.Alpha.html#Lumaa).
 pub type Lumaa<T = f32> = Alpha<Luma<T>, T>;
@@ -31,7 +31,7 @@ impl<T: Float> Luma<T> {
     ///Linear luminance from an 8 bit value.
     pub fn new_u8(luma: u8) -> Luma<T> {
         Luma {
-            luma: T::from(luma).unwrap() / T::from(255.0).unwrap(),
+            luma: flt::<T,_>(luma) / flt(255.0),
         }
     }
 }
@@ -50,7 +50,7 @@ impl<T: Float> Alpha<Luma<T>, T> {
     pub fn new_u8(luma: u8, alpha: u8) -> Lumaa<T> {
         Alpha {
             color: Luma::new_u8(luma),
-            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
+            alpha: flt::<T,_>(alpha) / flt(255.0),
         }
     }
 }
@@ -186,7 +186,7 @@ alpha_from!(Luma {Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Color});
 impl<T: Float> From<Rgb<T>> for Luma<T> {
     fn from(rgb: Rgb<T>) -> Luma<T> {
         Luma {
-            luma: rgb.red * T::from(0.2126).unwrap() + rgb.green * T::from(0.7152).unwrap() + rgb.blue * T::from(0.0722).unwrap(),
+            luma: rgb.red * flt(0.2126) + rgb.green * flt(0.7152) + rgb.blue * flt(0.0722),
         }
     }
 }

--- a/src/pixel/gamma_rgb.rs
+++ b/src/pixel/gamma_rgb.rs
@@ -1,6 +1,6 @@
 use num::Float;
 
-use {Alpha, Rgb, Rgba, clamp};
+use {Alpha, Rgb, Rgba, clamp, flt};
 
 use pixel::RgbPixel;
 
@@ -71,10 +71,10 @@ impl<T: Float> GammaRgb<T> {
     ///Create a new gamma encoded color, with transparency, from `u8` values.
     pub fn with_alpha_u8(red: u8, green: u8, blue: u8, alpha: u8, gamma: T) -> GammaRgb<T> {
         GammaRgb {
-            red: T::from(red).unwrap() / T::from(255.0).unwrap(),
-            green: T::from(green).unwrap() / T::from(255.0).unwrap(),
-            blue: T::from(blue).unwrap() / T::from(255.0).unwrap(),
-            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
+            red: flt::<T,_>(red) / flt(255.0),
+            green: flt::<T,_>(green) / flt(255.0),
+            blue: flt::<T,_>(blue) / flt(255.0),
+            alpha: flt::<T,_>(alpha) / flt(255.0),
             gamma: gamma,
         }
     }

--- a/src/pixel/mod.rs
+++ b/src/pixel/mod.rs
@@ -2,7 +2,7 @@
 
 use num::Float;
 
-use clamp;
+use {clamp, flt};
 
 pub use self::srgb::Srgb;
 pub use self::gamma_rgb::GammaRgb;
@@ -33,7 +33,7 @@ impl<T: Float> RgbPixel<T> for (f32, f32, f32, f32) {
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b, a) = *self;
-        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::from(a).unwrap() )
+        ( flt(r), flt(g), flt(b), flt(a) )
     }
 }
 
@@ -44,7 +44,7 @@ impl<T: Float> RgbPixel<T> for (f32, f32, f32) {
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b) = *self;
-        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::one() )
+        ( flt(r), flt(g), flt(b), T::one() )
     }
 }
 impl<T: Float> RgbPixel<T> for (f64, f64, f64, f64) {
@@ -54,7 +54,7 @@ impl<T: Float> RgbPixel<T> for (f64, f64, f64, f64) {
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b, a) = *self;
-        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::from(a).unwrap() )
+        ( flt(r), flt(g), flt(b), flt(a) )
     }
 }
 
@@ -65,13 +65,13 @@ impl<T: Float> RgbPixel<T> for (f64, f64, f64) {
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b) = *self;
-        ( T::from(r).unwrap(), T::from(g).unwrap(), T::from(b).unwrap(), T::one() )
+        ( flt(r), flt(g), flt(b), T::one() )
     }
 }
 
 impl<T: Float> RgbPixel<T> for (u8, u8, u8, u8) {
     fn from_rgba(red: T, green: T, blue: T, alpha: T) -> (u8, u8, u8, u8) {
-        let c255 = T::from(255.0).unwrap();
+        let c255 = flt(255.0);
         (
             clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
             clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
@@ -82,19 +82,19 @@ impl<T: Float> RgbPixel<T> for (u8, u8, u8, u8) {
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b, a) = *self;
-        let c255 = T::from(255.0).unwrap();
+        let c255: T = flt(255.0);
         (
-            T::from(r).unwrap() / c255,
-            T::from(g).unwrap() / c255,
-            T::from(b).unwrap() / c255,
-            T::from(a).unwrap() / c255,
+            flt::<T,_>(r) / c255,
+            flt::<T,_>(g) / c255,
+            flt::<T,_>(b) / c255,
+            flt::<T,_>(a) / c255,
         )
     }
 }
 
 impl<T: Float> RgbPixel<T> for (u8, u8, u8) {
     fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> (u8, u8, u8) {
-        let c255 = T::from(255.0).unwrap();
+        let c255: T = flt(255.0);
         (
             clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
             clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
@@ -104,11 +104,11 @@ impl<T: Float> RgbPixel<T> for (u8, u8, u8) {
 
     fn to_rgba(&self) -> (T, T, T, T) {
         let (r, g, b) = *self;
-        let c255 = T::from(255.0).unwrap();
+        let c255: T = flt(255.0);
         (
-            T::from(r).unwrap() / c255,
-            T::from(g).unwrap() / c255,
-            T::from(b).unwrap() / c255,
+            flt::<T,_>(r) / c255,
+            flt::<T,_>(g) / c255,
+            flt::<T,_>(b) / c255,
             T::one(),
         )
     }
@@ -120,7 +120,7 @@ impl<T: Float> RgbPixel<T> for [f32; 4] {
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
-        ( T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::from(self[3]).unwrap() )
+        ( flt(self[0]), flt(self[1]), flt(self[2]), flt(self[3]) )
     }
 }
 
@@ -130,7 +130,7 @@ impl<T: Float> RgbPixel<T> for [f32; 3] {
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
-        (T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::one())
+        (flt(self[0]), flt(self[1]), flt(self[2]), T::one())
     }
 }
 impl<T: Float> RgbPixel<T> for [f64; 4] {
@@ -139,7 +139,7 @@ impl<T: Float> RgbPixel<T> for [f64; 4] {
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
-        (T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::from(self[3]).unwrap())
+        (flt(self[0]), flt(self[1]), flt(self[2]), flt(self[3]))
     }
 }
 
@@ -149,13 +149,13 @@ impl<T: Float> RgbPixel<T> for [f64; 3] {
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
-        (T::from(self[0]).unwrap(), T::from(self[1]).unwrap(), T::from(self[2]).unwrap(), T::one())
+        (flt(self[0]), flt(self[1]), flt(self[2]), T::one())
     }
 }
 
 impl<T: Float> RgbPixel<T> for [u8; 4] {
     fn from_rgba(red: T, green: T, blue: T, alpha: T) -> [u8; 4] {
-        let c255 = T::from(255.0).unwrap();
+        let c255 = flt(255.0);
         [
             clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
             clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
@@ -165,19 +165,19 @@ impl<T: Float> RgbPixel<T> for [u8; 4] {
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
-        let c255 = T::from(255.0).unwrap();
+        let c255: T = flt(255.0);
         (
-            T::from(self[0]).unwrap() / c255,
-            T::from(self[1]).unwrap() / c255,
-            T::from(self[2]).unwrap() / c255,
-            T::from(self[3]).unwrap() / c255,
+            flt::<T,_>(self[0]) / c255,
+            flt::<T,_>(self[1]) / c255,
+            flt::<T,_>(self[2]) / c255,
+            flt::<T,_>(self[3]) / c255,
         )
     }
 }
 
 impl<T: Float> RgbPixel<T> for [u8; 3] {
     fn from_rgba(red: T, green: T, blue: T, _alpha: T) -> [u8; 3] {
-        let c255 = T::from(255.0).unwrap();
+        let c255 = flt(255.0);
         [
             clamp(red * c255, T::zero(), c255).to_u8().unwrap(),
             clamp(green * c255, T::zero(), c255).to_u8().unwrap(),
@@ -186,11 +186,11 @@ impl<T: Float> RgbPixel<T> for [u8; 3] {
     }
 
     fn to_rgba(&self) -> (T, T, T, T) {
-        let c255 = T::from(255.0).unwrap();
+        let c255: T = flt(255.0);
         (
-            T::from(self[0]).unwrap() / c255,
-            T::from(self[1]).unwrap() / c255,
-            T::from(self[2]).unwrap() / c255,
+            flt::<T,_>(self[0]) / c255,
+            flt::<T,_>(self[1]) / c255,
+            flt::<T,_>(self[2]) / c255,
             T::one(),
         )
     }

--- a/src/pixel/srgb.rs
+++ b/src/pixel/srgb.rs
@@ -1,6 +1,6 @@
 use num::Float;
 
-use {Color, Alpha, Rgb, Rgba, clamp};
+use {Color, Alpha, Rgb, Rgba, clamp, flt};
 
 use pixel::RgbPixel;
 
@@ -61,10 +61,10 @@ impl<T: Float> Srgb<T> {
     ///Create a new sRGB encoded color, with transparency, from `u8` values.
     pub fn with_alpha_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Srgb<T> {
         Srgb {
-            red: T::from(red).unwrap() / T::from(255.0).unwrap(),
-            green: T::from(green).unwrap() / T::from(255.0).unwrap(),
-            blue: T::from(blue).unwrap() / T::from(255.0).unwrap(),
-            alpha: T::from(alpha).unwrap() / T::from(255.0).unwrap(),
+            red: flt::<T,_>(red) / flt(255.0),
+            green: flt::<T,_>(green) / flt(255.0),
+            blue: flt::<T,_>(blue) / flt(255.0),
+            alpha: flt::<T,_>(alpha) / flt(255.0),
         }
     }
 
@@ -132,17 +132,17 @@ impl<T: Float> From<Color<T>> for Srgb<T> {
 }
 
 fn from_srgb<T: Float>(x: T) -> T {
-    if x <= T::from(0.04045).unwrap() {
-        x / T::from(12.92).unwrap()
+    if x <= flt(0.04045) {
+        x / flt(12.92)
     } else {
-        ((x + T::from(0.055).unwrap()) / T::from(1.055).unwrap()).powf(T::from(2.4).unwrap())
+        ((x + flt(0.055)) / flt(1.055)).powf(flt(2.4))
     }
 }
 
 fn to_srgb<T: Float>(x: T) -> T {
-    if x <= T::from(0.0031308).unwrap() {
-        T::from(12.92).unwrap() * x
+    if x <= flt(0.0031308) {
+        x * flt(12.92)
     } else {
-        T::from(1.055).unwrap() * x.powf(T::from(1.0 / 2.4).unwrap()) - T::from(0.055).unwrap()
+        x.powf(T::one() / flt(2.4)) * flt(1.055)  - flt(0.055)
     }
 }

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -1,8 +1,8 @@
-use num::traits::Float;
+use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, Xyz};
+use {Color, Alpha, Rgb, Luma, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, flt, Xyz};
 
 const D65_X: f64 = 0.312727;
 const D65_Y: f64 = 0.329023;
@@ -110,7 +110,7 @@ impl<T: Float> Default for Yxy<T> {
         // Since Y (luma) is 0.0, this makes the default color black just like for other colors.
         // The reason for not using 0 for x and y is that this outside the usual color gamut and might
         // cause scaling issues.
-        Yxy::new(T::from(D65_X).unwrap(), T::from(D65_Y).unwrap(), T::zero())
+        Yxy::new(flt(D65_X), flt(D65_Y), T::zero())
     }
 }
 
@@ -231,8 +231,8 @@ impl<T: Float> From<Luma<T>> for Yxy<T> {
     fn from(luma: Luma<T>) -> Yxy<T> {
         // Use the D65 white point Yxy values for x and y as D65 is used as the default
         Yxy {
-            x: T::from(D65_X).unwrap(),
-            y: T::from(D65_Y).unwrap(),
+            x: flt(D65_X),
+            y: flt(D65_Y),
             luma: luma.luma,
         }
     }


### PR DESCRIPTION
Use function flt() to convert constants to trait Float type. Changed all T::from().unwrap() to use this flt() function defined in lib.rs. Makes the code easier to read, especially the formula's.

closes #33