### PR TITLE
Adding whitepoint for colors spaces

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -2,7 +2,7 @@ use num::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp, flt};
+use { Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp, flt};
 
 ///Linear HSL with an alpha component. See the [`Hsla` implementation in `Alpha`](struct.Alpha.html#Hsla).
 pub type Hsla<T = f32> = Alpha<Hsl<T>, T>;
@@ -195,9 +195,9 @@ impl<T: Float> Sub<T> for Hsl<T> {
     }
 }
 
-from_color!(to Hsl from Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv);
+// from_color!(to Hsl from Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv);
 
-alpha_from!(Hsl {Rgb, Xyz, Yxy, Luma, Lab, Lch, Hsv, Color});
+// alpha_from!(Hsl {Rgb, Xyz, Yxy, Luma, Lab, Lch, Hsv, Color});
 
 impl<T: Float> From<Rgb<T>> for Hsl<T> {
     fn from(rgb: Rgb<T>) -> Hsl<T> {

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -2,7 +2,7 @@ use num::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp, flt};
+use { Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, clamp, flt};
 
 ///Linear HSV with an alpha component. See the [`Hsva` implementation in `Alpha`](struct.Alpha.html#Hsva).
 pub type Hsva<T = f32> = Alpha<Hsv<T>, T>;
@@ -194,9 +194,9 @@ impl<T: Float> Sub<T> for Hsv<T> {
     }
 }
 
-from_color!(to Hsv from Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl);
+// from_color!(to Hsv from Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsl);
 
-alpha_from!(Hsv {Rgb, Xyz, Yxy, Luma, Lab, Lch, Hsl, Color});
+// alpha_from!(Hsv {Rgb, Xyz, Yxy, Luma, Lab, Lch, Hsl, Color});
 
 
 impl<T: Float> From<Rgb<T>> for Hsv<T> {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,13 +1,16 @@
 use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
+use std::marker::PhantomData;
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp, flt};
+use { Alpha, Rgb, Luma, Xyz, Yxy, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, WhitePoint, D65, clamp, flt};
+use lch::LchSpace;
 
-use tristimulus::{X_N, Y_N, Z_N};
+pub type Lab<T> = LabSpace<D65, T>;
+pub type Laba<T> = AlphaLabSpace<D65, T>;
 
 ///CIE L*a*b* (CIELAB) with an alpha component. See the [`Laba` implementation in `Alpha`](struct.Alpha.html#Laba).
-pub type Laba<T = f32> = Alpha<Lab<T>, T>;
+pub type AlphaLabSpace<WP, T = f32> = Alpha<LabSpace<WP,T>, T>;
 
 ///The CIE L*a*b* (CIELAB) color space.
 ///
@@ -21,7 +24,10 @@ pub type Laba<T = f32> = Alpha<Lab<T>, T>;
 ///The parameters of L*a*b* are quite different, compared to many other color
 ///spaces, so manipulating them manually can be unintuitive.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Lab<T: Float = f32> {
+pub struct LabSpace<WP = D65, T = f32>
+    where T: Float,
+        WP: WhitePoint<T>
+{
     ///L* is the lightness of the color. 0.0 gives absolute black and 1.0
     ///give the brightest white.
     pub l: T,
@@ -31,77 +37,101 @@ pub struct Lab<T: Float = f32> {
 
     ///b* goes from yellow at -1.0 to blue at 1.0.
     pub b: T,
+
+    _wp: PhantomData<WP>,
 }
 
-impl<T: Float> Lab<T> {
+impl<WP, T> LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
     ///CIE L*a*b*.
-    pub fn new(l: T, a: T, b: T) -> Lab<T> {
-        Lab {
+    pub fn new(l: T, a: T, b: T) -> LabSpace<WP, T> {
+        LabSpace {
             l: l,
             a: a,
             b: b,
+            _wp: PhantomData,
         }
     }
 }
 
 ///<span id="Laba"></span>[`Laba`](type.Laba.html) implementations.
-impl<T: Float> Alpha<Lab<T>, T> {
+impl<WP, T> Alpha<LabSpace<WP, T>, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
     ///CIE L*a*b* and transparency.
-    pub fn new(l: T, a: T, b: T, alpha: T) -> Laba<T> {
+    pub fn new(l: T, a: T, b: T, alpha: T) -> AlphaLabSpace<WP, T> {
         Alpha {
-            color: Lab::new(l, a, b),
+            color: LabSpace::new(l, a, b),
             alpha: alpha,
         }
     }
 }
 
-impl<T: Float> Limited for Lab<T> {
-    fn is_valid(&self) -> bool {
-        self.l >= T::zero() && self.l <= T::one() &&
-        self.a >= -T::one() && self.a <= T::one() &&
-        self.b >= -T::one() && self.b <= T::one()
-    }
+// Rendered error http://is.gd/tHCm5C
+// impl<WP, T> Limited for LabSpace<WP, T>
+// where T: Float,
+//     WP: WhitePoint<T>
+// {
+//     fn is_valid(&self) -> bool {
+//         self.l >= T::zero() && self.l <= T::one() &&
+//         self.a >= -T::one() && self.a <= T::one() &&
+//         self.b >= -T::one() && self.b <= T::one()
+//     }
+//
+//     fn clamp(&self) -> LabSpace<WP, T> {
+//         let mut c = *self;
+//         c.clamp_self();
+//         c
+//     }
+//
+//     fn clamp_self(&mut self) {
+//         self.l = clamp(self.l, T::zero(), T::one());
+//         self.a = clamp(self.a, -T::one(), T::one());
+//         self.b = clamp(self.b, -T::one(), T::one());
+//     }
+// }
 
-    fn clamp(&self) -> Lab<T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.l = clamp(self.l, T::zero(), T::one());
-        self.a = clamp(self.a, -T::one(), T::one());
-        self.b = clamp(self.b, -T::one(), T::one());
-    }
-}
-
-impl<T: Float> Mix for Lab<T> {
+impl<WP, T> Mix for LabSpace<WP, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
     type Scalar = T;
 
-    fn mix(&self, other: &Lab<T>, factor: T) -> Lab<T> {
+    fn mix(&self, other: &LabSpace<WP, T>, factor: T) -> LabSpace<WP, T> {
         let factor = clamp(factor, T::zero(), T::one());
 
-        Lab {
+        LabSpace {
             l: self.l + factor * (other.l - self.l),
             a: self.a + factor * (other.a - self.a),
             b: self.b + factor * (other.b - self.b),
+            _wp: PhantomData,
         }
     }
 }
 
-impl<T: Float> Shade for Lab<T> {
+impl<WP, T> Shade for LabSpace<WP, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Lab<T> {
-        Lab {
+    fn lighten(&self, amount: T) -> LabSpace<WP, T> {
+        LabSpace {
             l: self.l + amount,
             a: self.a,
             b: self.b,
+            _wp: PhantomData,
         }
     }
 }
 
-impl<T: Float> GetHue for Lab<T> {
+impl<WP, T> GetHue for LabSpace<WP, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
     type Hue = LabHue<T>;
 
     fn get_hue(&self) -> Option<LabHue<T>> {
@@ -119,152 +149,210 @@ impl<T: Float> Default for Lab<T> {
     }
 }
 
-impl<T: Float> Add<Lab<T>> for Lab<T> {
-    type Output = Lab<T>;
 
-    fn add(self, other: Lab<T>) -> Lab<T> {
-        Lab {
+impl<WP, T> Add<LabSpace<WP, T>> for LabSpace<WP, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP, T>;
+
+    fn add(self, other: LabSpace<WP, T>) -> LabSpace<WP, T> {
+        LabSpace {
             l: self.l + other.l,
             a: self.a + other.a,
             b: self.b + other.b,
+            _wp: PhantomData,
         }
     }
 }
 
-impl<T: Float> Add<T> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Add<T> for LabSpace<WP, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP, T>;
 
-    fn add(self, c: T) -> Lab<T> {
-        Lab {
+    fn add(self, c: T) -> LabSpace<WP, T> {
+        LabSpace {
             l: self.l + c,
             a: self.a + c,
             b: self.b + c,
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> Sub<Lab<T>> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Sub<LabSpace<WP,T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP,T>;
 
-    fn sub(self, other: Lab<T>) -> Lab<T> {
-        Lab {
+    fn sub(self, other: LabSpace<WP,T>) -> LabSpace<WP,T> {
+        LabSpace {
             l: self.l - other.l,
             a: self.a - other.a,
             b: self.b - other.b,
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> Sub<T> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Sub<T> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP,T>;
 
-    fn sub(self, c: T) -> Lab<T> {
-        Lab {
+    fn sub(self, c: T) -> LabSpace<WP,T> {
+        LabSpace {
             l: self.l - c,
             a: self.a - c,
             b: self.b - c,
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> Mul<Lab<T>> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Mul<LabSpace<WP,T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP,T>;
 
-    fn mul(self, other: Lab<T>) -> Lab<T> {
-        Lab {
+    fn mul(self, other: LabSpace<WP,T>) -> LabSpace<WP,T> {
+        LabSpace {
             l: self.l * other.l,
             a: self.a * other.a,
             b: self.b * other.b,
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> Mul<T> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Mul<T> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP,T>;
 
-    fn mul(self, c: T) -> Lab<T> {
-        Lab {
+    fn mul(self, c: T) -> LabSpace<WP,T> {
+        LabSpace {
             l: self.l * c,
             a: self.a * c,
             b: self.b * c,
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> Div<Lab<T>> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Div<LabSpace<WP,T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP,T>;
 
-    fn div(self, other: Lab<T>) -> Lab<T> {
-        Lab {
+    fn div(self, other: LabSpace<WP,T>) -> LabSpace<WP,T> {
+        LabSpace {
             l: self.l / other.l,
             a: self.a / other.a,
             b: self.b / other.b,
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> Div<T> for Lab<T> {
-    type Output = Lab<T>;
+impl<WP, T> Div<T> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    type Output = LabSpace<WP,T>;
 
-    fn div(self, c: T) -> Lab<T> {
-        Lab {
+    fn div(self, c: T) -> LabSpace<WP,T> {
+        LabSpace {
             l: self.l / c,
             a: self.a / c,
             b: self.b / c,
+            _wp: PhantomData
         }
     }
 }
 
-from_color!(to Lab from Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl);
+// from_color!(to Lab from Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl);
 
-alpha_from!(Lab {Rgb, Xyz, Yxy, Luma, Lch, Hsv, Hsl, Color});
+// alpha_from!(LabSpace {Rgb, Xyz, Yxy, Luma, Lch, Hsv, Hsl, Color});
 
-impl<T: Float> From<Xyz<T>> for Lab<T> {
-    fn from(xyz: Xyz<T>) -> Lab<T> {
-        Lab {
-            l: (f(xyz.y / flt(Y_N)) * flt(116.0) - flt(16.0)) / flt(100.0),
-            a: (f(xyz.x / flt(X_N)) - f(xyz.y / flt(Y_N))) * flt(500.0) / flt(128.0),
-            b: (f(xyz.y / flt(Y_N)) - f(xyz.z / flt(Z_N))) * flt(200.0) / flt(128.0),
+impl<WP, T> From<Xyz<T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(xyz: Xyz<T>) -> LabSpace<WP,T> {
+        let wp_xyz: Xyz<T> = WP::get_yxy().into();
+
+        LabSpace {
+            l: (f(xyz.y / wp_xyz.y) * flt(116.0) - flt(16.0)) / flt(100.0),
+            a: (f(xyz.x / wp_xyz.x) - f(xyz.y / wp_xyz.y)) * flt(500.0) / flt(128.0),
+            b: (f(xyz.y / wp_xyz.y) - f(xyz.z / wp_xyz.z)) * flt(200.0) / flt(128.0),
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> From<Yxy<T>> for Lab<T> {
-    fn from(yxy: Yxy<T>) -> Lab<T> {
+impl<WP, T> From<Yxy<T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(yxy: Yxy<T>) -> LabSpace<WP,T> {
         Xyz::from(yxy).into()
     }
 }
 
-impl<T: Float> From<Rgb<T>> for Lab<T> {
-    fn from(rgb: Rgb<T>) -> Lab<T> {
+impl<WP, T> From<Rgb<T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(rgb: Rgb<T>) -> LabSpace<WP,T> {
         Xyz::from(rgb).into()
     }
 }
 
-impl<T: Float> From<Luma<T>> for Lab<T> {
-    fn from(luma: Luma<T>) -> Lab<T> {
+impl<WP, T> From<Luma<T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(luma: Luma<T>) -> LabSpace<WP,T> {
         Xyz::from(luma).into()
     }
 }
 
-impl<T: Float> From<Lch<T>> for Lab<T> {
-    fn from(lch: Lch<T>) -> Lab<T> {
-        Lab {
+impl<WP, T> From<LchSpace<WP, T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(lch: LchSpace<WP, T>) -> LabSpace<WP,T> {
+        LabSpace {
             l: lch.l,
             a: lch.chroma.max(T::zero()) * lch.hue.to_radians().cos(),
             b: lch.chroma.max(T::zero()) * lch.hue.to_radians().sin(),
+            _wp: PhantomData
         }
     }
 }
 
-impl<T: Float> From<Hsv<T>> for Lab<T> {
-    fn from(hsv: Hsv<T>) -> Lab<T> {
+impl<WP, T> From<Hsv<T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(hsv: Hsv<T>) -> LabSpace<WP,T> {
         Xyz::from(hsv).into()
     }
 }
 
-impl<T: Float> From<Hsl<T>> for Lab<T> {
-    fn from(hsl: Hsl<T>) -> Lab<T> {
+impl<WP, T> From<Hsl<T>> for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(hsl: Hsl<T>) -> LabSpace<WP,T> {
         Xyz::from(hsl).into()
     }
 }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -23,7 +23,7 @@ pub type AlphaLabSpace<WP, T = f32> = Alpha<LabSpace<WP,T>, T>;
 ///
 ///The parameters of L*a*b* are quite different, compared to many other color
 ///spaces, so manipulating them manually can be unintuitive.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct LabSpace<WP = D65, T = f32>
     where T: Float,
         WP: WhitePoint<T>
@@ -39,6 +39,19 @@ pub struct LabSpace<WP = D65, T = f32>
     pub b: T,
 
     _wp: PhantomData<WP>,
+}
+
+
+impl<WP, T> Copy for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{}
+
+impl<WP, T> Clone for LabSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn clone(&self) -> LabSpace<WP,T> { *self }
 }
 
 impl<WP, T> LabSpace<WP,T>
@@ -70,29 +83,28 @@ impl<WP, T> Alpha<LabSpace<WP, T>, T>
     }
 }
 
-// Rendered error http://is.gd/tHCm5C
-// impl<WP, T> Limited for LabSpace<WP, T>
-// where T: Float,
-//     WP: WhitePoint<T>
-// {
-//     fn is_valid(&self) -> bool {
-//         self.l >= T::zero() && self.l <= T::one() &&
-//         self.a >= -T::one() && self.a <= T::one() &&
-//         self.b >= -T::one() && self.b <= T::one()
-//     }
-//
-//     fn clamp(&self) -> LabSpace<WP, T> {
-//         let mut c = *self;
-//         c.clamp_self();
-//         c
-//     }
-//
-//     fn clamp_self(&mut self) {
-//         self.l = clamp(self.l, T::zero(), T::one());
-//         self.a = clamp(self.a, -T::one(), T::one());
-//         self.b = clamp(self.b, -T::one(), T::one());
-//     }
-// }
+impl<WP, T> Limited for LabSpace<WP, T>
+where T: Float,
+    WP: WhitePoint<T>
+{
+    fn is_valid(&self) -> bool {
+        self.l >= T::zero() && self.l <= T::one() &&
+        self.a >= -T::one() && self.a <= T::one() &&
+        self.b >= -T::one() && self.b <= T::one()
+    }
+
+    fn clamp(&self) -> LabSpace<WP, T> {
+        let mut c = *self;
+        c.clamp_self();
+        c
+    }
+
+    fn clamp_self(&mut self) {
+        self.l = clamp(self.l, T::zero(), T::one());
+        self.a = clamp(self.a, -T::one(), T::one());
+        self.b = clamp(self.b, -T::one(), T::one());
+    }
+}
 
 impl<WP, T> Mix for LabSpace<WP, T>
     where T: Float,

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -18,7 +18,7 @@ pub type AlphaLchSpace<WP, T = f32> = Alpha<LchSpace<WP, T>, T>;
 ///cylindrical color space, like [HSL](struct.Hsl.html) and
 ///[HSV](struct.Hsv.html). This gives it the same ability to directly change
 ///the hue and colorfulness of a color, while preserving other visual aspects.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct LchSpace<WP = D65, T = f32>
 where T: Float,
     WP: WhitePoint<T>
@@ -40,6 +40,17 @@ where T: Float,
     _wp: PhantomData<WP>,
 }
 
+impl<WP, T> Copy for LchSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{}
+
+impl<WP, T> Clone for LchSpace<WP,T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn clone(&self) -> LchSpace<WP,T> { *self }
+}
 
 impl<WP, T> LchSpace<WP, T>
     where T: Float,
@@ -71,26 +82,26 @@ impl<WP, T> Alpha<LchSpace<WP, T>, T>
     }
 }
 
-// impl<WP, T> Limited for LchSpace<WP, T>
-//     where T: Float,
-//         WP: WhitePoint<T>
-// {
-//     fn is_valid(&self) -> bool {
-//         self.l >= T::zero() && self.l <= T::one() &&
-//         self.chroma >= T::zero()
-//     }
-//
-//     fn clamp(&self) -> LchSpace<WP, T> {
-//         let mut c = *self;
-//         c.clamp_self();
-//         c
-//     }
-//
-//     fn clamp_self(&mut self) {
-//         self.l = clamp(self.l, T::zero(), T::one());
-//         self.chroma = self.chroma.max(T::zero())
-//     }
-// }
+impl<WP, T> Limited for LchSpace<WP, T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn is_valid(&self) -> bool {
+        self.l >= T::zero() && self.l <= T::one() &&
+        self.chroma >= T::zero()
+    }
+
+    fn clamp(&self) -> LchSpace<WP, T> {
+        let mut c = *self;
+        c.clamp_self();
+        c
+    }
+
+    fn clamp_self(&mut self) {
+        self.l = clamp(self.l, T::zero(), T::one());
+        self.chroma = self.chroma.max(T::zero())
+    }
+}
 
 impl<WP, T> Mix for LchSpace<WP, T>
     where T: Float,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ extern crate num;
 
 use num::{Float, ToPrimitive, NumCast};
 
-use pixel::{Srgb, GammaRgb};
+// use pixel::{Srgb, GammaRgb};
 
 pub use gradient::Gradient;
 pub use alpha::Alpha;
@@ -290,6 +290,7 @@ mod hsl;
 mod hues;
 
 mod white_point;
+mod rgb_variant;
 mod tristimulus;
 
 // macro_rules! make_color {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,57 +62,58 @@ pub use lch::{Lch, Lcha};
 pub use hsv::{Hsv, Hsva};
 pub use hsl::{Hsl, Hsla};
 pub use yxy::{Yxy, Yxya};
+pub use white_point::{WhitePoint, D50, D65};
 
 pub use hues::{LabHue, RgbHue};
 
-macro_rules! from_color {
-    (to $to:ident from $($from:ident),+) => (
-        impl<T:Float> From<Color<T>> for $to<T> {
-            fn from(color: Color<T>) -> $to<T> {
-                match color {
-                    Color::$to(c) => c,
-                    $(Color::$from(c) => c.into(),)+
-                }
-            }
-        }
-    )
-}
-
-macro_rules! alpha_from {
-    ($self_ty:ident {$($other:ident),+}) => (
-        impl<T: Float> From<Alpha<$self_ty<T>, T>> for $self_ty<T> {
-            fn from(color: Alpha<$self_ty<T>, T>) -> $self_ty<T> {
-                color.color
-            }
-        }
-
-        $(
-            impl<T: Float> From<Alpha<$other<T>, T>> for Alpha<$self_ty<T>, T> {
-                fn from(other: Alpha<$other<T>, T>) -> Alpha<$self_ty<T>, T> {
-                    Alpha {
-                        color: other.color.into(),
-                        alpha: other.alpha,
-                    }
-                }
-            }
-
-            impl<T: Float> From<$other<T>> for Alpha<$self_ty<T>, T> {
-                fn from(color: $other<T>) -> Alpha<$self_ty<T>, T> {
-                    Alpha {
-                        color: color.into(),
-                        alpha: T::one(),
-                    }
-                }
-            }
-
-            impl<T: Float> From<Alpha<$other<T>, T>> for $self_ty<T> {
-                fn from(other: Alpha<$other<T>, T>) -> $self_ty<T> {
-                    other.color.into()
-                }
-            }
-        )+
-    )
-}
+// macro_rules! from_color {
+//     (to $to:ident from $($from:ident),+) => (
+//         impl<T:Float> From<Color<T>> for $to<T> {
+//             fn from(color: Color<T>) -> $to<T> {
+//                 match color {
+//                     Color::$to(c) => c,
+//                     $(Color::$from(c) => c.into(),)+
+//                 }
+//             }
+//         }
+//     )
+// }
+//
+// macro_rules! alpha_from {
+//     ($self_ty:ident {$($other:ident),+}) => (
+//         impl<T: Float> From<Alpha<$self_ty<T>, T>> for $self_ty<T> {
+//             fn from(color: Alpha<$self_ty<T>, T>) -> $self_ty<T> {
+//                 color.color
+//             }
+//         }
+//
+//         $(
+//             impl<T: Float> From<Alpha<$other<T>, T>> for Alpha<$self_ty<T>, T> {
+//                 fn from(other: Alpha<$other<T>, T>) -> Alpha<$self_ty<T>, T> {
+//                     Alpha {
+//                         color: other.color.into(),
+//                         alpha: other.alpha,
+//                     }
+//                 }
+//             }
+//
+//             impl<T: Float> From<$other<T>> for Alpha<$self_ty<T>, T> {
+//                 fn from(color: $other<T>) -> Alpha<$self_ty<T>, T> {
+//                     Alpha {
+//                         color: color.into(),
+//                         alpha: T::one(),
+//                     }
+//                 }
+//             }
+//
+//             impl<T: Float> From<Alpha<$other<T>, T>> for $self_ty<T> {
+//                 fn from(other: Alpha<$other<T>, T>) -> $self_ty<T> {
+//                     other.color.into()
+//                 }
+//             }
+//         )+
+//     )
+// }
 
 //Helper macro for approximate component wise comparison. Most color spaces
 //are in roughly the same ranges, so this epsilon should be alright.
@@ -288,125 +289,126 @@ mod hsl;
 
 mod hues;
 
+mod white_point;
 mod tristimulus;
 
-macro_rules! make_color {
-    ($(
-        #[$variant_comment:meta]
-        $variant:ident $(and $($representations:ident),+ )* {$(
-            #[$ctor_comment:meta]
-            $ctor_name:ident $( <$( $ty_params:ident: $ty_param_traits:ident $( <$( $ty_inner_traits:ident ),*> )*),*> )* ($($ctor_field:ident : $ctor_ty:ty),*) [alpha: $alpha_ty:ty] => $ctor_original:ident;
-        )+}
-    )+) => (
-
-        ///Generic color with an alpha component. See the [`Colora` implementation in `Alpha`](struct.Alpha.html#Colora).
-        pub type Colora<T = f32> = Alpha<Color<T>, T>;
-
-        ///A generic color type.
-        ///
-        ///The `Color` may belong to any color space and it may change
-        ///depending on which operation is performed. That makes it immune to
-        ///the "without conversion" rule of the operations it supports. The
-        ///color spaces are selected as follows:
-        ///
-        /// * `Mix`: RGB for no particular reason, except that it's intuitive.
-        /// * `Shade`: CIE L*a*b* for its luminance component.
-        /// * `Hue` and `GetHue`: CIE L*C*h° for its hue component and how it preserves the apparent lightness.
-        /// * `Saturate`: CIE L*C*h° for its chromaticity component and how it preserves the apparent lightness.
-        ///
-        ///It's not recommended to use `Color` when full control is necessary,
-        ///but it can easily be converted to a fixed color space in those
-        ///cases.
-        #[derive(Clone, Copy, Debug)]
-        pub enum Color<T:Float = f32> {
-            $(#[$variant_comment] $variant($variant<T>)),+
-        }
-
-        impl<T:Float> Color<T> {
-            $(
-                $(
-                    #[$ctor_comment]
-                    pub fn $ctor_name$(<$($ty_params : $ty_param_traits$( <$( $ty_inner_traits ),*> )*),*>)*($($ctor_field: $ctor_ty),*) -> Color<T> {
-                        Color::$variant($variant::$ctor_original($($ctor_field),*))
-                    }
-                )+
-            )+
-        }
-
-        ///<span id="Colora"></span>[`Colora`](type.Colora.html) implementations.
-        impl<T:Float> Alpha<Color<T>, T> {
-            $(
-                $(
-                    #[$ctor_comment]
-                    pub fn $ctor_name$(<$($ty_params : $ty_param_traits$( <$( $ty_inner_traits ),*> )*),*>)*($($ctor_field: $ctor_ty,)* alpha: $alpha_ty) -> Colora<T> {
-                        Alpha::<$variant<T>, T>::$ctor_original($($ctor_field,)* alpha).into()
-                    }
-                )+
-            )+
-        }
-
-        impl<T:Float> Mix for Color<T> {
-            type Scalar = T;
-
-            fn mix(&self, other: &Color<T>, factor: T) -> Color<T> {
-                Rgb::from(*self).mix(&Rgb::from(*other), factor).into()
-            }
-        }
-
-        impl<T:Float> Shade for Color<T> {
-            type Scalar = T;
-
-            fn lighten(&self, amount: T) -> Color<T> {
-                Lab::from(*self).lighten(amount).into()
-            }
-        }
-
-        impl<T:Float> GetHue for Color<T> {
-            type Hue = LabHue<T>;
-
-            fn get_hue(&self) -> Option<LabHue<T>> {
-                Lch::from(*self).get_hue()
-            }
-        }
-
-        impl<T:Float> Hue for Color<T> {
-            fn with_hue(&self, hue: LabHue<T>) -> Color<T> {
-                Lch::from(*self).with_hue(hue).into()
-            }
-
-            fn shift_hue(&self, amount: LabHue<T>) -> Color<T> {
-                Lch::from(*self).shift_hue(amount).into()
-            }
-        }
-
-        impl<T:Float> Saturate for Color<T> {
-            type Scalar = T;
-
-            fn saturate(&self, factor: T) -> Color<T> {
-                Lch::from(*self).saturate(factor).into()
-            }
-        }
-
-        $(
-            impl<T:Float> From<$variant<T>> for Color<T> {
-                fn from(color: $variant<T>) -> Color<T> {
-                    Color::$variant(color)
-                }
-            }
-
-            $($(
-                impl<T:Float> From<$representations<T>> for Color<T> {
-                    fn from(color: $representations<T>) -> Color<T> {
-                        Color::$variant(color.into())
-                    }
-                }
-            )+)*
-        )+
-
-        alpha_from!(Color {$($variant),+});
-
-    )
-}
+// macro_rules! make_color {
+//     ($(
+//         #[$variant_comment:meta]
+//         $variant:ident $(and $($representations:ident),+ )* {$(
+//             #[$ctor_comment:meta]
+//             $ctor_name:ident $( <$( $ty_params:ident: $ty_param_traits:ident $( <$( $ty_inner_traits:ident ),*> )*),*> )* ($($ctor_field:ident : $ctor_ty:ty),*) [alpha: $alpha_ty:ty] => $ctor_original:ident;
+//         )+}
+//     )+) => (
+//
+//         ///Generic color with an alpha component. See the [`Colora` implementation in `Alpha`](struct.Alpha.html#Colora).
+//         pub type Colora<T = f32> = Alpha<Color<T>, T>;
+//
+//         ///A generic color type.
+//         ///
+//         ///The `Color` may belong to any color space and it may change
+//         ///depending on which operation is performed. That makes it immune to
+//         ///the "without conversion" rule of the operations it supports. The
+//         ///color spaces are selected as follows:
+//         ///
+//         /// * `Mix`: RGB for no particular reason, except that it's intuitive.
+//         /// * `Shade`: CIE L*a*b* for its luminance component.
+//         /// * `Hue` and `GetHue`: CIE L*C*h° for its hue component and how it preserves the apparent lightness.
+//         /// * `Saturate`: CIE L*C*h° for its chromaticity component and how it preserves the apparent lightness.
+//         ///
+//         ///It's not recommended to use `Color` when full control is necessary,
+//         ///but it can easily be converted to a fixed color space in those
+//         ///cases.
+//         // #[derive(Clone, Copy, Debug)]
+//         pub enum Color<T:Float = f32> {
+//             $(#[$variant_comment] $variant($variant<T>)),+
+//         }
+//
+//         impl<T:Float> Color<T> {
+//             $(
+//                 $(
+//                     #[$ctor_comment]
+//                     pub fn $ctor_name$(<$($ty_params : $ty_param_traits$( <$( $ty_inner_traits ),*> )*),*>)*($($ctor_field: $ctor_ty),*) -> Color<T> {
+//                         Color::$variant($variant::$ctor_original($($ctor_field),*))
+//                     }
+//                 )+
+//             )+
+//         }
+//
+//         ///<span id="Colora"></span>[`Colora`](type.Colora.html) implementations.
+//         impl<T:Float> Alpha<Color<T>, T> {
+//             $(
+//                 $(
+//                     #[$ctor_comment]
+//                     pub fn $ctor_name$(<$($ty_params : $ty_param_traits$( <$( $ty_inner_traits ),*> )*),*>)*($($ctor_field: $ctor_ty,)* alpha: $alpha_ty) -> Colora<T> {
+//                         Alpha::<$variant<T>, T>::$ctor_original($($ctor_field,)* alpha).into()
+//                     }
+//                 )+
+//             )+
+//         }
+//
+//         impl<T:Float> Mix for Color<T> {
+//             type Scalar = T;
+//
+//             fn mix(&self, other: &Color<T>, factor: T) -> Color<T> {
+//                 Rgb::from(*self).mix(&Rgb::from(*other), factor).into()
+//             }
+//         }
+//
+//         impl<T:Float> Shade for Color<T> {
+//             type Scalar = T;
+//
+//             fn lighten(&self, amount: T) -> Color<T> {
+//                 Lab::from(*self).lighten(amount).into()
+//             }
+//         }
+//
+//         impl<T:Float> GetHue for Color<T> {
+//             type Hue = LabHue<T>;
+//
+//             fn get_hue(&self) -> Option<LabHue<T>> {
+//                 Lch::from(*self).get_hue()
+//             }
+//         }
+//
+//         impl<T:Float> Hue for Color<T> {
+//             fn with_hue(&self, hue: LabHue<T>) -> Color<T> {
+//                 Lch::from(*self).with_hue(hue).into()
+//             }
+//
+//             fn shift_hue(&self, amount: LabHue<T>) -> Color<T> {
+//                 Lch::from(*self).shift_hue(amount).into()
+//             }
+//         }
+//
+//         impl<T:Float> Saturate for Color<T> {
+//             type Scalar = T;
+//
+//             fn saturate(&self, factor: T) -> Color<T> {
+//                 Lch::from(*self).saturate(factor).into()
+//             }
+//         }
+//
+//         $(
+//             impl<T:Float> From<$variant<T>> for Color<T> {
+//                 fn from(color: $variant<T>) -> Color<T> {
+//                     Color::$variant(color)
+//                 }
+//             }
+//
+//             $($(
+//                 impl<T:Float> From<$representations<T>> for Color<T> {
+//                     fn from(color: $representations<T>) -> Color<T> {
+//                         Color::$variant(color.into())
+//                     }
+//                 }
+//             )+)*
+//         )+
+//
+//         // alpha_from!(Color {$($variant),+});
+//
+//     )
+// }
 
 fn clamp<T:Float>(v: T, min: T, max: T) -> T {
     if v < min {
@@ -418,61 +420,61 @@ fn clamp<T:Float>(v: T, min: T, max: T) -> T {
     }
 }
 
-make_color! {
-    ///Linear luminance.
-    Luma {
-        ///Linear luminance.
-        y(luma: T)[alpha: T] => new;
-
-        ///Linear luminance from an 8 bit value.
-        y_u8(luma: u8)[alpha: u8] => new_u8;
-    }
-
-    ///Linear RGB.
-    Rgb and Srgb, GammaRgb {
-        ///Linear RGB.
-        rgb(red: T, green: T, blue: T)[alpha: T] => new;
-
-        ///Linear RGB from 8 bit values.
-        rgb_u8(red: u8, green: u8, blue: u8)[alpha: u8] => new_u8;
-    }
-
-    ///CIE 1931 XYZ.
-    Xyz {
-        ///CIE XYZ.
-        xyz(x: T, y: T, z: T)[alpha: T] => new;
-    }
-
-    ///CIE 1931 Yxy.
-    Yxy {
-        ///CIE Yxy.
-        yxy(x: T, y: T, luma: T)[alpha: T] => new;
-    }
-
-    ///CIE L*a*b* (CIELAB).
-    Lab {
-        ///CIE L*a*b*.
-        lab(l: T, a: T, b: T)[alpha: T] => new;
-    }
-
-    ///CIE L*C*h°, a polar version of CIE L*a*b*.
-    Lch {
-        ///CIE L*C*h°.
-        lch(l: T, chroma: T, hue: LabHue<T>)[alpha: T] => new;
-    }
-
-    ///Linear HSV, a cylindrical version of RGB.
-    Hsv {
-        ///Linear HSV.
-        hsv(hue: RgbHue<T>, saturation: T, value: T)[alpha: T] => new;
-    }
-
-    ///Linear HSL, a cylindrical version of RGB.
-    Hsl {
-        ///Linear HSL.
-        hsl(hue: RgbHue<T>, saturation: T, lightness: T)[alpha: T] => new;
-    }
-}
+// make_color! {
+//     ///Linear luminance.
+//     Luma {
+//         ///Linear luminance.
+//         y(luma: T)[alpha: T] => new;
+//
+//         ///Linear luminance from an 8 bit value.
+//         y_u8(luma: u8)[alpha: u8] => new_u8;
+//     }
+//
+//     ///Linear RGB.
+//     Rgb and Srgb, GammaRgb {
+//         ///Linear RGB.
+//         rgb(red: T, green: T, blue: T)[alpha: T] => new;
+//
+//         ///Linear RGB from 8 bit values.
+//         rgb_u8(red: u8, green: u8, blue: u8)[alpha: u8] => new_u8;
+//     }
+//
+//     ///CIE 1931 XYZ.
+//     Xyz {
+//         ///CIE XYZ.
+//         xyz(x: T, y: T, z: T)[alpha: T] => new;
+//     }
+//
+//     ///CIE 1931 Yxy.
+//     Yxy {
+//         ///CIE Yxy.
+//         yxy(x: T, y: T, luma: T)[alpha: T] => new;
+//     }
+//
+//     ///CIE L*a*b* (CIELAB).
+//     Lab {
+//         ///CIE L*a*b*.
+//         lab(l: T, a: T, b: T)[alpha: T] => new;
+//     }
+//
+//     ///CIE L*C*h°, a polar version of CIE L*a*b*.
+//     Lch {
+//         ///CIE L*C*h°.
+//         lch(l: T, chroma: T, hue: LabHue<T>)[alpha: T] => new;
+//     }
+//
+//     ///Linear HSV, a cylindrical version of RGB.
+//     Hsv {
+//         ///Linear HSV.
+//         hsv(hue: RgbHue<T>, saturation: T, value: T)[alpha: T] => new;
+//     }
+//
+//     ///Linear HSL, a cylindrical version of RGB.
+//     Hsl {
+//         ///Linear HSL.
+//         hsl(hue: RgbHue<T>, saturation: T, lightness: T)[alpha: T] => new;
+//     }
+// }
 
 ///A trait for clamping and checking if colors are within their ranges.
 pub trait Limited {

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -2,7 +2,7 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, flt};
+use { Alpha, Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, flt};
 
 ///Linear luminance with an alpha component. See the [`Lumaa` implementation in `Alpha`](struct.Alpha.html#Lumaa).
 pub type Lumaa<T = f32> = Alpha<Luma<T>, T>;
@@ -179,9 +179,9 @@ impl<T: Float> Div<T> for Luma<T> {
     }
 }
 
-from_color!(to Luma from Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl);
+// from_color!(to Luma from Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl);
 
-alpha_from!(Luma {Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Color});
+// alpha_from!(Luma {Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Rgb<T>> for Luma<T> {
     fn from(rgb: Rgb<T>) -> Luma<T> {

--- a/src/pixel/mod.rs
+++ b/src/pixel/mod.rs
@@ -4,11 +4,11 @@ use num::Float;
 
 use {clamp, flt};
 
-pub use self::srgb::Srgb;
-pub use self::gamma_rgb::GammaRgb;
+// pub use self::srgb::Srgb;
+// pub use self::gamma_rgb::GammaRgb;
 
-mod srgb;
-mod gamma_rgb;
+// mod srgb;
+// mod gamma_rgb;
 
 ///A conversion trait for RGB pixel formats.
 ///

--- a/src/pixel/srgb.rs
+++ b/src/pixel/srgb.rs
@@ -1,6 +1,6 @@
 use num::Float;
 
-use {Color, Alpha, Rgb, Rgba, clamp, flt};
+use { Alpha, Rgb, Rgba, clamp, flt};
 
 use pixel::RgbPixel;
 
@@ -113,23 +113,23 @@ impl<T: Float> Srgb<T> {
     }
 }
 
-impl<T: Float> From<Rgb<T>> for Srgb<T> {
-    fn from(rgb: Rgb<T>) -> Srgb<T> {
-        Rgba::from(rgb).into()
-    }
-}
-
-impl<T: Float> From<Rgba<T>> for Srgb<T> {
-    fn from(rgba: Rgba<T>) -> Srgb<T> {
-        Srgb::from_linear(rgba)
-    }
-}
-
-impl<T: Float> From<Color<T>> for Srgb<T> {
-    fn from(color: Color<T>) -> Srgb<T> {
-        Rgb::from(color).into()
-    }
-}
+// impl<T: Float> From<Rgb<T>> for Srgb<T> {
+//     fn from(rgb: Rgb<T>) -> Srgb<T> {
+//         Rgba::from(rgb).into()
+//     }
+// }
+//
+// impl<T: Float> From<Rgba<T>> for Srgb<T> {
+//     fn from(rgba: Rgba<T>) -> Srgb<T> {
+//         Srgb::from_linear(rgba)
+//     }
+// }
+//
+// impl<T: Float> From<Color<T>> for Srgb<T> {
+//     fn from(color: Color<T>) -> Srgb<T> {
+//         Rgb::from(color).into()
+//     }
+// }
 
 fn from_srgb<T: Float>(x: T) -> T {
     if x <= flt(0.04045) {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -2,7 +2,7 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, RgbHue, clamp, flt};
+use {Alpha, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, RgbHue, clamp, flt};
 use pixel::{RgbPixel, Srgb, GammaRgb};
 
 ///Linear RGB with an alpha component. See the [`Rgba` implementation in `Alpha`](struct.Alpha.html#Rgba).
@@ -286,9 +286,9 @@ impl<T: Float> Div<T> for Rgb<T> {
     }
 }
 
-from_color!(to Rgb from Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl);
+// from_color!(to Rgb from Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl);
 
-alpha_from!(Rgb {Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl, Color});
+// alpha_from!(Rgb {Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Luma<T>> for Rgb<T> {
     fn from(luma: Luma<T>) -> Rgb<T> {
@@ -388,17 +388,17 @@ impl<T: Float> From<Hsl<T>> for Rgb<T> {
     }
 }
 
-impl<T: Float> From<Srgb<T>> for Rgb<T> {
-    fn from(srgb: Srgb<T>) -> Rgb<T> {
-        srgb.to_linear().into()
-    }
-}
-
-impl<T: Float> From<GammaRgb<T>> for Rgb<T> {
-    fn from(gamma_rgb: GammaRgb<T>) -> Rgb<T> {
-        gamma_rgb.to_linear().into()
-    }
-}
+// impl<T: Float> From<Srgb<T>> for Rgb<T> {
+//     fn from(srgb: Srgb<T>) -> Rgb<T> {
+//         srgb.to_linear().into()
+//     }
+// }
+//
+// impl<T: Float> From<GammaRgb<T>> for Rgb<T> {
+//     fn from(gamma_rgb: GammaRgb<T>) -> Rgb<T> {
+//         gamma_rgb.to_linear().into()
+//     }
+// }
 
 impl<T: Float> From<Srgb<T>> for Alpha<Rgb<T>, T> {
     fn from(srgb: Srgb<T>) -> Alpha<Rgb<T>, T> {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,12 +1,18 @@
 use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
+use std::marker::PhantomData;
 
 use {Alpha, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, RgbHue, clamp, flt};
-use pixel::{RgbPixel, Srgb, GammaRgb};
+use pixel::RgbPixel;
+use white_point::{WhitePoint, D65};
+use rgb_variant::{RgbVariant, SrgbSpace};
+
+pub type Rgb<T> = RgbColor<SrgbSpace, D65, T>;
+pub type Rgba<T> = AlphaRgbColor<SrgbSpace, D65, T>;
 
 ///Linear RGB with an alpha component. See the [`Rgba` implementation in `Alpha`](struct.Alpha.html#Rgba).
-pub type Rgba<T = f32> = Alpha<Rgb<T>, T>;
+pub type AlphaRgbColor<CS, WP, T = f32> = Alpha<RgbColor<CS, WP, T>, T>;
 
 ///Linear RGB.
 ///
@@ -20,8 +26,12 @@ pub type Rgba<T = f32> = Alpha<Rgb<T>, T>;
 ///meaning that gamma correction is required when converting to and from a
 ///displayable RGB, such as sRGB. See the [`pixel`](pixel/index.html) module
 ///for encoding types.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Rgb<T: Float = f32> {
+#[derive(Debug, PartialEq)]
+pub struct RgbColor<CS, WP, T = f32>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     ///The amount of red light, where 0.0 is no red light and 1.0 is the
     ///highest displayable amount.
     pub red: T,
@@ -33,31 +43,57 @@ pub struct Rgb<T: Float = f32> {
     ///The amount of blue light, where 0.0 is no blue light and 1.0 is the
     ///highest displayable amount.
     pub blue: T,
+
+    _wp: PhantomData<WP>,
+
+    _cs: PhantomData<CS>,
 }
 
-impl<T: Float> Rgb<T> {
+impl<CS, WP, T> Copy for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{}
+
+impl<CS, WP, T> Clone for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn clone(&self) -> RgbColor<CS, WP, T> { *self }
+}
+
+impl<CS, WP, T> RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     ///Linear RGB.
-    pub fn new(red: T, green: T, blue: T) -> Rgb<T> {
-        Rgb {
+    pub fn new(red: T, green: T, blue: T) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: red,
             green: green,
             blue: blue,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 
     ///Linear RGB from 8 bit values.
-    pub fn new_u8(red: u8, green: u8, blue: u8) -> Rgb<T> {
-        Rgb {
+    pub fn new_u8(red: u8, green: u8, blue: u8) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: flt::<T,_>(red) / flt(255.0),
             green: flt::<T,_>(green) / flt(255.0),
             blue: flt::<T,_>(blue) / flt(255.0),
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 
     ///Linear RGB from a linear pixel value.
-    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> Rgb<T> {
+    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> RgbColor<CS, WP, T> {
         let (r, g, b, _) = pixel.to_rgba();
-        Rgb::new(r, g, b)
+        RgbColor::new(r, g, b)
     }
 
     ///Convert to a linear RGB pixel. `Rgb` is already assumed to be linear,
@@ -81,27 +117,31 @@ impl<T: Float> Rgb<T> {
 }
 
 ///<span id="Rgba"></span>[`Rgba`](type.Rgba.html) implementations.
-impl<T: Float> Alpha<Rgb<T>, T> {
+impl<CS, WP, T> Alpha<RgbColor<CS, WP, T>, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     ///Linear RGB with transparency.
-    pub fn new(red: T, green: T, blue: T, alpha: T) -> Rgba<T> {
-        Alpha {
-            color: Rgb::new(red, green, blue),
+    pub fn new(red: T, green: T, blue: T, alpha: T) -> AlphaRgbColor<CS, WP, T> {
+        AlphaRgbColor {
+            color: RgbColor::new(red, green, blue),
             alpha: alpha,
         }
     }
 
     ///Linear RGB with transparency from 8 bit values.
-    pub fn new_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Rgba<T> {
+    pub fn new_u8(red: u8, green: u8, blue: u8, alpha: u8) -> AlphaRgbColor<CS, WP, T> {
         Alpha {
-            color: Rgb::new_u8(red, green, blue),
+            color: RgbColor::new_u8(red, green, blue),
             alpha: flt::<T,_>(alpha) / flt(255.0),
         }
     }
 
     ///Linear RGB from a linear pixel value.
-    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> Rgba<T> {
+    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> AlphaRgbColor<CS, WP, T> {
         let (r, g, b, a) = pixel.to_rgba();
-        Rgba::new(r, g, b, a)
+        AlphaRgbColor::new(r, g, b, a)
     }
 
     ///Convert to a linear RGB pixel. `Rgb` is already assumed to be linear,
@@ -124,14 +164,18 @@ impl<T: Float> Alpha<Rgb<T>, T> {
     }
 }
 
-impl<T: Float> Limited for Rgb<T> {
+impl<CS, WP, T> Limited for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     fn is_valid(&self) -> bool {
         self.red >= T::zero() && self.red <= T::one() &&
         self.green >= T::zero() && self.green <= T::one() &&
         self.blue >= T::zero() && self.blue <= T::one()
     }
 
-    fn clamp(&self) -> Rgb<T> {
+    fn clamp(&self) -> RgbColor<CS, WP, T> {
         let mut c = *self;
         c.clamp_self();
         c
@@ -144,33 +188,49 @@ impl<T: Float> Limited for Rgb<T> {
     }
 }
 
-impl<T: Float> Mix for Rgb<T> {
+impl<CS, WP, T> Mix for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     type Scalar = T;
 
-    fn mix(&self, other: &Rgb<T>, factor: T) -> Rgb<T> {
+    fn mix(&self, other: &RgbColor<CS, WP, T>, factor: T) -> RgbColor<CS, WP, T> {
         let factor = clamp(factor, T::zero(), T::one());
 
-        Rgb {
+        RgbColor {
             red: self.red + factor * (other.red - self.red),
             green: self.green + factor * (other.green - self.green),
             blue: self.blue + factor * (other.blue - self.blue),
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Shade for Rgb<T> {
+impl<CS, WP, T> Shade for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Rgb<T> {
-        Rgb {
+    fn lighten(&self, amount: T) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red + amount,
             green: self.green + amount,
             blue: self.blue + amount,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> GetHue for Rgb<T> {
+impl<CS, WP, T> GetHue for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
     type Hue = RgbHue<T>;
 
     fn get_hue(&self) -> Option<RgbHue<T>> {
@@ -184,104 +244,156 @@ impl<T: Float> GetHue for Rgb<T> {
     }
 }
 
-impl<T: Float> Default for Rgb<T> {
-    fn default() -> Rgb<T> {
-        Rgb::new(T::zero(), T::zero(), T::zero())
+impl<CS, WP, T> Default for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn default() -> RgbColor<CS, WP, T> {
+        RgbColor::new(T::zero(), T::zero(), T::zero())
     }
 }
 
-impl<T: Float> Add<Rgb<T>> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Add<RgbColor<CS, WP, T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn add(self, other: Rgb<T>) -> Rgb<T> {
-        Rgb {
+    fn add(self, other: RgbColor<CS, WP, T>) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red + other.red,
             green: self.green + other.green,
             blue: self.blue + other.blue,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Add<T> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Add<T> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn add(self, c: T) -> Rgb<T> {
-        Rgb {
+    fn add(self, c: T) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red + c,
             green: self.green + c,
             blue: self.blue + c,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Sub<Rgb<T>> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Sub<RgbColor<CS, WP, T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn sub(self, other: Rgb<T>) -> Rgb<T> {
-        Rgb {
+    fn sub(self, other: RgbColor<CS, WP, T>) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red - other.red,
             green: self.green - other.green,
             blue: self.blue - other.blue,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Sub<T> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Sub<T> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn sub(self, c: T) -> Rgb<T> {
-        Rgb {
+    fn sub(self, c: T) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red - c,
             green: self.green - c,
             blue: self.blue - c,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Mul<Rgb<T>> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Mul<RgbColor<CS, WP, T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn mul(self, other: Rgb<T>) -> Rgb<T> {
-        Rgb {
+    fn mul(self, other: RgbColor<CS, WP, T>) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red * other.red,
             green: self.green * other.green,
             blue: self.blue * other.blue,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Mul<T> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Mul<T> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn mul(self, c: T) -> Rgb<T> {
-        Rgb {
+    fn mul(self, c: T) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red * c,
             green: self.green * c,
             blue: self.blue * c,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Div<Rgb<T>> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Div<RgbColor<CS, WP, T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn div(self, other: Rgb<T>) -> Rgb<T> {
-        Rgb {
+    fn div(self, other: RgbColor<CS, WP, T>) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red / other.red,
             green: self.green / other.green,
             blue: self.blue / other.blue,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> Div<T> for Rgb<T> {
-    type Output = Rgb<T>;
+impl<CS, WP, T> Div<T> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    type Output = RgbColor<CS, WP, T>;
 
-    fn div(self, c: T) -> Rgb<T> {
-        Rgb {
+    fn div(self, c: T) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: self.red / c,
             green: self.green / c,
             blue: self.blue / c,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
@@ -290,46 +402,75 @@ impl<T: Float> Div<T> for Rgb<T> {
 
 // alpha_from!(Rgb {Xyz, Yxy, Luma, Lab, Lch, Hsv, Hsl, Color});
 
-impl<T: Float> From<Luma<T>> for Rgb<T> {
-    fn from(luma: Luma<T>) -> Rgb<T> {
-        Rgb {
+impl<CS, WP, T> From<Luma<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(luma: Luma<T>) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: luma.luma,
             green: luma.luma,
             blue: luma.luma,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> From<Xyz<T>> for Rgb<T> {
-    fn from(xyz: Xyz<T>) -> Rgb<T> {
-        Rgb {
+
+impl<CS, WP, T> From<Xyz<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(xyz: Xyz<T>) -> RgbColor<CS, WP, T> {
+        RgbColor {
             red: xyz.x * flt(3.2406) + xyz.y * flt(-1.5372) + xyz.z * flt(-0.4986),
             green: xyz.x * flt(-0.9689) + xyz.y * flt(1.8758) + xyz.z * flt(0.0415),
             blue: xyz.x * flt(0.0557) + xyz.y * flt(-0.2040) + xyz.z * flt(1.0570),
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> From<Yxy<T>> for Rgb<T> {
-    fn from(yxy: Yxy<T>) -> Rgb<T> {
+impl<CS, WP, T> From<Yxy<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(yxy: Yxy<T>) -> RgbColor<CS, WP, T> {
         Xyz::from(yxy).into()
     }
 }
 
-impl<T: Float> From<Lab<T>> for Rgb<T> {
-    fn from(lab: Lab<T>) -> Rgb<T> {
+impl<CS, WP, T> From<Lab<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(lab: Lab<T>) -> RgbColor<CS, WP, T> {
         Xyz::from(lab).into()
     }
 }
 
-impl<T: Float> From<Lch<T>> for Rgb<T> {
-    fn from(lch: Lch<T>) -> Rgb<T> {
+impl<CS, WP, T> From<Lch<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(lch: Lch<T>) -> RgbColor<CS, WP, T> {
         Lab::from(lch).into()
     }
 }
 
-impl<T: Float> From<Hsv<T>> for Rgb<T> {
-    fn from(hsv: Hsv<T>) -> Rgb<T> {
+impl<CS, WP, T> From<Hsv<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(hsv: Hsv<T>) -> RgbColor<CS, WP, T> {
         let c = hsv.value * hsv.saturation;
         let h = hsv.hue.to_positive_degrees() / flt(60.0);
         let x = c * (T::one() - (h % flt(2.0) - T::one()).abs());
@@ -350,16 +491,22 @@ impl<T: Float> From<Hsv<T>> for Rgb<T> {
         };
 
 
-        Rgb {
+        RgbColor {
             red: red + m,
             green: green + m,
             blue: blue + m,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-impl<T: Float> From<Hsl<T>> for Rgb<T> {
-    fn from(hsl: Hsl<T>) -> Rgb<T> {
+impl<CS, WP, T> From<Hsl<T>> for RgbColor<CS, WP, T>
+    where T: Float,
+        WP: WhitePoint<T>,
+        CS: RgbVariant<T>
+{
+    fn from(hsl: Hsl<T>) -> RgbColor<CS, WP, T> {
         let c = (T::one() - ( hsl.lightness * flt(2.0) - T::one()).abs()) * hsl.saturation;
         let h = hsl.hue.to_positive_degrees() / flt(60.0);
         let x = c * (T::one() - (h % flt(2.0) - T::one()).abs());
@@ -380,37 +527,39 @@ impl<T: Float> From<Hsl<T>> for Rgb<T> {
         };
 
 
-        Rgb {
+        RgbColor {
             red: red + m,
             green: green + m,
             blue: blue + m,
+            _wp: PhantomData,
+            _cs: PhantomData,
         }
     }
 }
 
-// impl<T: Float> From<Srgb<T>> for Rgb<T> {
-//     fn from(srgb: Srgb<T>) -> Rgb<T> {
+// impl<CS, WP, T> From<Srgb<T>> for RgbColor<CS, WP, T>
+//     fn from(srgb: Srgb<T>) -> RgbColor<CS, WP, T> {
 //         srgb.to_linear().into()
 //     }
 // }
 //
-// impl<T: Float> From<GammaRgb<T>> for Rgb<T> {
-//     fn from(gamma_rgb: GammaRgb<T>) -> Rgb<T> {
+// impl<CS, WP, T> From<GammaRgbColor<CS, WP, T>> for RgbColor<CS, WP, T>
+//     fn from(gamma_rgb: GammaRgbColor<CS, WP, T>) -> RgbColor<CS, WP, T> {
 //         gamma_rgb.to_linear().into()
 //     }
 // }
 
-impl<T: Float> From<Srgb<T>> for Alpha<Rgb<T>, T> {
-    fn from(srgb: Srgb<T>) -> Alpha<Rgb<T>, T> {
-        srgb.to_linear()
-    }
-}
-
-impl<T: Float> From<GammaRgb<T>> for Alpha<Rgb<T>, T> {
-    fn from(gamma_rgb: GammaRgb<T>) -> Alpha<Rgb<T>, T> {
-        gamma_rgb.to_linear()
-    }
-}
+// impl<CS, WP, T> From<Srgb<T>> for Alpha<RgbColor<CS, WP, T>, T> {
+//     fn from(srgb: Srgb<T>) -> Alpha<RgbColor<CS, WP, T>, T> {
+//         srgb.to_linear()
+//     }
+// }
+//
+// impl<CS, WP, T> From<GammaRgbColor<CS, WP, T>> for Alpha<RgbColor<CS, WP, T>, T> {
+//     fn from(gamma_rgb: GammaRgbColor<CS, WP, T>) -> Alpha<RgbColor<CS, WP, T>, T> {
+//         gamma_rgb.to_linear()
+//     }
+// }
 
 #[cfg(test)]
 mod test {

--- a/src/rgb_variant.rs
+++ b/src/rgb_variant.rs
@@ -1,0 +1,38 @@
+use num::Float;
+
+use flt;
+use Yxy;
+
+pub struct Primaries<T: Float> {
+    red: Yxy<T>,
+    green: Yxy<T>,
+    blue: Yxy<T>,
+}
+
+pub trait RgbVariant<T: Float> {
+    fn get_primaries() -> Primaries<T>;
+}
+
+pub struct AdobeRgbSpace;
+
+impl<T:Float> RgbVariant<T> for AdobeRgbSpace {
+    fn get_primaries() -> Primaries<T> {
+        Primaries {
+            red: Yxy::new(flt(0.6400), flt(0.3300), flt(0.297361)),
+            green: Yxy::new(flt(0.2100),	flt(0.7100), flt(0.627355)),
+            blue: Yxy::new(flt(0.1500), flt(0.0600),	flt(0.075285)),
+        }
+    }
+}
+
+pub struct SrgbSpace;
+
+impl<T:Float> RgbVariant<T> for SrgbSpace {
+    fn get_primaries() -> Primaries<T> {
+        Primaries {
+            red: Yxy::new(flt(0.6400), flt(0.3300), flt(0.212656)),
+            green: Yxy::new(flt(0.3000),	flt(0.6000), flt(0.715158)),
+            blue: Yxy::new(flt(0.1500), flt(0.0600),	flt(0.072186)),
+        }
+    }
+}

--- a/src/white_point.rs
+++ b/src/white_point.rs
@@ -1,0 +1,63 @@
+use num::Float;
+
+use {Yxy, flt};
+
+// IS AN ENUM OF WHITE POINTS REQUIRED??
+// pub enum WhitePointKind {
+//     D65,
+//     D65Fov10,
+//     D50,
+//     D50Fov10,
+// }
+//
+// pub trait GetWhitePoint<T:Float>: Sized {
+//     fn yxy(&self) -> Yxy<T>;
+// }
+//
+// impl<T:Float> GetWhitePoint<T> for WhitePointKind {
+//     fn get_yxy_vals(&self) -> Yxy<T> {
+//         match *self {
+//             WhitePointKind::D65 => D65::get_yxy(),
+//             WhitePointKind::D65Fov10 => D65Fov10::get_yxy(),
+//             WhitePointKind::D50 => D50::get_yxy(),
+//             WhitePointKind::D50Fov10 => D50Fov10::get_yxy(),
+//             WhitePointKind::NoWhitePoint => NoWhitePoint::get_yxy(),
+//         }
+//     }
+// }
+
+pub trait WhitePoint<T: Float> {
+    fn get_yxy() -> Yxy<T>;
+}
+
+macro_rules! generate_white_point {
+    ($x: ident => ($p1: expr, $p2:expr, $p3:expr)) => (
+        impl<T: Float> WhitePoint<T> for $x {
+
+            fn get_yxy() -> Yxy<T> {
+                Yxy::new(flt($p1), flt($p2), flt($p3))
+            }
+        }
+    );
+}
+
+// pub struct NoWhitePoint;
+// generate_white_point!(NoWhitePoint => (1.0, 1.0, 1.0));
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct D65;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct D65Fov10;
+
+generate_white_point!(D65 => (0.31271,0.32902, 1.0));
+generate_white_point!(D65Fov10 => (0.34773, 0.35952, 1.0));
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct D50;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct D50Fov10;
+
+generate_white_point!(D50 => ( 0.31271,0.32902, 1.0));
+generate_white_point!(D50Fov10 => (0.31382,0.33100, 1.0));

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -2,7 +2,10 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, flt, Xyz};
+use { Alpha, Rgb, Luma, Hsv, Hsl, Limited, Mix, Shade, clamp, flt, Xyz};
+use lab::LabSpace;
+use lch::LchSpace;
+use white_point::WhitePoint;
 
 const D65_X: f64 = 0.312727;
 const D65_Y: f64 = 0.329023;
@@ -210,9 +213,9 @@ impl<T: Float> Div<T> for Yxy<T> {
     }
 }
 
-from_color!(to Yxy from Xyz, Rgb, Luma, Lab, Lch, Hsv, Hsl);
+// from_color!(to Yxy from Xyz, Rgb, Luma, Lab, Lch, Hsv, Hsl);
 
-alpha_from!(Yxy {Xyz, Rgb, Luma, Lab, Lch, Hsv, Hsl, Color});
+// alpha_from!(Yxy {Xyz, Rgb, Luma, Lab, Lch, Hsv, Hsl, Color});
 
 impl<T: Float> From<Xyz<T>> for Yxy<T> {
     fn from(xyz: Xyz<T>) -> Yxy<T> {
@@ -238,15 +241,21 @@ impl<T: Float> From<Luma<T>> for Yxy<T> {
     }
 }
 
-impl<T: Float> From<Lab<T>> for Yxy<T> {
-    fn from(lab: Lab<T>) -> Yxy<T> {
+impl<WP, T> From<LabSpace<WP, T>> for Yxy<T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(lab: LabSpace<WP, T>) -> Yxy<T> {
         Xyz::from(lab).into()
     }
 }
 
-impl<T: Float> From<Lch<T>> for Yxy<T> {
-    fn from(lch: Lch<T>) -> Yxy<T> {
-        Lab::from(lch).into()
+impl<WP, T> From<LchSpace<WP, T>> for Yxy<T>
+    where T: Float,
+        WP: WhitePoint<T>
+{
+    fn from(lch: LchSpace<WP, T>) -> Yxy<T> {
+        LabSpace::from(lch).into()
     }
 }
 


### PR DESCRIPTION
This is a work in progress.

#### Implemented so far: 
White points for lab and lch. I won't add the white points for Xyz and Yxy for now. Lets see how things shape up and take a call on that.

#### Issues:
Unable to derive copy for the struct with phantom data. Hence impleminting the Limited trait errors.  Here is a link to the playground showing the issue. http://is.gd/tHCm5C

#### Notes
Had to comment the color enum and the from_color and alpha_color macros. These assume a single trait  for all colors. This will show a lot of noise in the git diff.

#### Next
Make rgb, color space and white point aware.
