### PR TITLE
Implement color blending

### DIFF
--- a/src/blend/blend.rs
+++ b/src/blend/blend.rs
@@ -1,0 +1,377 @@
+use num::{Float, One, Zero};
+
+use {ComponentWise, clamp, flt};
+use blend::{PreAlpha, BlendFunction};
+
+///A trait for colors that can be blended together.
+///
+///Blending can either be performed through the predefined blend modes, or a
+///custom blend functions.
+///
+///_Note: The default implementations of the blend modes are meant for color
+///components in the range [0.0, 1.0] and may otherwise produce strange
+///results._
+pub trait Blend: Sized {
+    ///The core color type. Typically `Self` for color types without alpha.
+    type Color: Blend<Color=Self::Color> + ComponentWise;
+
+    ///Convert the color to premultiplied alpha.
+    fn into_premultiplied(self) -> PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>;
+
+    ///Convert the color from premultiplied alpha.
+    fn from_premultiplied(color: PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>) -> Self;
+
+    ///Blend self, as the source color, with `destination`, using
+    ///`blend_function`. Anything that implements `BlendFunction` is
+    ///acceptable, including functions and closures.
+    ///
+    ///```
+    ///use palette::{Rgb, Rgba, Blend};
+    ///use palette::blend::PreAlpha;
+    ///
+    ///type PreRgba = PreAlpha<Rgb<f32>, f32>;
+    ///
+    ///fn blend_mode(a: PreRgba, b: PreRgba) -> PreRgba {
+    ///    PreAlpha {
+    ///        color: Rgb::new(a.red * b.green, a.green * b.blue, a.blue * b.red),
+    ///        alpha: a.alpha * b.alpha,
+    ///    }
+    ///}
+    ///
+    ///let a = Rgba::new(0.2, 0.5, 0.1, 0.8);
+    ///let b = Rgba::new(0.6, 0.3, 0.5, 0.1);
+    ///let c = a.blend(b, blend_mode);
+    ///```
+    fn blend<F>(self, destination: Self, blend_function: F) -> Self where F: BlendFunction<Self::Color> {
+        Self::from_premultiplied(blend_function.apply_to(self.into_premultiplied(), destination.into_premultiplied()))
+    }
+
+    ///Place `self` over `other`. This is the good old common alpha
+    ///composition equation.
+    fn over(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a + b * (one - src.alpha)),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Results in the parts of `self` that overlaps the visible parts of
+    ///`other`.
+    fn inside(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise_self(|a| a * dst.alpha),
+            alpha: clamp(src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Results in the parts of `self` that lies outside the visible parts of
+    ///`other`.
+    fn outside(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise_self(|a| a * (one - dst.alpha)),
+            alpha: clamp(src.alpha * (one - dst.alpha), zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Place `self` over only the visible parts of `other`.
+    fn atop(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a * dst.alpha + b * (one - src.alpha)),
+            alpha: clamp(dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Results in either `self` or `other`, where they do not overlap.
+    fn xor(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let two = one + one;
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a * (one - dst.alpha) + b * (one - src.alpha)),
+            alpha: clamp(src.alpha + dst.alpha - two * src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+
+    ///Add `self` and `other`. This uses the alpha component to regulate the
+    ///effect, so it's not just plain component wise addition.
+    fn plus(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a + b),
+            alpha: clamp(src.alpha + dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Multiply `self` with `other`. This uses the alpha component to regulate
+    ///the effect, so it's not just plain component wise multiplication.
+    fn multiply(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| {
+                a * b + a * (one - dst.alpha) + b * (one - src.alpha)
+            }),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Make a color which is at least as light as `self` or `other`.
+    fn screen(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a + b - a * b),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Multiply `self` or `other` if other is dark, or screen them if `other`
+    ///is light. This results in an S curve.
+    fn overlay(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let two = one + one;
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| if b * two <= dst.alpha {
+                two * a * b + a * (one - dst.alpha) + b * (one - src.alpha)
+            } else {
+                a * (one + dst.alpha) + b * (one + src.alpha) - two * a * b - src.alpha * dst.alpha
+            }),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Return the darkest parts of `self` and `other`.
+    fn darken(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| (a * dst.alpha).min(b * src.alpha) + a * (one - dst.alpha) + b * (one - src.alpha)),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Return the lightest parts of `self` and `other`.
+    fn lighten(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| (a * dst.alpha).max(b * src.alpha) + a * (one - dst.alpha) + b * (one - src.alpha)),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Lighten `other` to reflect `self`. Results in `other` if `self` is
+    ///black.
+    fn dodge(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| if a == src.alpha && !b.is_normal() {
+                a * (one - dst.alpha)
+            } else if a == src.alpha {
+                src.alpha * dst.alpha + a * (one - dst.alpha) + b * (one - src.alpha)
+            } else {
+                src.alpha * dst.alpha * one.min((b/dst.alpha) * src.alpha / (src.alpha - a)) + a * (one - dst.alpha) + b * (one - src.alpha)
+            }),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Darken `other` to reflect `self`. Results in `other` if `self` is
+    ///white.
+    fn burn(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| if !a.is_normal() && b == dst.alpha {
+                src.alpha * dst.alpha + b * (one - src.alpha)
+            } else if !a.is_normal() {
+                b * (one - src.alpha)
+            } else {
+                src.alpha * dst.alpha * (one - one.min((one - b/dst.alpha) * src.alpha/a)) + a * (one - dst.alpha) + b * (one - src.alpha)
+            }),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Multiply `self` or `other` if other is dark, or screen them if `self`
+    ///is light. This is similar to `overlay`, but depends on `self` instead
+    ///of `other`.
+    fn hard_light(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let two = one + one;
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| if a * two <= src.alpha {
+                two * a * b + a * (one - dst.alpha) + b * (one - src.alpha)
+            } else {
+                a * (one + dst.alpha) + b * (one + src.alpha) - two * a * b - src.alpha * dst.alpha
+            }),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Lighten `other` if `self` is light, or darken `other` as if it's burned
+    ///if `self` is dark. The effect is increased if the components of `self`
+    ///is further from 0.5.
+    fn soft_light(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let two = one + one;
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| {
+                let m = if dst.alpha.is_normal() { b / dst.alpha } else { zero };
+
+                if a * two <= src.alpha {
+                    b * (src.alpha + (two * a - src.alpha) * (one - m)) + a * (one - dst.alpha) + b * (one - src.alpha)
+                } else if b * flt(4.0) <= dst.alpha {
+                    let m2 = m * m;
+                    let m3 = m2 * m;
+                    
+                    dst.alpha * (two * a - src.alpha) * (m3 * flt(16.0) - m2 * flt(12.0) - m * flt(3.0)) + a - a * dst.alpha + b
+                } else {
+                    dst.alpha * (two * a - src.alpha) * (m.sqrt() - m) + a - a * dst.alpha + b
+                }
+            }),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Return the absolute difference between `self` and `other`. It's
+    ///basically `abs(self - other)`, but regulated by the alpha component.
+    fn difference(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let two = one + one;
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a + b - two * (a * dst.alpha).min(b * src.alpha)),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+
+    ///Similar to `difference`, but appears to result in a lower contrast.
+    ///`other` is inverted if `self` is white, and preserved if `self` is
+    ///black.
+    fn exclusion(self, other: Self) -> Self {
+        let one = <Self::Color as ComponentWise>::Scalar::one();
+        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let two = one + one;
+
+        let src = self.into_premultiplied();
+        let dst = other.into_premultiplied();
+
+        let result = PreAlpha {
+            color: src.color.component_wise(&dst.color, |a, b| a + b - two * a * b),
+            alpha: clamp(src.alpha + dst.alpha - src.alpha * dst.alpha, zero, one),
+        };
+
+        Self::from_premultiplied(result)
+    }
+}

--- a/src/blend/equations.rs
+++ b/src/blend/equations.rs
@@ -1,0 +1,203 @@
+use num::Float;
+
+use {ComponentWise, Blend};
+use blend::{PreAlpha, BlendFunction};
+
+///A pair of blending equations and corresponding parameters.
+///
+///The `Equations` type is similar to how blending works in OpenGL, where a
+///blend function has can be written as `e(sp * S, dp * D)`. `e` is the
+///equation (like `s + d`), `sp` and `dp` are the source and destination
+///parameters, and `S` and `D` are the source and destination colors.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Equations {
+    ///The equation for the color components.
+    pub color_equation: Equation,
+
+    ///The equation for the alpha component.
+    pub alpha_equation: Equation,
+
+    ///The parameters for the color components.
+    pub color_parameters: Parameters,
+
+    ///The parameters for the alpha component.
+    pub alpha_parameters: Parameters,
+}
+
+impl Equations {
+    ///Create a pair of blending equations, where all the parameters are
+    ///`One`.
+    pub fn from_equations(color: Equation, alpha: Equation) -> Equations {
+        Equations {
+            color_equation: color,
+            alpha_equation: alpha,
+            color_parameters: Parameters {
+                source: Parameter::One,
+                destination: Parameter::One,
+            },
+            alpha_parameters: Parameters {
+                source: Parameter::One,
+                destination: Parameter::One,
+            },
+        }
+    }
+
+    ///Create a pair of additive blending equations with the provided
+    ///parameters.
+    pub fn from_parameters(source: Parameter, destination: Parameter) -> Equations {
+        Equations {
+            color_equation: Equation::Add,
+            alpha_equation: Equation::Add,
+            color_parameters: Parameters {
+                source: source,
+                destination: destination,
+            },
+            alpha_parameters: Parameters {
+                source: source,
+                destination: destination,
+            },
+        }
+    }
+}
+
+impl<C: Blend<Color=C> + ComponentWise + Clone> BlendFunction<C> for Equations {
+    fn apply_to(self, source: PreAlpha<C, C::Scalar>, destination: PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar> {
+        let col_src_param = self.color_parameters.source.apply_to(source.clone(), destination.clone());
+        let col_dst_param = self.color_parameters.destination.apply_to(source.clone(), destination.clone());
+        let alpha_src_param = self.alpha_parameters.source.apply_to(source.clone(), destination.clone());
+        let alpha_dst_param = self.alpha_parameters.destination.apply_to(source.clone(), destination.clone());
+
+        let src_color = col_src_param.mul_color(source.color.clone());
+        let dst_color = col_dst_param.mul_color(destination.color.clone());
+        let src_alpha = alpha_src_param.mul_constant(source.alpha);
+        let dst_alpha = alpha_dst_param.mul_constant(destination.alpha);
+
+        let color = match self.color_equation {
+            Equation::Add => src_color.component_wise(&dst_color, |a, b| a + b),
+            Equation::Subtract => src_color.component_wise(&dst_color, |a, b| a - b),
+            Equation::ReverseSubtract => dst_color.component_wise(&src_color, |a, b| a - b),
+            Equation::Min => source.color.component_wise(&destination.color, |a, b| a.min(b)),
+            Equation::Max => source.color.component_wise(&destination.color, |a, b| a.max(b)),
+        };
+
+        let alpha = match self.alpha_equation {
+            Equation::Add => src_alpha + dst_alpha,
+            Equation::Subtract => src_alpha - dst_alpha,
+            Equation::ReverseSubtract => dst_alpha - src_alpha,
+            Equation::Min => source.alpha.min(destination.alpha),
+            Equation::Max => source.alpha.max(destination.alpha),
+        };
+
+        PreAlpha {
+            color: color,
+            alpha: alpha,
+        }
+    }
+}
+
+///A blending equation.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Equation {
+    ///Add the source and destination, according to `sp * S + dp * D`.
+    Add,
+
+    ///Subtract the destination from the source, according to `sp * S - dp * D`.
+    Subtract,
+
+    ///Subtract the source from the destination, according to `dp * D - sp * S`.
+    ReverseSubtract,
+
+    ///Create a color where each component is the smallest of each of the
+    ///source and destination components. A.k.a. component wise min. The
+    ///parameters are ignored.
+    Min,
+
+    ///Create a color where each component is the largest of each of the
+    ///source and destination components. A.k.a. component wise max. The
+    ///parameters are ignored.
+    Max,
+}
+
+///A pair of source and destination parameters.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Parameters {
+    ///The source parameter.
+    pub source: Parameter,
+
+    ///The destination parameter.
+    pub destination: Parameter,
+}
+
+///A blending parameter.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Parameter {
+    ///A simple 1.
+    One,
+
+    ///A simple 0.
+    Zero,
+
+    ///The source color, or alpha.
+    SourceColor,
+
+    ///One minus the source color, or alpha.
+    OneMinusSourceColor,
+
+    ///The destination color, or alpha.
+    DestinationColor,
+
+    ///One minus the destination color, or alpha.
+    OneMinusDestinationColor,
+
+    ///The source alpha.
+    SourceAlpha,
+
+    ///One minus the source alpha.
+    OneMinusSourceAlpha,
+
+    ///The destination alpha.
+    DestinationAlpha,
+
+    ///One minus the destination alpha.
+    OneMinusDestinationAlpha,
+}
+
+impl Parameter {
+    fn apply_to<C, T: Float>(&self, source: PreAlpha<C, T>, destination: PreAlpha<C, T>) -> ParamOut<C, T> where
+        PreAlpha<C, T>: ComponentWise<Scalar=T>,
+    {
+        match *self {
+            Parameter::One => ParamOut::Constant(T::one()),
+            Parameter::Zero => ParamOut::Constant(T::zero()),
+            Parameter::SourceColor => ParamOut::Color(source),
+            Parameter::OneMinusSourceColor => ParamOut::Color(source.component_wise_self(|a| T::one() - a)),
+            Parameter::DestinationColor => ParamOut::Color(destination),
+            Parameter::OneMinusDestinationColor => ParamOut::Color(destination.component_wise_self(|a| T::one() - a)),
+            Parameter::SourceAlpha => ParamOut::Constant(source.alpha),
+            Parameter::OneMinusSourceAlpha => ParamOut::Constant(T::one() - source.alpha),
+            Parameter::DestinationAlpha => ParamOut::Constant(destination.alpha),
+            Parameter::OneMinusDestinationAlpha => ParamOut::Constant(T::one() - destination.alpha),
+        }
+    }
+}
+
+enum ParamOut<C, T: Float> {
+    Color(PreAlpha<C, T>),
+    Constant(T),
+}
+
+impl<C: ComponentWise<Scalar=T>, T: Float> ParamOut<C, T> {
+    fn mul_constant(self, other: T) -> T {
+        match self {
+            ParamOut::Color(c) => c.alpha * other,
+            ParamOut::Constant(c) => c * other,
+        }
+    }
+
+    fn mul_color(self, other: C) -> C {
+        match self {
+            ParamOut::Color(c) => other.component_wise(&c.color, |a, b| a * b),
+            ParamOut::Constant(c) => other.component_wise_self(|a| a * c),
+        }
+    }
+}

--- a/src/blend/mod.rs
+++ b/src/blend/mod.rs
@@ -1,0 +1,65 @@
+//!Color blending and blending equations.
+//!
+//!Palette offers both OpenGL style blending equations, as well as most of the
+//!SVG composition operators (also common in photo manipulation software). The
+//!composition operators are all implemented in the
+//![`Blend`](trait.Blend.html) trait, and ready to use with any appropriate
+//!color type:
+//!
+//!```
+//!use palette::{Rgba, Blend};
+//!
+//!let a = Rgba::new(0.2, 0.5, 0.1, 0.8);
+//!let b = Rgba::new(0.6, 0.3, 0.5, 0.1);
+//!let c = a.overlay(b);
+//!```
+//!
+//!Blending equations can be defined using the
+//![`Equations`](struct.Equations.html) type, which is then passed to the
+//!`blend` function, from the `Blend` trait:
+//!
+//!```
+//!use palette::{Rgba, Blend};
+//!use palette::blend::{Equations, Parameter};
+//!
+//!let blend_mode = Equations::from_parameters(
+//!    Parameter::SourceAlpha,
+//!    Parameter::OneMinusSourceAlpha
+//!);
+//!
+//!let a = Rgba::new(0.2, 0.5, 0.1, 0.8);
+//!let b = Rgba::new(0.6, 0.3, 0.5, 0.1);
+//!let c = a.blend(b, blend_mode);
+//!```
+//!
+//!Note that blending will use [premultiplied alpha](struct.PreAlpha.html),
+//!which may result in loss of some color information in some cases. One such
+//!case is that a completely transparent resultant color will become black.
+
+use ComponentWise;
+
+pub use self::equations::{Equations, Equation, Parameters, Parameter};
+pub use self::pre_alpha::PreAlpha;
+pub use self::blend::Blend;
+
+mod equations;
+mod pre_alpha;
+mod blend;
+
+#[cfg(test)]
+mod test;
+
+///A trait for custom blend functions.
+pub trait BlendFunction<C: Blend<Color=C> + ComponentWise> {
+    ///Apply this blend function to a pair of colors.
+    fn apply_to(self, source: PreAlpha<C, C::Scalar>, destination: PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar>;
+}
+
+impl<C, F> BlendFunction<C> for F where
+    C: Blend<Color=C> + ComponentWise,
+    F: FnOnce(PreAlpha<C, C::Scalar>, PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar>,
+{
+    fn apply_to(self, source: PreAlpha<C, C::Scalar>, destination: PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar> {
+        (self)(source, destination)
+    }
+}

--- a/src/blend/pre_alpha.rs
+++ b/src/blend/pre_alpha.rs
@@ -1,0 +1,244 @@
+use std::ops::{Add, Sub, Mul, Div, Deref, DerefMut};
+use approx::ApproxEq;
+use num::Float;
+
+use {Alpha, ComponentWise, Mix, Blend, clamp};
+
+///Premultiplied alpha wrapper.
+///
+///Premultiplied colors are commonly used in composition algorithms to
+///simplify the calculations. It may also be preferred when interpolating
+///between colors, which is one of the reasons why it's offered as a separate
+///type. The other reason is to make it easier to avoid unnecessary
+///computations in composition chains.
+///
+///```
+///use palette::{Blend, Rgb, Rgba};
+///use palette::blend::PreAlpha;
+///
+///let a = PreAlpha::from(Rgba::new(0.4, 0.5, 0.5, 0.3));
+///let b = PreAlpha::from(Rgba::new(0.3, 0.8, 0.4, 0.4));
+///let c = PreAlpha::from(Rgba::new(0.7, 0.1, 0.8, 0.8));
+///
+///let res = Rgb::from_premultiplied(a.screen(b).overlay(c));
+///```
+///
+///Note that converting to and from premultiplied alpha will cause the alpha
+///component to be clamped to [0.0, 1.0].
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct PreAlpha<C, T: Float> {
+    ///The premultiplied color components (`original.color * original.alpha`).
+    pub color: C,
+
+    ///The transparency component. 0.0 is fully transparent and 1.0 is fully
+    ///opaque.
+    pub alpha: T,
+}
+
+impl<C, T> From<Alpha<C, T>> for PreAlpha<C, T> where
+    C: ComponentWise<Scalar=T>,
+    T: Float,
+{
+    fn from(color: Alpha<C, T>) -> PreAlpha<C, T> {
+        let alpha = clamp(color.alpha, T::zero(), T::one());
+
+        PreAlpha{
+            color: color.color.component_wise_self(|a| a * alpha),
+            alpha: alpha
+        }
+    }
+}
+
+impl<C, T> From<PreAlpha<C, T>> for Alpha<C, T> where
+    C: ComponentWise<Scalar=T>,
+    T: Float,
+{
+    fn from(color: PreAlpha<C, T>) -> Alpha<C, T> {
+        let alpha = clamp(color.alpha, T::zero(), T::one());
+
+        let color = color.color.component_wise_self(|a| if alpha.is_normal() {
+            a / alpha
+        } else {
+            T::zero()
+        });
+
+        Alpha {
+            color: color,
+            alpha: alpha,
+        }
+    }
+}
+
+impl<C, T> Blend for PreAlpha<C, T> where
+    C: Blend<Color=C> + ComponentWise<Scalar=T>,
+    T: Float,
+{
+    type Color = C;
+
+    fn into_premultiplied(self) -> PreAlpha<C, T> {
+        self
+    }
+
+    fn from_premultiplied(color: PreAlpha<C, T>) -> PreAlpha<C, T> {
+        color
+    }
+}
+
+impl<C: Mix> Mix for PreAlpha<C, C::Scalar> {
+    type Scalar = C::Scalar;
+    
+    fn mix(&self, other: &PreAlpha<C, C::Scalar>, factor: C::Scalar) -> PreAlpha<C, C::Scalar> {
+        PreAlpha {
+            color: self.color.mix(&other.color, factor),
+            alpha: self.alpha + factor * (other.alpha - self.alpha),
+        }
+    }
+}
+
+impl<C: ComponentWise<Scalar=T>, T: Float> ComponentWise for PreAlpha<C, T> {
+    type Scalar = T;
+
+    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &PreAlpha<C, T>, mut f: F) -> PreAlpha<C, T> {
+        PreAlpha {
+            alpha: f(self.alpha, other.alpha),
+            color: self.color.component_wise(&other.color, f),
+        }
+    }
+
+    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> PreAlpha<C, T> {
+        PreAlpha {
+            alpha: f(self.alpha),
+            color: self.color.component_wise_self(f),
+        }
+    }
+}impl<C, T> ApproxEq for PreAlpha<C, T> where
+    C: ApproxEq<Epsilon=T::Epsilon>,
+    T: ApproxEq + Float,
+    T::Epsilon: Copy,
+{
+    type Epsilon = T::Epsilon;
+
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps()
+    }
+
+    fn relative_eq(&self, other: &PreAlpha<C, T>, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+        self.color.relative_eq(&other.color, epsilon, max_relative) &&
+        self.alpha.relative_eq(&other.alpha, epsilon, max_relative)
+    }
+
+    fn ulps_eq(&self, other: &PreAlpha<C, T>, epsilon: Self::Epsilon, max_ulps: u32) -> bool{
+        self.color.ulps_eq(&other.color, epsilon, max_ulps) &&
+        self.alpha.ulps_eq(&other.alpha, epsilon, max_ulps)
+    }
+}
+
+impl<C: Add, T: Float> Add for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn add(self, other: PreAlpha<C, T>) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color + other.color,
+            alpha: self.alpha + other.alpha,
+        }
+    }
+}
+
+impl<T: Float, C: Add<T>> Add<T> for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn add(self, c: T) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color + c,
+            alpha: self.alpha + c,
+        }
+    }
+}
+
+impl<C: Sub, T: Float> Sub for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn sub(self, other: PreAlpha<C, T>) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color - other.color,
+            alpha: self.alpha - other.alpha,
+        }
+    }
+}
+
+impl<T: Float, C: Sub<T>> Sub<T> for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn sub(self, c: T) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color - c,
+            alpha: self.alpha - c,
+        }
+    }
+}
+
+impl<C: Mul, T: Float> Mul for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn mul(self, other: PreAlpha<C, T>) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color * other.color,
+            alpha: self.alpha * other.alpha,
+        }
+    }
+}
+
+impl<T: Float, C: Mul<T>> Mul<T> for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn mul(self, c: T) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color * c,
+            alpha: self.alpha * c,
+        }
+    }
+}
+
+impl<C: Div, T: Float> Div for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn div(self, other: PreAlpha<C, T>) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color / other.color,
+            alpha: self.alpha / other.alpha,
+        }
+    }
+}
+
+impl<T: Float, C: Div<T>> Div<T> for PreAlpha<C, T> {
+    type Output = PreAlpha<C::Output, T>;
+
+    fn div(self, c: T) -> PreAlpha<C::Output, T> {
+        PreAlpha {
+            color: self.color / c,
+            alpha: self.alpha / c,
+        }
+    }
+}
+
+impl<C, T: Float> Deref for PreAlpha<C, T> {
+    type Target = C;
+
+    fn deref(&self) -> &C {
+        &self.color
+    }
+}
+
+impl<C, T: Float> DerefMut for PreAlpha<C, T> {
+    fn deref_mut(&mut self) -> &mut C {
+        &mut self.color
+    }
+}

--- a/src/blend/test.rs
+++ b/src/blend/test.rs
@@ -1,0 +1,366 @@
+use {Color, Colora, Rgb, Rgba, Blend, ComponentWise};
+use blend::PreAlpha;
+
+#[test]
+fn blend_color() {
+    let a = Color::rgb(1.0, 0.0, 0.0);
+    let b = Color::rgb(0.0, 0.0, 1.0);
+
+    let c: Rgb = a.blend(b, |a: PreAlpha<Rgb<_>, _>, b: PreAlpha<Rgb<_>, _>| a.component_wise(&b, |a, b| a + b)).into();
+    assert_relative_eq!(Rgb::new(1.0, 0.0, 1.0), c);
+}
+
+#[test]
+fn blend_alpha_color() {
+    let a = Colora::rgb(1.0, 0.0, 0.0, 0.2);
+    let b = Colora::rgb(0.0, 0.0, 1.0, 0.2);
+
+    let c: Rgba = a.blend(b, |a: PreAlpha<Rgb<_>, _>, b: PreAlpha<Rgb<_>, _>| a.component_wise(&b, |a, b| a + b)).into();
+    assert_relative_eq!(Rgba::new(0.2 / 0.4, 0.0, 0.2 / 0.4, 0.4), c);
+}
+
+#[test]
+fn over() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.5, 0.0, 0.3), a.over(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.over(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 0.5);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5 / 0.75, 0.05 / 0.75, 0.15 / 0.75, 0.75), a.over(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.over(b));
+}
+
+#[test]
+fn inside() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.5, 0.0, 0.3), a.inside(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 0.5), a.inside(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.0, 0.0, 0.0, 0.0), a.inside(b));
+}
+
+#[test]
+fn outside() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.0, 0.0, 0.0), a.outside(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 0.5), a.outside(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.outside(b));
+}
+
+#[test]
+fn atop() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.5, 0.0, 0.3), a.atop(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 0.5), a.atop(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 0.5);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.1, 0.15, 0.5), a.atop(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.0, 0.0, 0.0, 0.0), a.atop(b));
+}
+
+#[test]
+fn xor() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.0, 0.0, 0.0), a.xor(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 0.5), a.xor(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 0.5);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.1, 0.15, 0.5), a.xor(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.xor(b));
+}
+
+#[test]
+fn plus() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.5, 0.2, 0.3), a.plus(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(1.0, 0.1, 0.3, 1.0), a.plus(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 0.5);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.1, 0.15, 1.0), a.plus(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.plus(b));
+}
+
+#[test]
+fn multiply() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(0.5, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.25, 0.0, 0.0), a.multiply(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(0.5, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.375, 0.0, 0.15, 1.0), a.multiply(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(0.5, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.multiply(b));
+}
+
+#[test]
+fn screen() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(0.5, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.75, 0.2, 0.3), a.screen(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(0.5, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.625, 0.1, 0.3, 1.0), a.screen(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(0.5, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.screen(b));
+}
+
+#[test]
+fn overlay() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(0.5, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.5, 0.0, 0.0), a.overlay(b));
+
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.0, 0.0), a.overlay(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.0, 0.15, 1.0), a.overlay(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.overlay(b));
+}
+
+#[test]
+fn darken() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.5, 0.0, 0.0), a.darken(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.15, 1.0), a.darken(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 0.5);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5 / 0.75, 0.05 / 0.75, 0.075 / 0.75, 0.75), a.darken(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.darken(b));
+}
+
+#[test]
+fn lighten() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.2, 0.3), a.lighten(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.1, 0.3, 1.0), a.lighten(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 0.5);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.625 / 0.75, 0.1 / 0.75, 0.15 / 0.75, 0.75), a.lighten(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.lighten(b));
+}
+
+#[test]
+fn dodge() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.2, 0.0), a.dodge(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.1, 0.15, 1.0), a.dodge(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.dodge(b));
+}
+
+#[test]
+fn burn() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.0, 0.0), a.burn(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.0, 0.15, 1.0), a.burn(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.burn(b));
+}
+
+#[test]
+fn hard_light() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.0, 0.0), a.hard_light(b));
+
+    let a = Rgb::new(1.0, 0.2, 0.0);
+    let b = Rgb::new(0.5, 0.0, 0.3);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.0, 0.0), a.hard_light(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.0, 0.15, 1.0), a.hard_light(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.hard_light(b));
+}
+
+#[test]
+fn soft_light() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(1.0, 0.04, 0.0), a.soft_light(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.75, 0.02, 0.15, 1.0), a.soft_light(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.soft_light(b));
+}
+
+#[test]
+fn difference() {
+    let a = Rgb::new(0.5, 0.0, 0.3);
+    let b = Rgb::new(1.0, 0.2, 0.0);
+
+    assert_relative_eq!(Rgb::new(0.5, 0.2, 0.3), a.difference(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.1, 0.3, 1.0), a.difference(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.difference(b));
+}
+
+#[test]
+fn exclusion() {
+    let a = Rgb::new(1.0, 0.5, 0.0);
+    let b = Rgb::new(0.8, 0.4, 0.3);
+
+    assert_relative_eq!(Rgb::new(0.2, 0.5, 0.3), a.exclusion(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.5);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.1, 0.3, 1.0), a.difference(b));
+
+    let a = Rgba::new(0.5, 0.0, 0.3, 1.0);
+    let b = Rgba::new(1.0, 0.2, 0.0, 0.0);
+
+    assert_relative_eq!(Rgba::new(0.5, 0.0, 0.3, 1.0), a.difference(b));
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -187,6 +187,15 @@ macro_rules! impl_from_trait {
             }
         }
 
+        impl<T: Float> From<Alpha<Color<T>, T>> for Alpha<$self_ty<T>,T> {
+            fn from(color: Alpha<Color<T>, T>) -> Alpha<$self_ty<T>,T> {
+                Alpha {
+                    color: color.color.into(),
+                    alpha: color.alpha,
+                }
+            }
+        }
+
         $(
             impl<T: Float> From<$other<T>> for $self_ty<T> {
                 fn from(other: $other<T>) -> $self_ty<T> {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -2,7 +2,10 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Alpha, Xyz, Limited, Mix, Shade, GetHue, LabHue, FromColor, Lch, clamp, flt};
+use {Alpha, Xyz, Lch, LabHue};
+use {Limited, Mix, Shade, GetHue, FromColor, ComponentWise};
+use {clamp, flt};
+
 use tristimulus::{X_N, Y_N, Z_N};
 
 ///CIE L*a*b* (CIELAB) with an alpha component. See the [`Laba` implementation in `Alpha`](struct.Alpha.html#Laba).
@@ -151,6 +154,26 @@ impl<T: Float> GetHue for Lab<T> {
             None
         } else {
             Some(LabHue::from_radians(self.b.atan2(self.a)))
+        }
+    }
+}
+
+impl<T: Float> ComponentWise for Lab<T> {
+    type Scalar = T;
+
+    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Lab<T>, mut f: F) -> Lab<T> {
+        Lab {
+            l: f(self.l, other.l),
+            a: f(self.a, other.a),
+            b: f(self.b, other.b),
+        }
+    }
+
+    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Lab<T> {
+        Lab {
+            l: f(self.l),
+            a: f(self.a),
+            b: f(self.b),
         }
     }
 }

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -2,7 +2,10 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Alpha, Limited, Mix, Shade, FromColor,  Rgb, Lab, Yxy, Luma, clamp, flt};
+use {Alpha, Yxy, Rgb, Luma, Lab};
+use {Limited, Mix, Shade, FromColor, ComponentWise};
+use {clamp, flt};
+
 use tristimulus::{X_N, Y_N, Z_N};
 
 ///CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in `Alpha`](struct.Alpha.html#Xyza).
@@ -157,6 +160,26 @@ impl<T: Float> Shade for Xyz<T> {
             x: self.x,
             y: self.y + amount,
             z: self.z,
+        }
+    }
+}
+
+impl<T: Float> ComponentWise for Xyz<T> {
+    type Scalar = T;
+
+    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Xyz<T>, mut f: F) -> Xyz<T> {
+        Xyz {
+            x: f(self.x, other.x),
+            y: f(self.y, other.y),
+            z: f(self.z, other.z),
+        }
+    }
+
+    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Xyz<T> {
+        Xyz {
+            x: f(self.x),
+            y: f(self.y),
+            z: f(self.z),
         }
     }
 }

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -2,7 +2,9 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Alpha, Xyz, Luma, Limited, Mix, Shade, FromColor, clamp, flt};
+use {Alpha, Luma, Xyz};
+use {Limited, Mix, Shade, FromColor, ComponentWise};
+use {clamp, flt};
 
 const D65_X: f64 = 0.312727;
 const D65_Y: f64 = 0.329023;
@@ -123,6 +125,26 @@ impl<T: Float> Shade for Yxy<T> {
             x: self.x,
             y: self.y,
             luma: self.luma + amount,
+        }
+    }
+}
+
+impl<T: Float> ComponentWise for Yxy<T> {
+    type Scalar = T;
+
+    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Yxy<T>, mut f: F) -> Yxy<T> {
+        Yxy {
+            x: f(self.x, other.x),
+            y: f(self.y, other.y),
+            luma: f(self.luma, other.luma),
+        }
+    }
+
+    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Yxy<T> {
+        Yxy {
+            x: f(self.x),
+            y: f(self.y),
+            luma: f(self.luma),
         }
     }
 }


### PR DESCRIPTION
This introduces the `Blend` trait, which implements proper color blending for colors where it makes sense. The introduction of this trait includes:

 * Implementation of OpenGL style blending, with blending equations and blending parameters.
 * Implementation of most of the [SVG composition operators](https://www.w3.org/TR/SVGCompositing/#containerElementCompositingOperators) (also common in photo manipulation software).
 * Introduction of a type for premultiplied alpha, which is useful for lengthy composition chains.
 * Introduction of the `ComponentWise` trait, with functions for repeatedly performing actions on each component of a color. It's restricted to colors where all of the components are of the same type.

Closes #3.