### PR TITLE
Add conversion trait

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,231 @@
+use num::Float;
+
+use {Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Color};
+
+///FromColor provides conversion between the colors.
+///
+///It requires from_xyz and derives conversion to other colors as a default from this.
+///These defaults must be overridden when direct conversion exists between colors.
+///For example, Luma has direct conversion to Rgb. So from_rgb conversion for Luma and
+///from_luma for Rgb is implemented directly. The from for the same color must override
+///the default. For example, from_rgb for Rgb will convert via Xyz which needs to be overridden
+///with self to avoid the unnecessary converison.
+pub trait FromColor<T>: Sized
+    where T: Float,
+{
+    ///Convert from XYZ color space
+    fn from_xyz(Xyz<T>) -> Self;
+
+    ///Convert from Yxy color space
+    fn from_yxy(inp: Yxy<T>) -> Self {
+        Self::from_xyz(inp.into_xyz())
+    }
+
+    ///Convert from L*a*b* color space
+    fn from_lab(inp: Lab<T>) -> Self {
+        Self::from_xyz(inp.into_xyz())
+    }
+
+    ///Convert from L*C*h° color space
+    fn from_lch(inp: Lch<T>) -> Self {
+        Self::from_lab(inp.into_lab())
+    }
+
+    ///Convert from RGB color space
+    fn from_rgb(inp: Rgb<T>) -> Self {
+        Self::from_xyz(inp.into_xyz())
+    }
+
+    ///Convert from HSL color space
+    fn from_hsl(inp: Hsl<T>) -> Self {
+        Self::from_rgb(inp.into_rgb())
+    }
+
+    ///Convert from HSV color space
+    fn from_hsv(inp: Hsv<T>) -> Self {
+        Self::from_rgb(inp.into_rgb())
+    }
+
+    ///Convert from Luma
+    fn from_luma(inp: Luma<T>) -> Self {
+        Self::from_xyz(inp.into_xyz())
+    }
+
+}
+
+
+///IntoColor provides conversion between the colors.
+///
+///It requires into into_xyz and derives conversion to other colors as a default from this.
+///These defaults must be overridden when direct conversion exists between colors.
+pub trait IntoColor<T>: Sized
+    where T: Float,
+{
+
+    ///Convert into XYZ space
+    fn into_xyz(self) -> Xyz<T>;
+
+    ///Convert into Yxy color space
+    fn into_yxy(self) -> Yxy<T> {
+        Yxy::from_xyz(self.into_xyz())
+    }
+
+    ///Convert into L*a*b* color space
+    fn into_lab(self) -> Lab<T> {
+        Lab::from_xyz(self.into_xyz())
+    }
+
+    ///Convert into L*C*h° color space
+    fn into_lch(self) -> Lch<T> {
+        Lch::from_lab(self.into_lab())
+    }
+
+    ///Convert into RGB color space.
+    fn into_rgb(self) -> Rgb<T> {
+        Rgb::from_xyz(self.into_xyz())
+    }
+
+    ///Convert into HSL color space
+    fn into_hsl(self) -> Hsl<T> {
+        Hsl::from_rgb(self.into_rgb())
+    }
+
+    ///Convert into HSV color space
+    fn into_hsv(self) -> Hsv<T> {
+        Hsv::from_rgb(self.into_rgb())
+    }
+
+    ///Convert into Luma
+    fn into_luma(self) -> Luma<T> {
+        Luma::from_xyz(self.into_xyz())
+    }
+
+}
+
+macro_rules! impl_into_color {
+    ($self_ty:ident, $from_fn: ident) => {
+        impl< T: Float > IntoColor<T> for $self_ty<T> {
+
+            fn into_xyz(self) -> Xyz<T> {
+                Xyz::$from_fn(self)
+            }
+
+            fn into_yxy(self) -> Yxy<T> {
+                Yxy::$from_fn(self)
+            }
+
+            fn into_lab(self) -> Lab<T> {
+                Lab::$from_fn(self)
+            }
+
+            fn into_lch(self) -> Lch<T> {
+                Lch::$from_fn(self)
+            }
+
+            fn into_rgb(self) -> Rgb<T> {
+                Rgb::$from_fn(self)
+            }
+
+            fn into_hsl(self) -> Hsl<T> {
+                Hsl::$from_fn(self)
+            }
+
+            fn into_hsv(self) -> Hsv<T> {
+                Hsv::$from_fn(self)
+            }
+
+            fn into_luma(self) -> Luma<T> {
+                Luma::$from_fn(self)
+            }
+
+        }
+
+    }
+}
+
+
+macro_rules! impl_from_trait {
+    (($self_ty:ident, $into_fn: ident) => {$($other:ident),+}) => (
+        impl<T: Float> From<Alpha<$self_ty<T>, T>> for $self_ty<T> {
+            fn from(color: Alpha<$self_ty<T>, T>) -> $self_ty<T> {
+                color.color
+            }
+        }
+
+        impl<T: Float> From<Color<T>> for $self_ty<T> {
+            fn from(color: Color<T>) -> $self_ty<T> {
+                match color {
+                    Color::Luma(c) => c.$into_fn(),
+                    Color::Rgb(c) => c.$into_fn(),
+                    Color::Xyz(c) => c.$into_fn(),
+                    Color::Yxy(c) => c.$into_fn(),
+                    Color::Lab(c) => c.$into_fn(),
+                    Color::Lch(c) => c.$into_fn(),
+                    Color::Hsv(c) => c.$into_fn(),
+                    Color::Hsl(c) => c.$into_fn(),
+                }
+            }
+        }
+
+        impl<T: Float> From<Color<T>> for Alpha<$self_ty<T>,T> {
+            fn from(color: Color<T>) -> Alpha<$self_ty<T>,T> {
+                Alpha {
+                    color: color.into(),
+                    alpha: T::one(),
+                }
+            }
+        }
+
+        $(
+            impl<T: Float> From<$other<T>> for $self_ty<T> {
+                fn from(other: $other<T>) -> $self_ty<T> {
+                    other.$into_fn()
+                }
+            }
+
+            impl<T: Float> From<Alpha<$other<T>, T>> for Alpha<$self_ty<T>, T> {
+                fn from(other: Alpha<$other<T>, T>) -> Alpha<$self_ty<T>, T> {
+                    Alpha {
+                        color: other.color.$into_fn(),
+                        alpha: other.alpha,
+                    }
+                }
+            }
+
+            impl<T: Float> From<$other<T>> for Alpha<$self_ty<T>, T> {
+                fn from(color: $other<T>) -> Alpha<$self_ty<T>, T> {
+                    Alpha {
+                        color: color.$into_fn(),
+                        alpha: T::one(),
+                    }
+                }
+            }
+
+            impl<T: Float> From<Alpha<$other<T>, T>> for $self_ty<T> {
+                fn from(other: Alpha<$other<T>, T>) -> $self_ty<T> {
+                    other.color.$into_fn()
+                }
+            }
+
+        )+
+    )
+}
+
+impl_into_color!(Xyz,from_xyz);
+impl_into_color!(Yxy,from_yxy);
+impl_into_color!(Lab,from_lab);
+impl_into_color!(Lch,from_lch);
+impl_into_color!(Rgb,from_rgb);
+impl_into_color!(Hsl,from_hsl);
+impl_into_color!(Hsv,from_hsv);
+impl_into_color!(Luma,from_luma);
+
+
+impl_from_trait!((Xyz,into_xyz) => {Yxy, Lab, Lch, Rgb, Hsl, Hsv, Luma});
+impl_from_trait!((Yxy,into_yxy) => {Xyz, Lab, Lch, Rgb, Hsl, Hsv, Luma});
+impl_from_trait!((Lab,into_lab) => {Xyz, Yxy, Lch, Rgb, Hsl, Hsv, Luma});
+impl_from_trait!((Lch,into_lch) => {Xyz, Yxy, Lab, Rgb, Hsl, Hsv, Luma});
+impl_from_trait!((Rgb,into_rgb) => {Xyz, Yxy, Lab, Lch, Hsl, Hsv, Luma});
+impl_from_trait!((Hsl,into_hsl) => {Xyz, Yxy, Lab, Lch, Rgb, Hsv, Luma});
+impl_from_trait!((Hsv,into_hsv) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Luma});
+impl_from_trait!((Luma,into_luma) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv});

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -2,8 +2,7 @@ use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 
-use {Color, Alpha, Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl, Limited, Mix, Shade, GetHue, LabHue, clamp, flt};
-
+use {Alpha, Xyz, Limited, Mix, Shade, GetHue, LabHue, FromColor, Lch, clamp, flt};
 use tristimulus::{X_N, Y_N, Z_N};
 
 ///CIE L*a*b* (CIELAB) with an alpha component. See the [`Laba` implementation in `Alpha`](struct.Alpha.html#Laba).
@@ -53,6 +52,30 @@ impl<T: Float> Alpha<Lab<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> FromColor<T> for Lab<T> {
+    fn from_xyz(xyz: Xyz<T>) -> Self {
+        Lab {
+            l: (f(xyz.y / flt(Y_N)) * flt(116.0) - flt(16.0)) / flt(100.0),
+            a: (f(xyz.x / flt(X_N)) - f(xyz.y / flt(Y_N))) * flt(500.0) / flt(128.0),
+            b: (f(xyz.y / flt(Y_N)) - f(xyz.z / flt(Z_N))) * flt(200.0) / flt(128.0),
+        }
+    }
+
+    fn from_lab(lab: Lab<T>) -> Self {
+        lab
+    }
+
+    fn from_lch(lch: Lch<T>) -> Self {
+        Lab {
+            l: lch.l,
+            a: lch.chroma.max(T::zero()) * lch.hue.to_radians().cos(),
+            b: lch.chroma.max(T::zero()) * lch.hue.to_radians().sin(),
+        }
+    }
+
+
 }
 
 impl<T: Float> Limited for Lab<T> {
@@ -212,60 +235,6 @@ impl<T: Float> Div<T> for Lab<T> {
             a: self.a / c,
             b: self.b / c,
         }
-    }
-}
-
-from_color!(to Lab from Rgb, Luma, Xyz, Yxy, Lch, Hsv, Hsl);
-
-alpha_from!(Lab {Rgb, Xyz, Yxy, Luma, Lch, Hsv, Hsl, Color});
-
-impl<T: Float> From<Xyz<T>> for Lab<T> {
-    fn from(xyz: Xyz<T>) -> Lab<T> {
-        Lab {
-            l: (f(xyz.y / flt(Y_N)) * flt(116.0) - flt(16.0)) / flt(100.0),
-            a: (f(xyz.x / flt(X_N)) - f(xyz.y / flt(Y_N))) * flt(500.0) / flt(128.0),
-            b: (f(xyz.y / flt(Y_N)) - f(xyz.z / flt(Z_N))) * flt(200.0) / flt(128.0),
-        }
-    }
-}
-
-impl<T: Float> From<Yxy<T>> for Lab<T> {
-    fn from(yxy: Yxy<T>) -> Lab<T> {
-        Xyz::from(yxy).into()
-    }
-}
-
-impl<T: Float> From<Rgb<T>> for Lab<T> {
-    fn from(rgb: Rgb<T>) -> Lab<T> {
-        Xyz::from(rgb).into()
-    }
-}
-
-impl<T: Float> From<Luma<T>> for Lab<T> {
-    fn from(luma: Luma<T>) -> Lab<T> {
-        Xyz::from(luma).into()
-    }
-}
-
-impl<T: Float> From<Lch<T>> for Lab<T> {
-    fn from(lch: Lch<T>) -> Lab<T> {
-        Lab {
-            l: lch.l,
-            a: lch.chroma.max(T::zero()) * lch.hue.to_radians().cos(),
-            b: lch.chroma.max(T::zero()) * lch.hue.to_radians().sin(),
-        }
-    }
-}
-
-impl<T: Float> From<Hsv<T>> for Lab<T> {
-    fn from(hsv: Hsv<T>) -> Lab<T> {
-        Xyz::from(hsv).into()
-    }
-}
-
-impl<T: Float> From<Hsl<T>> for Lab<T> {
-    fn from(hsl: Hsl<T>) -> Lab<T> {
-        Xyz::from(hsl).into()
     }
 }
 

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -2,7 +2,7 @@ use num::Float;
 
 use std::ops::{Add, Sub};
 
-use {Color, Alpha, Limited, Mix, Shade, GetHue, Hue, Rgb, Luma, Xyz, Yxy, Lab, Hsv, Hsl, Saturate, LabHue, clamp};
+use {Alpha, Limited, Mix, Shade, GetHue, FromColor, IntoColor, Hue, Xyz, Lab, Saturate, LabHue, clamp};
 
 ///CIE L*C*h° with an alpha component. See the [`Lcha` implementation in `Alpha`](struct.Alpha.html#Lcha).
 pub type Lcha<T = f32> = Alpha<Lch<T>, T>;
@@ -50,6 +50,26 @@ impl<T: Float> Alpha<Lch<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> FromColor<T> for Lch<T> {
+    fn from_xyz(xyz: Xyz<T>) -> Self {
+        let lab: Lab<T> = xyz.into_lab();
+        Self::from_lab(lab)
+    }
+
+    fn from_lab(lab: Lab<T>) -> Self {
+        Lch {
+            l: lab.l,
+            chroma: (lab.a * lab.a + lab.b * lab.b).sqrt(),
+            hue: lab.get_hue().unwrap_or(LabHue::from(T::zero())),
+        }
+    }
+
+    fn from_lch(lch: Lch<T>) -> Self {
+        lch
+    }
+
 }
 
 impl<T: Float> Limited for Lch<T> {
@@ -189,56 +209,6 @@ impl<T: Float> Sub<T> for Lch<T> {
             chroma: self.chroma - c,
             hue: self.hue - c,
         }
-    }
-}
-
-from_color!(to Lch from Rgb, Luma, Xyz, Yxy, Lab, Hsv, Hsl);
-
-alpha_from!(Lch {Rgb, Xyz, Yxy, Luma, Lab, Hsv, Hsl, Color});
-
-impl<T: Float> From<Lab<T>> for Lch<T> {
-    fn from(lab: Lab<T>) -> Lch<T> {
-        Lch {
-            l: lab.l,
-            chroma: (lab.a * lab.a + lab.b * lab.b).sqrt(),
-            hue: lab.get_hue().unwrap_or(LabHue::from(T::zero())),
-        }
-    }
-}
-
-impl<T: Float> From<Rgb<T>> for Lch<T> {
-    fn from(rgb: Rgb<T>) -> Lch<T> {
-        Lab::from(rgb).into()
-    }
-}
-
-impl<T: Float> From<Luma<T>> for Lch<T> {
-    fn from(luma: Luma<T>) -> Lch<T> {
-        Lab::from(luma).into()
-    }
-}
-
-impl<T: Float> From<Xyz<T>> for Lch<T> {
-    fn from(xyz: Xyz<T>) -> Lch<T> {
-        Lab::from(xyz).into()
-    }
-}
-
-impl<T: Float> From<Yxy<T>> for Lch<T> {
-    fn from(yxy: Yxy<T>) -> Lch<T> {
-        Lab::from(yxy).into()
-    }
-}
-
-impl<T: Float> From<Hsv<T>> for Lch<T> {
-    fn from(hsv: Hsv<T>) -> Lch<T> {
-        Lab::from(hsv).into()
-    }
-}
-
-impl<T: Float> From<Hsl<T>> for Lch<T> {
-    fn from(hsl: Hsl<T>) -> Lch<T> {
-        Lab::from(hsl).into()
     }
 }
 

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -1,8 +1,9 @@
 use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
+use std::default::Default;
 
-use {Color, Alpha, Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Limited, Mix, Shade, clamp, flt};
+use {Alpha, Rgb, Xyz, Yxy, Limited, Mix, Shade, FromColor, clamp, flt};
 
 ///Linear luminance with an alpha component. See the [`Lumaa` implementation in `Alpha`](struct.Alpha.html#Lumaa).
 pub type Lumaa<T = f32> = Alpha<Luma<T>, T>;
@@ -53,6 +54,31 @@ impl<T: Float> Alpha<Luma<T>, T> {
             alpha: flt::<T,_>(alpha) / flt(255.0),
         }
     }
+}
+
+impl<T: Float> FromColor<T> for Luma<T> {
+    fn from_xyz(xyz: Xyz<T>) -> Self {
+        Luma {
+            luma: xyz.y,
+        }
+    }
+
+    fn from_yxy(yxy: Yxy<T>) -> Self {
+        Luma {
+            luma: yxy.luma,
+        }
+    }
+
+    fn from_rgb(rgb: Rgb<T>) -> Self {
+        Luma {
+            luma: rgb.red * flt(0.2126) + rgb.green * flt(0.7152) + rgb.blue * flt(0.0722),
+        }
+    }
+
+    fn from_luma(luma: Luma<T>) -> Self {
+        luma
+    }
+
 }
 
 impl<T: Float> Limited for Luma<T> {
@@ -176,58 +202,6 @@ impl<T: Float> Div<T> for Luma<T> {
         Luma {
             luma: self.luma / c,
         }
-    }
-}
-
-from_color!(to Luma from Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl);
-
-alpha_from!(Luma {Rgb, Xyz, Yxy, Lab, Lch, Hsv, Hsl, Color});
-
-impl<T: Float> From<Rgb<T>> for Luma<T> {
-    fn from(rgb: Rgb<T>) -> Luma<T> {
-        Luma {
-            luma: rgb.red * flt(0.2126) + rgb.green * flt(0.7152) + rgb.blue * flt(0.0722),
-        }
-    }
-}
-
-impl<T: Float> From<Xyz<T>> for Luma<T> {
-    fn from(xyz: Xyz<T>) -> Luma<T> {
-        Luma {
-            luma: xyz.y,
-        }
-    }
-}
-
-impl<T: Float> From<Yxy<T>> for Luma<T> {
-    fn from(yxy: Yxy<T>) -> Luma<T> {
-        Luma {
-            luma: yxy.luma,
-        }
-    }
-}
-
-impl<T: Float> From<Lab<T>> for Luma<T> {
-    fn from(lab: Lab<T>) -> Luma<T> {
-        Xyz::from(lab).into()
-    }
-}
-
-impl<T: Float> From<Lch<T>> for Luma<T> {
-    fn from(lch: Lch<T>) -> Luma<T> {
-        Xyz::from(lch).into()
-    }
-}
-
-impl<T: Float> From<Hsv<T>> for Luma<T> {
-    fn from(hsv: Hsv<T>) -> Luma<T> {
-        Rgb::from(hsv).into()
-    }
-}
-
-impl<T: Float> From<Hsl<T>> for Luma<T> {
-    fn from(hsl: Hsl<T>) -> Luma<T> {
-        Rgb::from(hsl).into()
     }
 }
 


### PR DESCRIPTION
This commit adds a FromColor and IntoColor conversion trait. These traits require from_xyz and into_xyz respectively to be implemented and auto derive the conversions for other colors. 

To implement FromColor and IntoColor for a type, a few things must by kept in mind.
- Derived colors like Hsl must override the default from_rgb  and use this for from_xyz for efficiency.

- The FromColor for the same color must override the default. For example, from_rgb for Rgb will convert via Xyz which needs to be overridden with self to avoid the unnecessary conversion.

- If a direct transform exists between the colors, then it should be overridden in both the colors. For example, Luma has direct conversion to Rgb. So from_rgb for Luma and from_luma for Rgb override the defaults.



