### PR TITLE
Add missing ApproxEq implementations

### DIFF
--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -2,6 +2,8 @@ use std::ops::{Deref, DerefMut, Add, Sub, Mul, Div};
 
 use num::Float;
 
+use approx::ApproxEq;
+
 use {Mix, Shade, GetHue, Hue, Saturate, Limited, clamp};
 
 ///An alpha component wrapper for colors.
@@ -110,6 +112,36 @@ impl<C: Default, T: Float> Default for Alpha<C, T> {
             color: C::default(),
             alpha: T::one(),
         }
+    }
+}
+
+impl<C, T> ApproxEq for Alpha<C, T> where
+    C: ApproxEq<Epsilon=T::Epsilon>,
+    T: ApproxEq + Float,
+    T::Epsilon: Copy,
+{
+    type Epsilon = T::Epsilon;
+
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps()
+    }
+
+    fn relative_eq(&self, other: &Alpha<C, T>, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+        self.color.relative_eq(&other.color, epsilon, max_relative) &&
+        self.alpha.relative_eq(&other.alpha, epsilon, max_relative)
+    }
+
+    fn ulps_eq(&self, other: &Alpha<C, T>, epsilon: Self::Epsilon, max_ulps: u32) -> bool{
+        self.color.ulps_eq(&other.color, epsilon, max_ulps) &&
+        self.alpha.ulps_eq(&other.alpha, epsilon, max_ulps)
     }
 }
 

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -41,7 +41,7 @@ impl_eq!( Yxy, [y, x, luma] );
 impl_eq!( Lab, [l, a, b] );
 impl_eq!( Rgb, [red, blue, green] );
 impl_eq!( Luma, [luma] );
-impl_eq!( Lch, [l, chroma] );
+impl_eq!( Lch, [l, chroma, hue] );
 impl_eq!( Hsl, [hue, saturation, lightness] );
 impl_eq!( Hsv, [hue, saturation, value] );
 impl_eq!( Hwb, [hue, whiteness, blackness] );

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -2,6 +2,7 @@ use num::Float;
 use approx::ApproxEq;
 
 use {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma, LabHue, RgbHue, flt};
+use pixel::{Srgb, GammaRgb};
 
 macro_rules! impl_eq {
     (  $self_ty: ident , [$($element: ident),+]) => {
@@ -45,6 +46,8 @@ impl_eq!( Lch, [l, chroma, hue] );
 impl_eq!( Hsl, [hue, saturation, lightness] );
 impl_eq!( Hsv, [hue, saturation, value] );
 impl_eq!( Hwb, [hue, whiteness, blackness] );
+impl_eq!( Srgb, [red, blue, green, alpha] );
+impl_eq!( GammaRgb, [red, blue, green, alpha, gamma] );
 
 // For hues diffence is calculated and compared to zero. However due to the way floating point's
 // work this is not so simple

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -2,6 +2,7 @@
 
 use num::{Float, One, Zero, NumCast};
 use std::cmp::max;
+use approx::ApproxEq;
 
 use flt;
 
@@ -273,6 +274,57 @@ impl<T: Float> From<::std::ops::RangeFull> for Range<T> {
             from: None,
             to: None,
         }
+    }
+}
+
+impl<T> ApproxEq for Range<T> where
+    T: ApproxEq + Float,
+    T::Epsilon: Copy,
+{
+    type Epsilon = T::Epsilon;
+
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps()
+    }
+
+    fn relative_eq(&self, other: &Range<T>, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+        let from = match (self.from, other.from) {
+            (Some(s), Some(o)) => s.relative_eq(&o, epsilon, max_relative),
+            (None, None) => true,
+            _ => false,
+        };
+
+        let to = match (self.to, other.to) {
+            (Some(s), Some(o)) => s.relative_eq(&o, epsilon, max_relative),
+            (None, None) => true,
+            _ => false,
+        };
+
+        from && to
+    }
+
+    fn ulps_eq(&self, other: &Range<T>, epsilon: Self::Epsilon, max_ulps: u32) -> bool{
+        let from = match (self.from, other.from) {
+            (Some(s), Some(o)) => s.ulps_eq(&o, epsilon, max_ulps),
+            (None, None) => true,
+            _ => false,
+        };
+
+        let to = match (self.to, other.to) {
+            (Some(s), Some(o)) => s.ulps_eq(&o, epsilon, max_ulps),
+            (None, None) => true,
+            _ => false,
+        };
+
+        from && to
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ extern crate phf;
 
 use num::{Float, ToPrimitive, NumCast};
 
+use approx::ApproxEq;
+
 use pixel::{Srgb, GammaRgb};
 
 pub use gradient::Gradient;
@@ -333,6 +335,39 @@ macro_rules! make_color {
 
             fn saturate(&self, factor: T) -> Color<T> {
                 Lch::from(*self).saturate(factor).into()
+            }
+        }
+
+        impl<T> ApproxEq for Color<T> where
+            T: Float + ApproxEq,
+            T::Epsilon: Copy + Float,
+        {
+            type Epsilon = T::Epsilon;
+
+            fn default_epsilon() -> Self::Epsilon {
+                T::default_epsilon()
+            }
+
+            fn default_max_relative() -> Self::Epsilon {
+                T::default_max_relative()
+            }
+
+            fn default_max_ulps() -> u32 {
+                T::default_max_ulps()
+            }
+
+            fn relative_eq(&self, other: &Self, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+                match (*self, *other) {
+                    $((Color::$variant(ref s), Color::$variant(ref o)) => s.relative_eq(o, epsilon, max_relative),)+
+                    _ => false
+                }
+            }
+
+            fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool{
+                match (*self, *other) {
+                    $((Color::$variant(ref s), Color::$variant(ref o)) => s.ulps_eq(o, epsilon, max_ulps),)+
+                    _ => false
+                }
             }
         }
 


### PR DESCRIPTION
#51 didn't implement `ApproxEq` for `Alpha` and `Color`, so this PR adds those implementations.