### PR TITLE
Add common color trait

### DIFF
--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -1,24 +1,28 @@
 use std::ops::{Deref, DerefMut, Add, Sub, Mul, Div};
 
-use num::Float;
+use num::{Float, One, Zero};
 
 use approx::ApproxEq;
 
-use {Mix, Shade, GetHue, Hue, Saturate, Limited, Blend, ComponentWise, clamp};
+use {Mix, Shade, GetHue, Hue, Saturate, Limited, Blend, ComponentWise, ColorType, clamp};
 use blend::PreAlpha;
 
 ///An alpha component wrapper for colors.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Alpha<C, T: Float> {
+pub struct Alpha<C: ColorType> {
     ///The color.
     pub color: C,
 
     ///The transparency component. 0.0 is fully transparent and 1.0 is fully
     ///opaque.
-    pub alpha: T,
+    pub alpha: C::Scalar,
 }
 
-impl<C, T: Float> Deref for Alpha<C, T> {
+impl<C: ColorType> ColorType for Alpha<C> {
+    type Scalar = C::Scalar;
+}
+
+impl<C: ColorType> Deref for Alpha<C> {
     type Target = C;
 
     fn deref(&self) -> &C {
@@ -26,16 +30,14 @@ impl<C, T: Float> Deref for Alpha<C, T> {
     }
 }
 
-impl<C, T: Float> DerefMut for Alpha<C, T> {
+impl<C: ColorType> DerefMut for Alpha<C> {
     fn deref_mut(&mut self) -> &mut C {
         &mut self.color
     }
 }
 
-impl<C: Mix> Mix for Alpha<C, C::Scalar> {
-    type Scalar = C::Scalar;
-    
-    fn mix(&self, other: &Alpha<C, C::Scalar>, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+impl<C: Mix> Mix for Alpha<C> {
+    fn mix(&self, other: &Alpha<C>, factor: C::Scalar) -> Alpha<C> {
         Alpha {
             color: self.color.mix(&other.color, factor),
             alpha: self.alpha + factor * (other.alpha - self.alpha),
@@ -43,10 +45,8 @@ impl<C: Mix> Mix for Alpha<C, C::Scalar> {
     }
 }
 
-impl<C: Shade> Shade for Alpha<C, C::Scalar> {
-    type Scalar = C::Scalar;
-
-    fn lighten(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+impl<C: Shade> Shade for Alpha<C> {
+    fn lighten(&self, amount: C::Scalar) -> Alpha<C> {
         Alpha {
             color: self.color.lighten(amount),
             alpha: self.alpha,
@@ -54,7 +54,7 @@ impl<C: Shade> Shade for Alpha<C, C::Scalar> {
     }
 }
 
-impl<C: GetHue, T: Float> GetHue for Alpha<C, T> {
+impl<C: GetHue + ColorType> GetHue for Alpha<C> {
     type Hue = C::Hue;
 
     fn get_hue(&self) -> Option<C::Hue> {
@@ -62,15 +62,15 @@ impl<C: GetHue, T: Float> GetHue for Alpha<C, T> {
     }
 }
 
-impl<C: Hue, T: Float> Hue for Alpha<C, T> {
-    fn with_hue(&self, hue: C::Hue) -> Alpha<C, T> {
+impl<C: Hue + ColorType> Hue for Alpha<C> {
+    fn with_hue(&self, hue: C::Hue) -> Alpha<C> {
         Alpha {
             color: self.color.with_hue(hue),
             alpha: self.alpha,
         }
     }
 
-    fn shift_hue(&self, amount: C::Hue) -> Alpha<C, T> {
+    fn shift_hue(&self, amount: C::Hue) -> Alpha<C> {
         Alpha {
             color: self.color.shift_hue(amount),
             alpha: self.alpha,
@@ -78,10 +78,8 @@ impl<C: Hue, T: Float> Hue for Alpha<C, T> {
     }
 }
 
-impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
-    type Scalar = C::Scalar;
-
-    fn saturate(&self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+impl<C: Saturate> Saturate for Alpha<C> {
+    fn saturate(&self, factor: C::Scalar) -> Alpha<C> {
         Alpha {
             color: self.color.saturate(factor),
             alpha: self.alpha,
@@ -89,50 +87,50 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
     }
 }
 
-impl<C: Limited, T: Float> Limited for Alpha<C, T> {
+impl<C: Limited + ColorType> Limited for Alpha<C> {
     fn is_valid(&self) -> bool {
-        self.color.is_valid() && self.alpha >= T::zero() && self.alpha <= T::one()
+        self.color.is_valid() && self.alpha >= C::Scalar::zero() && self.alpha <= C::Scalar::one()
     }
 
-    fn clamp(&self) -> Alpha<C, T> {
+    fn clamp(&self) -> Alpha<C> {
         Alpha {
             color: self.color.clamp(),
-            alpha: clamp(self.alpha, T::zero(), T::one()),
+            alpha: clamp(self.alpha, C::Scalar::zero(), C::Scalar::one()),
         }
     }
 
     fn clamp_self(&mut self) {
         self.color.clamp_self();
-        self.alpha = clamp(self.alpha, T::zero(), T::one());
+        self.alpha = clamp(self.alpha, C::Scalar::zero(), C::Scalar::one());
     }
 }
 
-impl<C: Blend, T: Float> Blend for Alpha<C, T> where
+impl<C, T> Blend for Alpha<C> where
+    C: Blend + ColorType<Scalar=T>,
     C::Color: ComponentWise<Scalar=T>,
-    Alpha<C, T>: Into<Alpha<C::Color, T>> + From<Alpha<C::Color, T>>,
+    Alpha<C>: Into<Alpha<C::Color>> + From<Alpha<C::Color>>,
+    T: Float,
 {
     type Color = C::Color;
 
-    fn into_premultiplied(self) -> PreAlpha<C::Color, T> {
-        PreAlpha::<C::Color, T>::from(self.into())
+    fn into_premultiplied(self) -> PreAlpha<C::Color> {
+        PreAlpha::<C::Color>::from(self.into())
     }
 
-    fn from_premultiplied(color: PreAlpha<C::Color, T>) -> Alpha<C, T> {
-        Alpha::<C::Color, T>::from(color).into()
+    fn from_premultiplied(color: PreAlpha<C::Color>) -> Alpha<C> {
+        Alpha::<C::Color>::from(color).into()
     }
 }
 
-impl<C: ComponentWise<Scalar=T>, T: Float> ComponentWise for Alpha<C, T> {
-    type Scalar = T;
-
-    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Alpha<C, T>, mut f: F) -> Alpha<C, T> {
+impl<C: ComponentWise> ComponentWise for Alpha<C> {
+    fn component_wise<F: FnMut(C::Scalar, C::Scalar) -> C::Scalar>(&self, other: &Alpha<C>, mut f: F) -> Alpha<C> {
         Alpha {
             alpha: f(self.alpha, other.alpha),
             color: self.color.component_wise(&other.color, f),
         }
     }
 
-    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Alpha<C, T> {
+    fn component_wise_self<F: FnMut(C::Scalar) -> C::Scalar>(&self, mut f: F) -> Alpha<C> {
         Alpha {
             alpha: f(self.alpha),
             color: self.color.component_wise_self(f),
@@ -140,49 +138,51 @@ impl<C: ComponentWise<Scalar=T>, T: Float> ComponentWise for Alpha<C, T> {
     }
 }
 
-impl<C: Default, T: Float> Default for Alpha<C, T> {
-    fn default() -> Alpha<C, T> {
+impl<C: Default + ColorType> Default for Alpha<C> {
+    fn default() -> Alpha<C> {
         Alpha {
             color: C::default(),
-            alpha: T::one(),
+            alpha: C::Scalar::one(),
         }
     }
 }
 
-impl<C, T> ApproxEq for Alpha<C, T> where
-    C: ApproxEq<Epsilon=T::Epsilon>,
-    T: ApproxEq + Float,
-    T::Epsilon: Copy,
+impl<C, T> ApproxEq for Alpha<C> where
+    C: ApproxEq<Epsilon=T> + ColorType<Scalar=T>,
+    T: ApproxEq<Epsilon=T> + Float,
 {
-    type Epsilon = T::Epsilon;
+    type Epsilon = T;
 
-    fn default_epsilon() -> Self::Epsilon {
-        T::default_epsilon()
+    fn default_epsilon() -> T {
+        C::Scalar::default_epsilon()
     }
 
-    fn default_max_relative() -> Self::Epsilon {
-        T::default_max_relative()
+    fn default_max_relative() -> T {
+        C::Scalar::default_max_relative()
     }
 
     fn default_max_ulps() -> u32 {
-        T::default_max_ulps()
+        C::Scalar::default_max_ulps()
     }
 
-    fn relative_eq(&self, other: &Alpha<C, T>, epsilon: Self::Epsilon, max_relative: Self::Epsilon) -> bool {
+    fn relative_eq(&self, other: &Alpha<C>, epsilon: T, max_relative: T) -> bool {
         self.color.relative_eq(&other.color, epsilon, max_relative) &&
         self.alpha.relative_eq(&other.alpha, epsilon, max_relative)
     }
 
-    fn ulps_eq(&self, other: &Alpha<C, T>, epsilon: Self::Epsilon, max_ulps: u32) -> bool{
+    fn ulps_eq(&self, other: &Alpha<C>, epsilon: T, max_ulps: u32) -> bool{
         self.color.ulps_eq(&other.color, epsilon, max_ulps) &&
         self.alpha.ulps_eq(&other.alpha, epsilon, max_ulps)
     }
 }
 
-impl<C: Add, T: Float> Add for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Add for Alpha<C> where
+    C: Add + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn add(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+    fn add(self, other: Alpha<C>) -> Alpha<C::Output> {
         Alpha {
             color: self.color + other.color,
             alpha: self.alpha + other.alpha,
@@ -190,21 +190,27 @@ impl<C: Add, T: Float> Add for Alpha<C, T> {
     }
 }
 
-impl<T: Float + Clone, C: Add<T>> Add<T> for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Add<T> for Alpha<C> where
+    C: Add<T> + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn add(self, c: T) -> Alpha<C::Output, T> {
+    fn add(self, c: C::Scalar) -> Alpha<C::Output> {
         Alpha {
-            color: self.color + c.clone(),
+            color: self.color + c,
             alpha: self.alpha + c,
         }
     }
 }
 
-impl<C: Sub, T: Float> Sub for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Sub for Alpha<C> where
+    C: Sub + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn sub(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+    fn sub(self, other: Alpha<C>) -> Alpha<C::Output> {
         Alpha {
             color: self.color - other.color,
             alpha: self.alpha - other.alpha,
@@ -212,21 +218,27 @@ impl<C: Sub, T: Float> Sub for Alpha<C, T> {
     }
 }
 
-impl<T: Float + Clone, C: Sub<T>> Sub<T> for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Sub<T> for Alpha<C> where
+    C: Sub<T> + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn sub(self, c: T) -> Alpha<C::Output, T> {
+    fn sub(self, c: C::Scalar) -> Alpha<C::Output> {
         Alpha {
-            color: self.color - c.clone(),
+            color: self.color - c,
             alpha: self.alpha - c,
         }
     }
 }
 
-impl<C: Mul, T: Float> Mul for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Mul for Alpha<C> where
+    C: Mul + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn mul(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+    fn mul(self, other: Alpha<C>) -> Alpha<C::Output> {
         Alpha {
             color: self.color * other.color,
             alpha: self.alpha * other.alpha,
@@ -234,21 +246,27 @@ impl<C: Mul, T: Float> Mul for Alpha<C, T> {
     }
 }
 
-impl<T: Float + Clone, C: Mul<T>> Mul<T> for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Mul<T> for Alpha<C> where
+    C: Mul<T> + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn mul(self, c: T) -> Alpha<C::Output, T> {
+    fn mul(self, c: C::Scalar) -> Alpha<C::Output> {
         Alpha {
-            color: self.color * c.clone(),
+            color: self.color * c,
             alpha: self.alpha * c,
         }
     }
 }
 
-impl<C: Div, T: Float> Div for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Div for Alpha<C> where
+    C: Div + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn div(self, other: Alpha<C, T>) -> Alpha<C::Output, T> {
+    fn div(self, other: Alpha<C>) -> Alpha<C::Output> {
         Alpha {
             color: self.color / other.color,
             alpha: self.alpha / other.alpha,
@@ -256,22 +274,25 @@ impl<C: Div, T: Float> Div for Alpha<C, T> {
     }
 }
 
-impl<T: Float + Clone, C: Div<T>> Div<T> for Alpha<C, T> {
-    type Output = Alpha<C::Output, T>;
+impl<C, T: Float> Div<T> for Alpha<C> where
+    C: Div<T> + ColorType<Scalar=T>,
+    C::Output: ColorType<Scalar=T>,
+{
+    type Output = Alpha<C::Output>;
 
-    fn div(self, c: T) -> Alpha<C::Output, T> {
+    fn div(self, c: C::Scalar) -> Alpha<C::Output> {
         Alpha {
-            color: self.color / c.clone(),
+            color: self.color / c,
             alpha: self.alpha / c,
         }
     }
 }
 
-impl<C, T: Float> From<C> for Alpha<C, T> {
-    fn from(color: C) -> Alpha<C, T> {
+impl<C: ColorType> From<C> for Alpha<C> {
+    fn from(color: C) -> Alpha<C> {
         Alpha {
             color: color,
-            alpha: T::one(),
+            alpha: C::Scalar::one(),
         }
     }
 }

--- a/src/blend/blend.rs
+++ b/src/blend/blend.rs
@@ -1,6 +1,6 @@
 use num::{Float, One, Zero};
 
-use {ComponentWise, clamp, flt};
+use {ComponentWise, ColorType, clamp, flt};
 use blend::{PreAlpha, BlendFunction};
 
 ///A trait for colors that can be blended together.
@@ -16,10 +16,10 @@ pub trait Blend: Sized {
     type Color: Blend<Color=Self::Color> + ComponentWise;
 
     ///Convert the color to premultiplied alpha.
-    fn into_premultiplied(self) -> PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>;
+    fn into_premultiplied(self) -> PreAlpha<Self::Color>;
 
     ///Convert the color from premultiplied alpha.
-    fn from_premultiplied(color: PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>) -> Self;
+    fn from_premultiplied(color: PreAlpha<Self::Color>) -> Self;
 
     ///Blend self, as the source color, with `destination`, using
     ///`blend_function`. Anything that implements `BlendFunction` is
@@ -29,7 +29,7 @@ pub trait Blend: Sized {
     ///use palette::{Rgb, Rgba, Blend};
     ///use palette::blend::PreAlpha;
     ///
-    ///type PreRgba = PreAlpha<Rgb<f32>, f32>;
+    ///type PreRgba = PreAlpha<Rgb<f32>>;
     ///
     ///fn blend_mode(a: PreRgba, b: PreRgba) -> PreRgba {
     ///    PreAlpha {
@@ -49,8 +49,8 @@ pub trait Blend: Sized {
     ///Place `self` over `other`. This is the good old common alpha
     ///composition equation.
     fn over(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -66,8 +66,8 @@ pub trait Blend: Sized {
     ///Results in the parts of `self` that overlaps the visible parts of
     ///`other`.
     fn inside(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -83,8 +83,8 @@ pub trait Blend: Sized {
     ///Results in the parts of `self` that lies outside the visible parts of
     ///`other`.
     fn outside(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -99,8 +99,8 @@ pub trait Blend: Sized {
 
     ///Place `self` over only the visible parts of `other`.
     fn atop(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -115,8 +115,8 @@ pub trait Blend: Sized {
 
     ///Results in either `self` or `other`, where they do not overlap.
     fn xor(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
         let two = one + one;
 
         let src = self.into_premultiplied();
@@ -134,8 +134,8 @@ pub trait Blend: Sized {
     ///Add `self` and `other`. This uses the alpha component to regulate the
     ///effect, so it's not just plain component wise addition.
     fn plus(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -151,8 +151,8 @@ pub trait Blend: Sized {
     ///Multiply `self` with `other`. This uses the alpha component to regulate
     ///the effect, so it's not just plain component wise multiplication.
     fn multiply(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -169,8 +169,8 @@ pub trait Blend: Sized {
 
     ///Make a color which is at least as light as `self` or `other`.
     fn screen(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -186,8 +186,8 @@ pub trait Blend: Sized {
     ///Multiply `self` or `other` if other is dark, or screen them if `other`
     ///is light. This results in an S curve.
     fn overlay(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
         let two = one + one;
 
         let src = self.into_premultiplied();
@@ -207,8 +207,8 @@ pub trait Blend: Sized {
 
     ///Return the darkest parts of `self` and `other`.
     fn darken(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -223,8 +223,8 @@ pub trait Blend: Sized {
 
     ///Return the lightest parts of `self` and `other`.
     fn lighten(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -240,8 +240,8 @@ pub trait Blend: Sized {
     ///Lighten `other` to reflect `self`. Results in `other` if `self` is
     ///black.
     fn dodge(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -263,8 +263,8 @@ pub trait Blend: Sized {
     ///Darken `other` to reflect `self`. Results in `other` if `self` is
     ///white.
     fn burn(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -287,8 +287,8 @@ pub trait Blend: Sized {
     ///is light. This is similar to `overlay`, but depends on `self` instead
     ///of `other`.
     fn hard_light(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
         let two = one + one;
 
         let src = self.into_premultiplied();
@@ -310,8 +310,8 @@ pub trait Blend: Sized {
     ///if `self` is dark. The effect is increased if the components of `self`
     ///is further from 0.5.
     fn soft_light(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
         let two = one + one;
 
         let src = self.into_premultiplied();
@@ -341,8 +341,8 @@ pub trait Blend: Sized {
     ///Return the absolute difference between `self` and `other`. It's
     ///basically `abs(self - other)`, but regulated by the alpha component.
     fn difference(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
         let two = one + one;
 
         let src = self.into_premultiplied();
@@ -360,8 +360,8 @@ pub trait Blend: Sized {
     ///`other` is inverted if `self` is white, and preserved if `self` is
     ///black.
     fn exclusion(self, other: Self) -> Self {
-        let one = <Self::Color as ComponentWise>::Scalar::one();
-        let zero = <Self::Color as ComponentWise>::Scalar::zero();
+        let one = <Self::Color as ColorType>::Scalar::one();
+        let zero = <Self::Color as ColorType>::Scalar::zero();
         let two = one + one;
 
         let src = self.into_premultiplied();

--- a/src/blend/mod.rs
+++ b/src/blend/mod.rs
@@ -52,14 +52,14 @@ mod test;
 ///A trait for custom blend functions.
 pub trait BlendFunction<C: Blend<Color=C> + ComponentWise> {
     ///Apply this blend function to a pair of colors.
-    fn apply_to(self, source: PreAlpha<C, C::Scalar>, destination: PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar>;
+    fn apply_to(self, source: PreAlpha<C>, destination: PreAlpha<C>) -> PreAlpha<C>;
 }
 
 impl<C, F> BlendFunction<C> for F where
     C: Blend<Color=C> + ComponentWise,
-    F: FnOnce(PreAlpha<C, C::Scalar>, PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar>,
+    F: FnOnce(PreAlpha<C>, PreAlpha<C>) -> PreAlpha<C>,
 {
-    fn apply_to(self, source: PreAlpha<C, C::Scalar>, destination: PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar> {
+    fn apply_to(self, source: PreAlpha<C>, destination: PreAlpha<C>) -> PreAlpha<C> {
         (self)(source, destination)
     }
 }

--- a/src/blend/test.rs
+++ b/src/blend/test.rs
@@ -6,7 +6,7 @@ fn blend_color() {
     let a = Color::rgb(1.0, 0.0, 0.0);
     let b = Color::rgb(0.0, 0.0, 1.0);
 
-    let c: Rgb = a.blend(b, |a: PreAlpha<Rgb<_>, _>, b: PreAlpha<Rgb<_>, _>| a.component_wise(&b, |a, b| a + b)).into();
+    let c: Rgb = a.blend(b, |a: PreAlpha<Rgb<_>>, b: PreAlpha<Rgb<_>>| a.component_wise(&b, |a, b| a + b)).into();
     assert_relative_eq!(Rgb::new(1.0, 0.0, 1.0), c);
 }
 
@@ -15,7 +15,7 @@ fn blend_alpha_color() {
     let a = Colora::rgb(1.0, 0.0, 0.0, 0.2);
     let b = Colora::rgb(0.0, 0.0, 1.0, 0.2);
 
-    let c: Rgba = a.blend(b, |a: PreAlpha<Rgb<_>, _>, b: PreAlpha<Rgb<_>, _>| a.component_wise(&b, |a, b| a + b)).into();
+    let c: Rgba = a.blend(b, |a: PreAlpha<Rgb<_>>, b: PreAlpha<Rgb<_>>| a.component_wise(&b, |a, b| a + b)).into();
     assert_relative_eq!(Rgba::new(0.2 / 0.4, 0.0, 0.2 / 0.4, 0.4), c);
 }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -156,8 +156,8 @@ macro_rules! impl_into_color {
 
 macro_rules! impl_from_trait {
     (($self_ty:ident, $into_fn: ident) => {$($other:ident),+}) => (
-        impl<T: Float> From<Alpha<$self_ty<T>, T>> for $self_ty<T> {
-            fn from(color: Alpha<$self_ty<T>, T>) -> $self_ty<T> {
+        impl<T: Float> From<Alpha<$self_ty<T>>> for $self_ty<T> {
+            fn from(color: Alpha<$self_ty<T>>) -> $self_ty<T> {
                 color.color
             }
         }
@@ -178,8 +178,8 @@ macro_rules! impl_from_trait {
             }
         }
 
-        impl<T: Float> From<Color<T>> for Alpha<$self_ty<T>,T> {
-            fn from(color: Color<T>) -> Alpha<$self_ty<T>,T> {
+        impl<T: Float> From<Color<T>> for Alpha<$self_ty<T>> {
+            fn from(color: Color<T>) -> Alpha<$self_ty<T>> {
                 Alpha {
                     color: color.into(),
                     alpha: T::one(),
@@ -187,8 +187,8 @@ macro_rules! impl_from_trait {
             }
         }
 
-        impl<T: Float> From<Alpha<Color<T>, T>> for Alpha<$self_ty<T>,T> {
-            fn from(color: Alpha<Color<T>, T>) -> Alpha<$self_ty<T>,T> {
+        impl<T: Float> From<Alpha<Color<T>>> for Alpha<$self_ty<T>> {
+            fn from(color: Alpha<Color<T>>) -> Alpha<$self_ty<T>> {
                 Alpha {
                     color: color.color.into(),
                     alpha: color.alpha,
@@ -203,8 +203,8 @@ macro_rules! impl_from_trait {
                 }
             }
 
-            impl<T: Float> From<Alpha<$other<T>, T>> for Alpha<$self_ty<T>, T> {
-                fn from(other: Alpha<$other<T>, T>) -> Alpha<$self_ty<T>, T> {
+            impl<T: Float> From<Alpha<$other<T>>> for Alpha<$self_ty<T>> {
+                fn from(other: Alpha<$other<T>>) -> Alpha<$self_ty<T>> {
                     Alpha {
                         color: other.color.$into_fn(),
                         alpha: other.alpha,
@@ -212,8 +212,8 @@ macro_rules! impl_from_trait {
                 }
             }
 
-            impl<T: Float> From<$other<T>> for Alpha<$self_ty<T>, T> {
-                fn from(color: $other<T>) -> Alpha<$self_ty<T>, T> {
+            impl<T: Float> From<$other<T>> for Alpha<$self_ty<T>> {
+                fn from(color: $other<T>) -> Alpha<$self_ty<T>> {
                     Alpha {
                         color: color.$into_fn(),
                         alpha: T::one(),
@@ -221,8 +221,8 @@ macro_rules! impl_from_trait {
                 }
             }
 
-            impl<T: Float> From<Alpha<$other<T>, T>> for $self_ty<T> {
-                fn from(other: Alpha<$other<T>, T>) -> $self_ty<T> {
+            impl<T: Float> From<Alpha<$other<T>>> for $self_ty<T> {
+                fn from(other: Alpha<$other<T>>) -> $self_ty<T> {
                     other.color.$into_fn()
                 }
             }

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -3,9 +3,10 @@ use num::Float;
 use std::ops::{Add, Sub};
 
 use {Alpha, Rgb, Xyz, Hsv, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, FromColor, IntoColor, clamp, flt};
+use ColorType;
 
 ///Linear HSL with an alpha component. See the [`Hsla` implementation in `Alpha`](struct.Alpha.html#Hsla).
-pub type Hsla<T = f32> = Alpha<Hsl<T>, T>;
+pub type Hsla<T = f32> = Alpha<Hsl<T>>;
 
 ///Linear HSL color space.
 ///
@@ -44,7 +45,7 @@ impl<T: Float> Hsl<T> {
 }
 
 ///<span id="Hsla"></span>[`Hsla`](type.Hsla.html) implementations.
-impl<T: Float> Alpha<Hsl<T>, T> {
+impl<T: Float> Alpha<Hsl<T>> {
     ///Linear HSL and transparency.
     pub fn new(hue: RgbHue<T>, saturation: T, lightness: T, alpha: T) -> Hsla<T> {
         Alpha {
@@ -52,6 +53,10 @@ impl<T: Float> Alpha<Hsl<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Hsl<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Hsl<T> {
@@ -136,8 +141,6 @@ impl<T: Float> Limited for Hsl<T> {
 }
 
 impl<T: Float> Mix for Hsl<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Hsl<T>, factor: T) -> Hsl<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
@@ -151,8 +154,6 @@ impl<T: Float> Mix for Hsl<T> {
 }
 
 impl<T: Float> Shade for Hsl<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Hsl<T> {
         Hsl {
             hue: self.hue,
@@ -193,8 +194,6 @@ impl<T: Float> Hue for Hsl<T> {
 }
 
 impl<T: Float> Saturate for Hsl<T> {
-    type Scalar = T;
-
     fn saturate(&self, factor: T) -> Hsl<T> {
         Hsl {
             hue: self.hue,

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -3,9 +3,10 @@ use num::Float;
 use std::ops::{Add, Sub};
 
 use {Alpha, Rgb, Xyz, Hsl, Hwb, Limited, Mix, Shade, GetHue, Hue, Saturate, RgbHue, FromColor, clamp, flt};
+use ColorType;
 
 ///Linear HSV with an alpha component. See the [`Hsva` implementation in `Alpha`](struct.Alpha.html#Hsva).
-pub type Hsva<T = f32> = Alpha<Hsv<T>, T>;
+pub type Hsva<T = f32> = Alpha<Hsv<T>>;
 
 ///Linear HSV color space.
 ///
@@ -43,7 +44,7 @@ impl<T: Float> Hsv<T> {
 }
 
 ///<span id="Hsva"></span>[`Hsva`](type.Hsva.html) implementations.
-impl<T: Float> Alpha<Hsv<T>, T> {
+impl<T: Float> Alpha<Hsv<T>> {
     ///Linear HSV and transparency.
     pub fn new(hue: RgbHue<T>, saturation: T, value: T, alpha: T) -> Hsva<T> {
         Alpha {
@@ -51,6 +52,10 @@ impl<T: Float> Alpha<Hsv<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Hsv<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Hsv<T> {
@@ -151,8 +156,6 @@ impl<T: Float> Limited for Hsv<T> {
 }
 
 impl<T: Float> Mix for Hsv<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Hsv<T>, factor: T) -> Hsv<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
@@ -166,8 +169,6 @@ impl<T: Float> Mix for Hsv<T> {
 }
 
 impl<T: Float> Shade for Hsv<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Hsv<T> {
         Hsv {
             hue: self.hue,
@@ -208,8 +209,6 @@ impl<T: Float> Hue for Hsv<T> {
 }
 
 impl<T: Float> Saturate for Hsv<T> {
-    type Scalar = T;
-
     fn saturate(&self, factor: T) -> Hsv<T> {
         Hsv {
             hue: self.hue,

--- a/src/hwb.rs
+++ b/src/hwb.rs
@@ -3,9 +3,10 @@ use num::Float;
 use std::ops::{Add, Sub};
 
 use {Alpha, Xyz, Hsv, Limited, Mix, Shade, GetHue, Hue, RgbHue, FromColor, clamp};
+use ColorType;
 
 ///Linear HWB with an alpha component. See the [`Hwba` implementation in `Alpha`](struct.Alpha.html#Hwba).
-pub type Hwba<T = f32> = Alpha<Hwb<T>, T>;
+pub type Hwba<T = f32> = Alpha<Hwb<T>>;
 
 ///Linear HWB color space.
 ///
@@ -45,7 +46,7 @@ impl<T: Float> Hwb<T> {
 }
 
 ///<span id="Hwba"></span>[`Hwba`](type.Hwba.html) implementations.
-impl<T: Float> Alpha<Hwb<T>, T> {
+impl<T: Float> Alpha<Hwb<T>> {
     ///Linear HSV and transparency.
     pub fn new(hue: RgbHue<T>, whiteness: T, blackness: T, alpha: T) -> Hwba<T> {
         Alpha {
@@ -53,6 +54,10 @@ impl<T: Float> Alpha<Hwb<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Hwb<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Hwb<T> {
@@ -100,8 +105,6 @@ impl<T: Float> Limited for Hwb<T> {
 }
 
 impl<T: Float> Mix for Hwb<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Hwb<T>, factor: T) -> Hwb<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
@@ -115,8 +118,6 @@ impl<T: Float> Mix for Hwb<T> {
 }
 
 impl<T: Float> Shade for Hwb<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Hwb<T> {
         Hwb {
             hue: self.hue,

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -3,13 +3,13 @@ use num::Float;
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Alpha, Xyz, Lch, LabHue};
-use {Limited, Mix, Shade, GetHue, FromColor, ComponentWise};
+use {Limited, Mix, Shade, GetHue, FromColor, ComponentWise, ColorType};
 use {clamp, flt};
 
 use tristimulus::{X_N, Y_N, Z_N};
 
 ///CIE L*a*b* (CIELAB) with an alpha component. See the [`Laba` implementation in `Alpha`](struct.Alpha.html#Laba).
-pub type Laba<T = f32> = Alpha<Lab<T>, T>;
+pub type Laba<T = f32> = Alpha<Lab<T>>;
 
 ///The CIE L*a*b* (CIELAB) color space.
 ///
@@ -47,7 +47,7 @@ impl<T: Float> Lab<T> {
 }
 
 ///<span id="Laba"></span>[`Laba`](type.Laba.html) implementations.
-impl<T: Float> Alpha<Lab<T>, T> {
+impl<T: Float> Alpha<Lab<T>> {
     ///CIE L*a*b* and transparency.
     pub fn new(l: T, a: T, b: T, alpha: T) -> Laba<T> {
         Alpha {
@@ -55,6 +55,10 @@ impl<T: Float> Alpha<Lab<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Lab<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Lab<T> {
@@ -121,8 +125,6 @@ impl<T: Float> Limited for Lab<T> {
 }
 
 impl<T: Float> Mix for Lab<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Lab<T>, factor: T) -> Lab<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -135,8 +137,6 @@ impl<T: Float> Mix for Lab<T> {
 }
 
 impl<T: Float> Shade for Lab<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Lab<T> {
         Lab {
             l: self.l + amount,
@@ -159,8 +159,6 @@ impl<T: Float> GetHue for Lab<T> {
 }
 
 impl<T: Float> ComponentWise for Lab<T> {
-    type Scalar = T;
-
     fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Lab<T>, mut f: F) -> Lab<T> {
         Lab {
             l: f(self.l, other.l),

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -3,9 +3,10 @@ use num::Float;
 use std::ops::{Add, Sub};
 
 use {Alpha, Limited, Mix, Shade, GetHue, FromColor, IntoColor, Hue, Xyz, Lab, Saturate, LabHue, clamp};
+use ColorType;
 
 ///CIE L*C*h° with an alpha component. See the [`Lcha` implementation in `Alpha`](struct.Alpha.html#Lcha).
-pub type Lcha<T = f32> = Alpha<Lch<T>, T>;
+pub type Lcha<T = f32> = Alpha<Lch<T>>;
 
 ///CIE L*C*h°, a polar version of [CIE L*a*b*](struct.Lab.html).
 ///
@@ -42,7 +43,7 @@ impl<T: Float> Lch<T> {
 }
 
 ///<span id="Lcha"></span>[`Lcha`](type.Lcha.html) implementations.
-impl<T: Float> Alpha<Lch<T>, T> {
+impl<T: Float> Alpha<Lch<T>> {
     ///CIE L*C*h° and transparency.
     pub fn new(l: T, chroma: T, hue: LabHue<T>, alpha: T) -> Lcha<T> {
         Alpha {
@@ -50,6 +51,10 @@ impl<T: Float> Alpha<Lch<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Lch<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Lch<T> {
@@ -91,8 +96,6 @@ impl<T: Float> Limited for Lch<T> {
 }
 
 impl<T: Float> Mix for Lch<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Lch<T>, factor: T) -> Lch<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
@@ -105,8 +108,6 @@ impl<T: Float> Mix for Lch<T> {
 }
 
 impl<T: Float> Shade for Lch<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Lch<T> {
         Lch {
             l: self.l + amount,
@@ -147,8 +148,6 @@ impl<T: Float> Hue for Lch<T> {
 }
 
 impl<T: Float> Saturate for Lch<T> {
-    type Scalar = T;
-
     fn saturate(&self, factor: T) -> Lch<T> {
         Lch {
             l: self.l,

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -3,12 +3,12 @@ use num::Float;
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Alpha, Rgb, Xyz, Yxy};
-use {Limited, Mix, Shade, FromColor, Blend, ComponentWise};
+use {Limited, Mix, Shade, FromColor, Blend, ComponentWise, ColorType};
 use {clamp, flt};
 use blend::PreAlpha;
 
 ///Linear luminance with an alpha component. See the [`Lumaa` implementation in `Alpha`](struct.Alpha.html#Lumaa).
-pub type Lumaa<T = f32> = Alpha<Luma<T>, T>;
+pub type Lumaa<T = f32> = Alpha<Luma<T>>;
 
 ///Linear luminance.
 ///
@@ -40,7 +40,7 @@ impl<T: Float> Luma<T> {
 }
 
 ///<span id="Lumaa"></span>[`Lumaa`](type.Lumaa.html) implementations.
-impl<T: Float> Alpha<Luma<T>, T> {
+impl<T: Float> Alpha<Luma<T>> {
     ///Linear luminance with transparency.
     pub fn new(luma: T, alpha: T) -> Lumaa<T> {
         Alpha {
@@ -56,6 +56,10 @@ impl<T: Float> Alpha<Luma<T>, T> {
             alpha: flt::<T,_>(alpha) / flt(255.0),
         }
     }
+}
+
+impl<T: Float> ColorType for Luma<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Luma<T> {
@@ -100,8 +104,6 @@ impl<T: Float> Limited for Luma<T> {
 }
 
 impl<T: Float> Mix for Luma<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Luma<T>, factor: T) -> Luma<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -112,8 +114,6 @@ impl<T: Float> Mix for Luma<T> {
 }
 
 impl<T: Float> Shade for Luma<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Luma<T> {
         Luma {
             luma: (self.luma + amount).max(T::zero()),
@@ -124,18 +124,16 @@ impl<T: Float> Shade for Luma<T> {
 impl<T: Float> Blend for Luma<T> {
     type Color = Luma<T>;
 
-    fn into_premultiplied(self) -> PreAlpha<Luma<T>, T> {
+    fn into_premultiplied(self) -> PreAlpha<Luma<T>> {
         Lumaa::from(self).into()
     }
 
-    fn from_premultiplied(color: PreAlpha<Luma<T>, T>) -> Self {
+    fn from_premultiplied(color: PreAlpha<Luma<T>>) -> Self {
         Lumaa::from(color).into()
     }
 }
 
 impl<T: Float> ComponentWise for Luma<T> {
-    type Scalar = T;
-
     fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Luma<T>, mut f: F) -> Luma<T> {
         Luma {
             luma: f(self.luma, other.luma),

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -3,13 +3,13 @@ use num::Float;
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Alpha, Luma, Xyz, Hsv, Hsl, RgbHue};
-use {Limited, Mix, Shade, GetHue, FromColor, Blend, ComponentWise};
+use {Limited, Mix, Shade, GetHue, FromColor, Blend, ComponentWise, ColorType};
 use {clamp, flt};
 use pixel::{RgbPixel, Srgb, GammaRgb};
 use blend::PreAlpha;
 
 ///Linear RGB with an alpha component. See the [`Rgba` implementation in `Alpha`](struct.Alpha.html#Rgba).
-pub type Rgba<T = f32> = Alpha<Rgb<T>, T>;
+pub type Rgba<T = f32> = Alpha<Rgb<T>>;
 
 ///Linear RGB.
 ///
@@ -84,7 +84,7 @@ impl<T: Float> Rgb<T> {
 }
 
 ///<span id="Rgba"></span>[`Rgba`](type.Rgba.html) implementations.
-impl<T: Float> Alpha<Rgb<T>, T> {
+impl<T: Float> Alpha<Rgb<T>> {
     ///Linear RGB with transparency.
     pub fn new(red: T, green: T, blue: T, alpha: T) -> Rgba<T> {
         Alpha {
@@ -125,6 +125,10 @@ impl<T: Float> Alpha<Rgb<T>, T> {
             clamp(self.alpha, T::zero(), T::one())
         )
     }
+}
+
+impl<T: Float> ColorType for Rgb<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Rgb<T> {
@@ -229,8 +233,6 @@ impl<T: Float> Limited for Rgb<T> {
 }
 
 impl<T: Float> Mix for Rgb<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Rgb<T>, factor: T) -> Rgb<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -243,8 +245,6 @@ impl<T: Float> Mix for Rgb<T> {
 }
 
 impl<T: Float> Shade for Rgb<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Rgb<T> {
         Rgb {
             red: self.red + amount,
@@ -271,18 +271,16 @@ impl<T: Float> GetHue for Rgb<T> {
 impl<T: Float> Blend for Rgb<T> {
     type Color = Rgb<T>;
 
-    fn into_premultiplied(self) -> PreAlpha<Rgb<T>, T> {
+    fn into_premultiplied(self) -> PreAlpha<Rgb<T>> {
         Rgba::from(self).into()
     }
 
-    fn from_premultiplied(color: PreAlpha<Rgb<T>, T>) -> Self {
+    fn from_premultiplied(color: PreAlpha<Rgb<T>>) -> Self {
         Rgba::from(color).into()
     }
 }
 
 impl<T: Float> ComponentWise for Rgb<T> {
-    type Scalar = T;
-
     fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Rgb<T>, mut f: F) -> Rgb<T> {
         Rgb {
             red: f(self.red, other.red),
@@ -414,14 +412,14 @@ impl<T: Float> From<GammaRgb<T>> for Rgb<T> {
     }
 }
 
-impl<T: Float> From<Srgb<T>> for Alpha<Rgb<T>, T> {
-    fn from(srgb: Srgb<T>) -> Alpha<Rgb<T>, T> {
+impl<T: Float> From<Srgb<T>> for Alpha<Rgb<T>> {
+    fn from(srgb: Srgb<T>) -> Alpha<Rgb<T>> {
         srgb.to_linear()
     }
 }
 
-impl<T: Float> From<GammaRgb<T>> for Alpha<Rgb<T>, T> {
-    fn from(gamma_rgb: GammaRgb<T>) -> Alpha<Rgb<T>, T> {
+impl<T: Float> From<GammaRgb<T>> for Alpha<Rgb<T>> {
+    fn from(gamma_rgb: GammaRgb<T>) -> Alpha<Rgb<T>> {
         gamma_rgb.to_linear()
     }
 }

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -3,13 +3,13 @@ use num::Float;
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Alpha, Yxy, Rgb, Luma, Lab};
-use {Limited, Mix, Shade, FromColor, ComponentWise};
+use {Limited, Mix, Shade, FromColor, ComponentWise, ColorType};
 use {clamp, flt};
 
 use tristimulus::{X_N, Y_N, Z_N};
 
 ///CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in `Alpha`](struct.Alpha.html#Xyza).
-pub type Xyza<T = f32> = Alpha<Xyz<T>, T>;
+pub type Xyza<T = f32> = Alpha<Xyz<T>>;
 
 ///The CIE 1931 XYZ color space.
 ///
@@ -47,7 +47,7 @@ impl<T: Float> Xyz<T> {
 }
 
 ///<span id="Xyza"></span>[`Xyza`](type.Xyza.html) implementations.
-impl<T: Float> Alpha<Xyz<T>, T> {
+impl<T: Float> Alpha<Xyz<T>> {
     ///CIE XYZ and transparency.
     pub fn new(x: T, y: T, z: T, alpha: T) -> Xyza<T> {
         Alpha {
@@ -55,6 +55,10 @@ impl<T: Float> Alpha<Xyz<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Xyz<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Xyz<T> {
@@ -139,8 +143,6 @@ impl<T: Float> Limited for Xyz<T> {
 }
 
 impl<T: Float> Mix for Xyz<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Xyz<T>, factor: T) -> Xyz<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -153,8 +155,6 @@ impl<T: Float> Mix for Xyz<T> {
 }
 
 impl<T: Float> Shade for Xyz<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Xyz<T> {
         Xyz {
             x: self.x,
@@ -165,8 +165,6 @@ impl<T: Float> Shade for Xyz<T> {
 }
 
 impl<T: Float> ComponentWise for Xyz<T> {
-    type Scalar = T;
-
     fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Xyz<T>, mut f: F) -> Xyz<T> {
         Xyz {
             x: f(self.x, other.x),

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -3,14 +3,14 @@ use num::Float;
 use std::ops::{Add, Sub, Mul, Div};
 
 use {Alpha, Luma, Xyz};
-use {Limited, Mix, Shade, FromColor, ComponentWise};
+use {Limited, Mix, Shade, FromColor, ComponentWise, ColorType};
 use {clamp, flt};
 
 const D65_X: f64 = 0.312727;
 const D65_Y: f64 = 0.329023;
 
 ///CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation in `Alpha`](struct.Alpha.html#Yxya).
-pub type Yxya<T = f32> = Alpha<Yxy<T>, T>;
+pub type Yxya<T = f32> = Alpha<Yxy<T>>;
 
 ///The CIE 1931 Yxy (xyY)  color space.
 ///
@@ -50,7 +50,7 @@ impl<T: Float> Yxy<T> {
 }
 
 ///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
-impl<T: Float> Alpha<Yxy<T>, T> {
+impl<T: Float> Alpha<Yxy<T>> {
     ///CIE Yxy and transparency.
     pub fn new(x: T, y: T, luma: T, alpha: T) -> Yxya<T> {
         Alpha {
@@ -58,6 +58,10 @@ impl<T: Float> Alpha<Yxy<T>, T> {
             alpha: alpha,
         }
     }
+}
+
+impl<T: Float> ColorType for Yxy<T> {
+    type Scalar = T;
 }
 
 impl<T: Float> FromColor<T> for Yxy<T> {
@@ -104,8 +108,6 @@ impl<T: Float> Limited for Yxy<T> {
 }
 
 impl<T: Float> Mix for Yxy<T> {
-    type Scalar = T;
-
     fn mix(&self, other: &Yxy<T>, factor: T) -> Yxy<T> {
         let factor = clamp(factor, T::zero(), T::one());
 
@@ -118,8 +120,6 @@ impl<T: Float> Mix for Yxy<T> {
 }
 
 impl<T: Float> Shade for Yxy<T> {
-    type Scalar = T;
-
     fn lighten(&self, amount: T) -> Yxy<T> {
         Yxy {
             x: self.x,
@@ -130,8 +130,6 @@ impl<T: Float> Shade for Yxy<T> {
 }
 
 impl<T: Float> ComponentWise for Yxy<T> {
-    type Scalar = T;
-
     fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Yxy<T>, mut f: F) -> Yxy<T> {
         Yxy {
             x: f(self.x, other.x),


### PR DESCRIPTION
Add a common trait for all of the color types, which defines the most basic properties. Its current purpose is to provide the component scalar type, but it could also include other information in the future (such as the white point). The reason for doing this at all is that it removes the need for associated scalar types in operation traits, as well as the need for the additional `T` type parameter on `Alpha` and `PreAlpha`.

This is a very breaking change. It removes the `Scalar` type from a number of traits, and removes the `T` type parameter from `Alpha` and `PreAlpha`. An unfortunate side effect is that I had to define `ApproxEq::Epsilon` for `Alpha` and `PreAlpha` to be the same as the scalar type, instead of using the `Epsilon` of the scalar type. It will probably not matter, but it's still less generic.
