### PR TITLE
Make color spaces white point aware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.7"
 optional = true
 
 [dev-dependencies]
-image = "0.4"
+image = "0.7"
 clap = "1"
 csv = "0.14"
 rustc-serialize  = "0.3"

--- a/examples/readme_examples.rs
+++ b/examples/readme_examples.rs
@@ -6,6 +6,7 @@ use image::{RgbImage, GenericImage};
 
 use palette::{Rgba, Gradient, Mix};
 use palette::pixel::Srgb;
+use palette::white_point::D65;
 
 mod color_spaces {
     use palette::{Rgb, Lch, Hue};
@@ -75,8 +76,8 @@ fn display_colors(filename: &str, colors: &[[u8; 3]]) {
 }
 
 fn display_gradients<A: Mix<Scalar=f64> + Clone, B: Mix<Scalar=f64> + Clone>(filename: &str, grad1: Gradient<A>, grad2: Gradient<B>) where
-    Rgba<f64>: From<A>,
-    Rgba<f64>: From<B>,
+    Rgba<D65, f64>: From<A>,
+    Rgba<D65, f64>: From<B>,
 {
     let mut image = RgbImage::new(256, 64);
 

--- a/src/blend/blend.rs
+++ b/src/blend/blend.rs
@@ -28,8 +28,9 @@ pub trait Blend: Sized {
     ///```
     ///use palette::{Rgb, Rgba, Blend};
     ///use palette::blend::PreAlpha;
+    ///use palette::white_point::D65;
     ///
-    ///type PreRgba = PreAlpha<Rgb<f32>, f32>;
+    ///type PreRgba = PreAlpha<Rgb<D65, f32>, f32>;
     ///
     ///fn blend_mode(a: PreRgba, b: PreRgba) -> PreRgba {
     ///    PreAlpha {
@@ -326,7 +327,7 @@ pub trait Blend: Sized {
                 } else if b * flt(4.0) <= dst.alpha {
                     let m2 = m * m;
                     let m3 = m2 * m;
-                    
+
                     dst.alpha * (two * a - src.alpha) * (m3 * flt(16.0) - m2 * flt(12.0) - m * flt(3.0)) + a - a * dst.alpha + b
                 } else {
                     dst.alpha * (two * a - src.alpha) * (m.sqrt() - m) + a - a * dst.alpha + b

--- a/src/chromatic_adaptation.rs
+++ b/src/chromatic_adaptation.rs
@@ -1,0 +1,261 @@
+//!Convert colors from one reference white point to another
+//!
+//!Chromatic adaptation is the human visual system’s ability to adjust to changes
+//!in illumination in order to preserve the appearance of object colors. It is responsible
+//!for the stable appearance of object colours despite the wide variation of light which
+//!might be reflected from an object and observed by our eyes.
+//!
+//!This library provides three methods for chromatic adaptation Bradford (which is the default),
+//!VonKries and XyzScaling
+//!
+//!```
+//!use palette::Xyz;
+//!use palette::white_point::{A, C};
+//!use palette::chromatic_adaptation::AdaptInto;
+//!
+//!
+//!let a = Xyz::<A, f32>::with_wp(0.315756, 0.162732, 0.015905);
+//!
+//!//Will convert Xyz<A, f32> to Xyz<C, f32> using Bradford chromatic adaptation
+//!let c: Xyz<C, f32> = a.adapt_into();
+//!
+//!//Should print {x: 0.257963, y: 0.139776,z: 0.058825}
+//!println!("{:?}", c)
+//!```
+use num::Float;
+
+use {Xyz, FromColor, IntoColor, flt};
+use white_point::WhitePoint;
+use matrix::{Mat3, multiply_xyz, multiply_3x3};
+
+
+///Chromatic adaptation methods implemented in the library
+pub enum  Method {
+    ///Bradford chromatic adaptation method
+    Bradford,
+    ///VonKries chromatic adaptation method
+    VonKries,
+    ///XyzScaling chromatic adaptation method
+    XyzScaling,
+}
+
+///Holds the matrix coeffecients for the chromatic adaptation methods
+pub struct ConeResponseMatrices<T: Float> {
+    ///3x3 matrix for the cone response domains
+    pub ma: Mat3<T>,
+    ///3x3 matrix for the inverse of the cone response domains
+    pub inv_ma: Mat3<T>,
+}
+
+///Generates a conversion matrix to convert the Xyz trisitmilus values from
+///one illuminant to another (Swp -> Dwp)
+pub trait TransformMatrix<Swp, Dwp, T>
+    where T: Float,
+        Swp: WhitePoint<T>,
+        Dwp: WhitePoint<T>,
+{
+    ///Get the cone response functions for the chromatic adaptation method
+    fn get_cone_response(&self) -> ConeResponseMatrices<T>;
+
+    ///Generates a 3x3 transformation matrix to convert color from one reference white point
+    ///to another with the given cone_response
+    fn generate_transform_matrix(&self) -> Mat3<T> {
+        let s_wp = Swp::get_xyz();
+        let t_wp = Dwp::get_xyz();
+        let adapt = self.get_cone_response();
+
+        let resp_src: Xyz<Swp,_> = multiply_xyz(&adapt.ma, &s_wp);
+        let resp_dst: Xyz<Dwp,_> = multiply_xyz(&adapt.ma, &t_wp);
+        let z = T::zero();
+        let resp = [resp_dst.x/resp_src.x, z , z , z, resp_dst.y/resp_src.y, z, z, z, resp_dst.z/ resp_src.z];
+
+        let tmp = multiply_3x3(&resp, &adapt.ma);
+        multiply_3x3(&adapt.inv_ma, &tmp)
+    }
+}
+
+
+impl<Swp, Dwp, T> TransformMatrix<Swp, Dwp, T> for Method
+    where T: Float,
+        Swp: WhitePoint<T>,
+        Dwp: WhitePoint<T>,
+{
+    fn get_cone_response(&self) -> ConeResponseMatrices<T> {
+        match *self {
+             Method::Bradford => {
+                ConeResponseMatrices::<T> {
+                    ma: [flt(0.8951000), flt(0.2664000), flt(-0.1614000),
+                         flt(-0.7502000), flt(1.7135000), flt(0.0367000),
+                         flt(0.0389000), flt(-0.0685000), flt(1.0296000)
+                         ],
+                    inv_ma: [flt(0.9869929), flt(-0.1470543), flt(0.1599627),
+                             flt(0.4323053), flt(0.5183603), flt(0.0492912),
+                             flt(-0.0085287), flt(0.0400428), flt(0.9684867)
+                            ],
+                }
+            }
+             Method::VonKries => {
+                ConeResponseMatrices::<T> {
+                    ma: [flt(0.4002400), flt(0.7076000), flt(-0.0808100),
+                         flt(-0.2263000), flt(1.1653200), flt(0.0457000),
+                         flt(0.0000000), flt(0.0000000), flt(0.9182200)
+                         ],
+                    inv_ma: [flt(1.8599364), flt(-1.1293816), flt(0.2198974),
+                             flt(0.3611914), flt(0.6388125), flt(-0.0000064),
+                             flt(0.0000000), flt(0.0000000), flt(1.0890636)
+                             ],
+                }
+            }
+             Method::XyzScaling => {
+                ConeResponseMatrices::<T> {
+                    ma: [flt(1.0000000), flt(0.0000000), flt(0.0000000),
+                         flt(0.0000000), flt(1.0000000), flt(0.0000000),
+                         flt(0.0000000), flt(0.0000000), flt(1.0000000)
+                         ],
+                    inv_ma: [flt(1.0000000), flt(0.0000000), flt(0.0000000),
+                             flt(0.0000000), flt(1.0000000), flt(0.0000000),
+                             flt(0.0000000), flt(0.0000000), flt(1.0000000)
+                             ],
+                }
+            }
+        }
+    }
+}
+
+
+///Trait to convert color from one reference white point to another
+///
+///Converts a color from the source white point (Swp) to the destination white point (Dwp).
+///Uses the bradford method for conversion by default.
+pub trait AdaptFrom<S, Swp, Dwp, T>: Sized
+    where T: Float,
+          Swp: WhitePoint<T>,
+          Dwp: WhitePoint<T>,
+{
+    ///Convert the source color to the destination color using the bradford method by default
+    fn adapt_from(color: S) -> Self {
+        Self::adapt_from_using(color, Method::Bradford)
+    }
+    ///Convert the source color to the destination color using the specified method
+    fn adapt_from_using<M: TransformMatrix<Swp, Dwp, T>>(color: S, method: M) -> Self;
+}
+
+impl<S, D, Swp, Dwp, T> AdaptFrom<S, Swp, Dwp, T> for D
+    where T: Float,
+          Swp: WhitePoint<T>,
+          Dwp: WhitePoint<T>,
+          S: IntoColor<Swp, T>,
+          D: FromColor<Dwp, T>,
+
+{
+    fn adapt_from_using<M: TransformMatrix<Swp, Dwp, T>>(color:S, method: M) -> D {
+        let src_xyz: Xyz<Swp, T> = color.into_xyz();
+        let transform_matrix = method.generate_transform_matrix();
+        let dst_xyz: Xyz<Dwp, T> = multiply_xyz(&transform_matrix, &src_xyz);
+        D::from_xyz(dst_xyz)
+    }
+}
+
+///Trait to convert color with one reference white point into another
+///
+///Converts a color with the source white point (Swp) into the destination white point (Dwp).
+///Uses the bradford method for conversion by default.
+pub trait AdaptInto<D, Swp, Dwp, T>: Sized
+    where T: Float,
+          Swp: WhitePoint<T>,
+          Dwp: WhitePoint<T>,
+{
+    ///Convert the source color to the destination color using the bradford method by default
+    fn adapt_into(self) -> D {
+        self.adapt_into_using(Method::Bradford)
+    }
+    ///Convert the source color to the destination color using the specified method
+    fn adapt_into_using<M: TransformMatrix<Swp, Dwp, T>>(self, method: M) -> D;
+}
+
+impl<S, D, Swp, Dwp, T> AdaptInto<D, Swp, Dwp, T> for S
+    where T: Float,
+          Swp: WhitePoint<T>,
+          Dwp: WhitePoint<T>,
+          D: AdaptFrom<S, Swp, Dwp, T>
+
+{
+    fn adapt_into_using<M: TransformMatrix<Swp, Dwp, T>>(self, method: M) -> D {
+        D::adapt_from_using(self, method)
+    }
+}
+
+
+
+
+#[cfg(test)]
+mod test {
+
+    use {Xyz};
+    use white_point::{D65, D50, A, C};
+    use super::{Method, TransformMatrix, AdaptInto, AdaptFrom};
+
+    #[test]
+    fn d65_to_d50_matrix_xyz_scaling() {
+        let expected = [1.0144665, 0.0000000, 0.0000000, 0.0000000, 1.0000000, 0.0000000, 0.0000000, 0.0000000, 0.7578869];
+        let xyz_scaling =  Method::XyzScaling;
+        let computed = <TransformMatrix<D65, D50, _>>::generate_transform_matrix(&xyz_scaling);
+        for (e, c) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(e, c, epsilon = 0.0001)
+        }
+    }
+    #[test]
+    fn d65_to_d50_matrix_von_kries() {
+        let expected = [1.0160803, 0.0552297, -0.0521326, 0.0060666, 0.9955661, -0.0012235, 0.0000000, 0.0000000, 0.7578869];
+        let von_kries =  Method::VonKries;
+        let computed = <TransformMatrix<D65, D50, _>>::generate_transform_matrix(&von_kries);
+        for (e, c) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(e, c, epsilon = 0.0001)
+        }
+    }
+    #[test]
+    fn d65_to_d50_matrix_bradford() {
+        let expected = [1.0478112, 0.0228866, -0.0501270, 0.0295424, 0.9904844, -0.0170491, -0.0092345, 0.0150436, 0.7521316];
+        let bradford =  Method::Bradford;
+        let computed = <TransformMatrix<D65, D50, _>>::generate_transform_matrix(&bradford);
+        for (e, c) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(e, c, epsilon = 0.0001)
+        }
+    }
+
+    #[test]
+    fn chromatic_adaptation_from_a_to_c() {
+        let input_a = Xyz::<A, f32>::with_wp(0.315756, 0.162732, 0.015905);
+
+        let expected_bradford = Xyz::<C, f32>::with_wp(0.257963, 0.139776, 0.058825);
+        let expected_vonkries = Xyz::<C, f32>::with_wp(0.268446, 0.159139, 0.052843);
+        let expected_xyz_scaling = Xyz::<C, f32>::with_wp(0.281868, 0.162732, 0.052844);
+
+        let computed_bradford: Xyz<C, f32> = Xyz::adapt_from(input_a);
+        assert_relative_eq!(expected_bradford, computed_bradford, epsilon = 0.0001);
+
+        let computed_vonkries: Xyz<C, f32> = Xyz::adapt_from_using(input_a, Method::VonKries);
+        assert_relative_eq!(expected_vonkries, computed_vonkries, epsilon = 0.0001);
+
+        let computed_xyz_scaling: Xyz<C,_> = Xyz::adapt_from_using(input_a, Method::XyzScaling);
+        assert_relative_eq!(expected_xyz_scaling, computed_xyz_scaling, epsilon = 0.0001);
+    }
+
+    #[test]
+    fn chromatic_adaptation_into_a_to_c() {
+        let input_a = Xyz::<A, f32>::with_wp(0.315756, 0.162732, 0.015905);
+
+        let expected_bradford = Xyz::<C, f32>::with_wp(0.257963, 0.139776, 0.058825);
+        let expected_vonkries = Xyz::<C, f32>::with_wp(0.268446, 0.159139, 0.052843);
+        let expected_xyz_scaling = Xyz::<C, f32>::with_wp(0.281868, 0.162732, 0.052844);
+
+        let computed_bradford: Xyz<C, f32> = input_a.adapt_into();
+        assert_relative_eq!(expected_bradford, computed_bradford, epsilon = 0.0001);
+
+        let computed_vonkries: Xyz<C, f32> = input_a.adapt_into_using(Method::VonKries);
+        assert_relative_eq!(expected_vonkries, computed_vonkries, epsilon = 0.0001);
+
+        let computed_xyz_scaling: Xyz<C,_> = input_a.adapt_into_using(Method::XyzScaling);
+        assert_relative_eq!(expected_xyz_scaling, computed_xyz_scaling, epsilon = 0.0001);
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,6 +1,7 @@
 use num::Float;
 
 use {Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hwb, Hsl, Color};
+use white_point::{WhitePoint, D65};
 
 ///FromColor provides conversion between the colors.
 ///
@@ -10,49 +11,50 @@ use {Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hwb, Hsl, Color};
 ///from_luma for Rgb is implemented directly. The from for the same color must override
 ///the default. For example, from_rgb for Rgb will convert via Xyz which needs to be overridden
 ///with self to avoid the unnecessary converison.
-pub trait FromColor<T>: Sized
+pub trait FromColor<Wp = D65, T = f32>: Sized
     where T: Float,
+        Wp: WhitePoint<T>
 {
     ///Convert from XYZ color space
-    fn from_xyz(Xyz<T>) -> Self;
+    fn from_xyz(Xyz<Wp, T>) -> Self;
 
     ///Convert from Yxy color space
-    fn from_yxy(inp: Yxy<T>) -> Self {
+    fn from_yxy(inp: Yxy<Wp, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
     ///Convert from L*a*b* color space
-    fn from_lab(inp: Lab<T>) -> Self {
+    fn from_lab(inp: Lab<Wp, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
     ///Convert from L*C*h° color space
-    fn from_lch(inp: Lch<T>) -> Self {
+    fn from_lch(inp: Lch<Wp, T>) -> Self {
         Self::from_lab(inp.into_lab())
     }
 
     ///Convert from RGB color space
-    fn from_rgb(inp: Rgb<T>) -> Self {
+    fn from_rgb(inp: Rgb<Wp, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
     ///Convert from HSL color space
-    fn from_hsl(inp: Hsl<T>) -> Self {
+    fn from_hsl(inp: Hsl<Wp, T>) -> Self {
         Self::from_rgb(inp.into_rgb())
     }
 
     ///Convert from HSV color space
-    fn from_hsv(inp: Hsv<T>) -> Self {
+    fn from_hsv(inp: Hsv<Wp, T>) -> Self {
         Self::from_rgb(inp.into_rgb())
     }
 
     ///Convert from HWB color space
-    fn from_hwb(inp: Hwb<T>) -> Self {
+    fn from_hwb(inp: Hwb<Wp, T>) -> Self {
         Self::from_hsv(inp.into_hsv())
     }
 
     ///Convert from Luma
-    fn from_luma(inp: Luma<T>) -> Self {
+    fn from_luma(inp: Luma<Wp, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
@@ -63,50 +65,51 @@ pub trait FromColor<T>: Sized
 ///
 ///It requires into into_xyz and derives conversion to other colors as a default from this.
 ///These defaults must be overridden when direct conversion exists between colors.
-pub trait IntoColor<T>: Sized
+pub trait IntoColor<Wp = D65, T = f32>: Sized
     where T: Float,
+     Wp: WhitePoint<T>
 {
 
     ///Convert into XYZ space
-    fn into_xyz(self) -> Xyz<T>;
+    fn into_xyz(self) -> Xyz<Wp, T>;
 
     ///Convert into Yxy color space
-    fn into_yxy(self) -> Yxy<T> {
+    fn into_yxy(self) -> Yxy<Wp, T> {
         Yxy::from_xyz(self.into_xyz())
     }
 
     ///Convert into L*a*b* color space
-    fn into_lab(self) -> Lab<T> {
+    fn into_lab(self) -> Lab<Wp, T> {
         Lab::from_xyz(self.into_xyz())
     }
 
     ///Convert into L*C*h° color space
-    fn into_lch(self) -> Lch<T> {
+    fn into_lch(self) -> Lch<Wp, T> {
         Lch::from_lab(self.into_lab())
     }
 
     ///Convert into RGB color space.
-    fn into_rgb(self) -> Rgb<T> {
+    fn into_rgb(self) -> Rgb<Wp, T> {
         Rgb::from_xyz(self.into_xyz())
     }
 
     ///Convert into HSL color space
-    fn into_hsl(self) -> Hsl<T> {
+    fn into_hsl(self) -> Hsl<Wp, T> {
         Hsl::from_rgb(self.into_rgb())
     }
 
     ///Convert into HSV color space
-    fn into_hsv(self) -> Hsv<T> {
+    fn into_hsv(self) -> Hsv<Wp, T> {
         Hsv::from_rgb(self.into_rgb())
     }
 
     ///Convert into HWB color space
-    fn into_hwb(self) -> Hwb<T> {
+    fn into_hwb(self) -> Hwb<Wp, T> {
         Hwb::from_hsv(self.into_hsv())
     }
 
     ///Convert into Luma
-    fn into_luma(self) -> Luma<T> {
+    fn into_luma(self) -> Luma<Wp, T> {
         Luma::from_xyz(self.into_xyz())
     }
 
@@ -114,37 +117,40 @@ pub trait IntoColor<T>: Sized
 
 macro_rules! impl_into_color {
     ($self_ty:ident, $from_fn: ident) => {
-        impl< T: Float > IntoColor<T> for $self_ty<T> {
+        impl<Wp, T> IntoColor<Wp, T> for $self_ty<Wp, T>
+            where T: Float,
+             Wp: WhitePoint<T>
+        {
 
-            fn into_xyz(self) -> Xyz<T> {
+            fn into_xyz(self) -> Xyz<Wp, T> {
                 Xyz::$from_fn(self)
             }
 
-            fn into_yxy(self) -> Yxy<T> {
+            fn into_yxy(self) -> Yxy<Wp, T> {
                 Yxy::$from_fn(self)
             }
 
-            fn into_lab(self) -> Lab<T> {
+            fn into_lab(self) -> Lab<Wp, T> {
                 Lab::$from_fn(self)
             }
 
-            fn into_lch(self) -> Lch<T> {
+            fn into_lch(self) -> Lch<Wp, T> {
                 Lch::$from_fn(self)
             }
 
-            fn into_rgb(self) -> Rgb<T> {
+            fn into_rgb(self) -> Rgb<Wp, T> {
                 Rgb::$from_fn(self)
             }
 
-            fn into_hsl(self) -> Hsl<T> {
+            fn into_hsl(self) -> Hsl<Wp, T> {
                 Hsl::$from_fn(self)
             }
 
-            fn into_hsv(self) -> Hsv<T> {
+            fn into_hsv(self) -> Hsv<Wp, T> {
                 Hsv::$from_fn(self)
             }
 
-            fn into_luma(self) -> Luma<T> {
+            fn into_luma(self) -> Luma<Wp, T> {
                 Luma::$from_fn(self)
             }
 
@@ -155,15 +161,21 @@ macro_rules! impl_into_color {
 
 
 macro_rules! impl_from_trait {
-    (($self_ty:ident, $into_fn: ident) => {$($other:ident),+}) => (
-        impl<T: Float> From<Alpha<$self_ty<T>, T>> for $self_ty<T> {
-            fn from(color: Alpha<$self_ty<T>, T>) -> $self_ty<T> {
+    (($self_ty: ident, $into_fn: ident) => {$($other: ident),+}) => (
+        impl<Wp, T> From<Alpha<$self_ty<Wp, T>, T>> for $self_ty<Wp, T>
+            where T: Float,
+                Wp: WhitePoint<T>
+        {
+            fn from(color: Alpha<$self_ty<Wp, T>, T>) -> $self_ty<Wp, T> {
                 color.color
             }
         }
 
-        impl<T: Float> From<Color<T>> for $self_ty<T> {
-            fn from(color: Color<T>) -> $self_ty<T> {
+        impl<Wp, T> From<Color<Wp, T>> for $self_ty<Wp, T>
+            where T: Float,
+                Wp: WhitePoint<T>
+        {
+            fn from(color: Color<Wp, T>) -> $self_ty<Wp, T> {
                 match color {
                     Color::Luma(c) => c.$into_fn(),
                     Color::Rgb(c) => c.$into_fn(),
@@ -178,8 +190,11 @@ macro_rules! impl_from_trait {
             }
         }
 
-        impl<T: Float> From<Color<T>> for Alpha<$self_ty<T>,T> {
-            fn from(color: Color<T>) -> Alpha<$self_ty<T>,T> {
+        impl<Wp, T> From<Color<Wp, T>> for Alpha<$self_ty<Wp, T>,T>
+            where T: Float,
+                Wp: WhitePoint<T>
+        {
+            fn from(color: Color<Wp, T>) -> Alpha<$self_ty<Wp, T>,T> {
                 Alpha {
                     color: color.into(),
                     alpha: T::one(),
@@ -187,8 +202,11 @@ macro_rules! impl_from_trait {
             }
         }
 
-        impl<T: Float> From<Alpha<Color<T>, T>> for Alpha<$self_ty<T>,T> {
-            fn from(color: Alpha<Color<T>, T>) -> Alpha<$self_ty<T>,T> {
+        impl<Wp, T> From<Alpha<Color<Wp, T>, T>> for Alpha<$self_ty<Wp, T>,T>
+            where T: Float,
+                Wp: WhitePoint<T>
+        {
+            fn from(color: Alpha<Color<Wp, T>, T>) -> Alpha<$self_ty<Wp, T>,T> {
                 Alpha {
                     color: color.color.into(),
                     alpha: color.alpha,
@@ -197,14 +215,20 @@ macro_rules! impl_from_trait {
         }
 
         $(
-            impl<T: Float> From<$other<T>> for $self_ty<T> {
-                fn from(other: $other<T>) -> $self_ty<T> {
+            impl<Wp, T> From<$other<Wp, T>> for $self_ty<Wp, T>
+                where T: Float,
+                    Wp: WhitePoint<T>
+            {
+                fn from(other: $other<Wp, T>) -> $self_ty<Wp, T> {
                     other.$into_fn()
                 }
             }
 
-            impl<T: Float> From<Alpha<$other<T>, T>> for Alpha<$self_ty<T>, T> {
-                fn from(other: Alpha<$other<T>, T>) -> Alpha<$self_ty<T>, T> {
+            impl<Wp, T> From<Alpha<$other<Wp, T>, T>> for Alpha<$self_ty<Wp, T>, T>
+                where T: Float,
+                    Wp: WhitePoint<T>
+            {
+                fn from(other: Alpha<$other<Wp, T>, T>) -> Alpha<$self_ty<Wp, T>, T> {
                     Alpha {
                         color: other.color.$into_fn(),
                         alpha: other.alpha,
@@ -212,8 +236,11 @@ macro_rules! impl_from_trait {
                 }
             }
 
-            impl<T: Float> From<$other<T>> for Alpha<$self_ty<T>, T> {
-                fn from(color: $other<T>) -> Alpha<$self_ty<T>, T> {
+            impl<Wp, T> From<$other<Wp, T>> for Alpha<$self_ty<Wp, T>, T>
+                where T: Float,
+                    Wp: WhitePoint<T>
+            {
+                fn from(color: $other<Wp, T>) -> Alpha<$self_ty<Wp, T>, T> {
                     Alpha {
                         color: color.$into_fn(),
                         alpha: T::one(),
@@ -221,8 +248,11 @@ macro_rules! impl_from_trait {
                 }
             }
 
-            impl<T: Float> From<Alpha<$other<T>, T>> for $self_ty<T> {
-                fn from(other: Alpha<$other<T>, T>) -> $self_ty<T> {
+            impl<Wp, T> From<Alpha<$other<Wp, T>, T>> for $self_ty<Wp, T>
+                where T: Float,
+                    Wp: WhitePoint<T>
+            {
+                fn from(other: Alpha<$other<Wp, T>, T>) -> $self_ty<Wp, T> {
                     other.color.$into_fn()
                 }
             }
@@ -231,23 +261,23 @@ macro_rules! impl_from_trait {
     )
 }
 
-impl_into_color!(Xyz,from_xyz);
-impl_into_color!(Yxy,from_yxy);
-impl_into_color!(Lab,from_lab);
-impl_into_color!(Lch,from_lch);
-impl_into_color!(Rgb,from_rgb);
-impl_into_color!(Hsl,from_hsl);
-impl_into_color!(Hsv,from_hsv);
-impl_into_color!(Hwb,from_hwb);
-impl_into_color!(Luma,from_luma);
+impl_into_color!(Xyz, from_xyz);
+impl_into_color!(Yxy, from_yxy);
+impl_into_color!(Lab, from_lab);
+impl_into_color!(Lch, from_lch);
+impl_into_color!(Rgb, from_rgb);
+impl_into_color!(Hsl, from_hsl);
+impl_into_color!(Hsv, from_hsv);
+impl_into_color!(Hwb, from_hwb);
+impl_into_color!(Luma ,from_luma);
 
 
-impl_from_trait!((Xyz,into_xyz) => {Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma});
-impl_from_trait!((Yxy,into_yxy) => {Xyz, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma});
-impl_from_trait!((Lab,into_lab) => {Xyz, Yxy, Lch, Rgb, Hsl, Hsv, Hwb, Luma});
-impl_from_trait!((Lch,into_lch) => {Xyz, Yxy, Lab, Rgb, Hsl, Hsv, Hwb, Luma});
-impl_from_trait!((Rgb,into_rgb) => {Xyz, Yxy, Lab, Lch, Hsl, Hsv, Hwb, Luma});
-impl_from_trait!((Hsl,into_hsl) => {Xyz, Yxy, Lab, Lch, Rgb, Hsv, Hwb, Luma});
-impl_from_trait!((Hsv,into_hsv) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hwb, Luma});
-impl_from_trait!((Hwb,into_hwb) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Luma});
-impl_from_trait!((Luma,into_luma) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb});
+impl_from_trait!((Xyz, into_xyz) => {Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma});
+impl_from_trait!((Yxy, into_yxy) => {Xyz, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma});
+impl_from_trait!((Lab, into_lab) => {Xyz, Yxy, Lch, Rgb, Hsl, Hsv, Hwb, Luma});
+impl_from_trait!((Lch, into_lch) => {Xyz, Yxy, Lab, Rgb, Hsl, Hsv, Hwb, Luma});
+impl_from_trait!((Rgb, into_rgb) => {Xyz, Yxy, Lab, Lch, Hsl, Hsv, Hwb, Luma});
+impl_from_trait!((Hsl, into_hsl) => {Xyz, Yxy, Lab, Lch, Rgb, Hsv, Hwb, Luma});
+impl_from_trait!((Hsv, into_hsv) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hwb, Luma});
+impl_from_trait!((Hwb, into_hwb) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Luma});
+impl_from_trait!((Luma, into_luma) => {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb});

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -3,11 +3,15 @@ use approx::ApproxEq;
 
 use {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma, LabHue, RgbHue, flt};
 use pixel::{Srgb, GammaRgb};
+use white_point::WhitePoint;
+
 
 macro_rules! impl_eq {
     (  $self_ty: ident , [$($element: ident),+]) => {
-        impl<T: Float + ApproxEq> ApproxEq for $self_ty<T>
-        where T::Epsilon: Copy + Float
+        impl<Wp, T> ApproxEq for $self_ty<Wp, T>
+        where T: Float + ApproxEq,
+            T::Epsilon: Copy + Float,
+            Wp: WhitePoint<T>
         {
             type Epsilon = <T as ApproxEq>::Epsilon;
 

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -375,7 +375,8 @@ mod test {
 
         let v1: Vec<_> = g1.take(10).take(5).collect();
         let v2: Vec<_> = g2.take(5).collect();
-
-        assert_eq!(v1, v2);
+        for (t1, t2) in v1.iter().zip(v2.iter()){
+            assert_relative_eq!(t1, t2);
+        }
     }
 }

--- a/src/hues.rs
+++ b/src/hues.rs
@@ -16,9 +16,9 @@ macro_rules! make_hues {
         ///also have some surprising effects if it's expected to act as a
         ///linear number.
         #[derive(Clone, Copy, Debug, Default)]
-        pub struct $name<T:Float = f32>(T);
+        pub struct $name<T: Float = f32>(T);
 
-        impl<T:Float> $name<T> {
+        impl<T: Float> $name<T> {
             ///Create a new hue from radians, instead of degrees.
             pub fn from_radians(radians: T) -> $name<T> {
                 $name(radians * flt(180.0) / flt(PI))
@@ -45,7 +45,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T:Float> From<T> for $name<T> {
+        impl<T: Float> From<T> for $name<T> {
             fn from(degrees: T) -> $name<T> {
                 $name(degrees)
             }
@@ -68,7 +68,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T:Float> PartialEq for $name<T> {
+        impl<T: Float> PartialEq for $name<T> {
             fn eq(&self, other: &$name<T>) -> bool {
                 let hue_s: T = (*self).to_degrees();
                 let hue_o: T = (*other).to_degrees();
@@ -76,14 +76,14 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T:Float> PartialEq<T> for $name<T> {
+        impl<T: Float> PartialEq<T> for $name<T> {
             fn eq(&self, other: &T) -> bool {
                 let hue: T = (*self).to_degrees();
                 hue.eq(&normalize_angle(*other))
             }
         }
 
-        impl<T:Float> Add<$name<T>> for $name<T> {
+        impl<T: Float> Add<$name<T>> for $name<T> {
             type Output = $name<T>;
 
             fn add(self, other: $name<T>) -> $name<T> {
@@ -91,7 +91,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T:Float> Add<T> for $name<T> {
+        impl<T: Float> Add<T> for $name<T> {
             type Output = $name<T>;
 
             fn add(self, other: T) -> $name<T> {
@@ -99,7 +99,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T:Float> Sub<$name<T>> for $name<T> {
+        impl<T: Float> Sub<$name<T>> for $name<T> {
             type Output = $name<T>;
 
             fn sub(self, other: $name<T>) -> $name<T> {
@@ -107,7 +107,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T:Float> Sub<T> for $name<T> {
+        impl<T: Float> Sub<T> for $name<T> {
             type Output = $name<T>;
 
             fn sub(self, other: T) -> $name<T> {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,127 @@
+//!This module provides simple matrix operations on 3x3 matrix to aid in chromatic adaptation and
+//!conversion calculations.
+
+use num::Float;
+
+use std::marker::PhantomData;
+
+use {Xyz, Rgb};
+use white_point::WhitePoint;
+
+///A 9 element array representing a 3x3 matrix
+pub type Mat3<T> = [T;9];
+
+///Multiply the 3x3 matrix with the XYZ color
+pub fn multiply_xyz<Swp: WhitePoint<T>, Dwp: WhitePoint<T>, T: Float>(c: &Mat3<T>, f: &Xyz<Swp, T>) -> Xyz<Dwp, T> {
+    Xyz {
+        x: (c[0] * f.x) + (c[1] * f.y) + (c[2] * f.z),
+        y: (c[3] * f.x) + (c[4] * f.y) + (c[5] * f.z),
+        z: (c[6] * f.x) + (c[7] * f.y) + (c[8] * f.z),
+        white_point: PhantomData,
+    }
+}
+///Multiply the 3x3 matrix with the XYZ color into RGB color
+pub fn multiply_xyz_to_rgb<Swp: WhitePoint<T>, Dwp: WhitePoint<T>, T: Float>(c: &Mat3<T>, f: &Xyz<Swp, T>) -> Rgb<Dwp, T> {
+    Rgb {
+        red: (c[0] * f.x) + (c[1] * f.y) + (c[2] * f.z),
+        green: (c[3] * f.x) + (c[4] * f.y) + (c[5] * f.z),
+        blue: (c[6] * f.x) + (c[7] * f.y) + (c[8] * f.z),
+        white_point: PhantomData,
+    }
+}
+///Multiply the 3x3 matrix with the  RGB into XYZ color
+pub fn multiply_rgb_to_xyz<Swp: WhitePoint<T>, Dwp: WhitePoint<T>, T: Float>(c: &Mat3<T>, f: &Rgb<Swp, T>) -> Xyz<Dwp, T> {
+    Xyz {
+        x: (c[0] * f.red) + (c[1] * f.green) + (c[2] * f.blue),
+        y: (c[3] * f.red) + (c[4] * f.green) + (c[5] * f.blue),
+        z: (c[6] * f.red) + (c[7] * f.green) + (c[8] * f.blue),
+        white_point: PhantomData,
+    }
+}
+
+///Multiply a 3x3 matrix with another 3x3 matrix
+pub fn multiply_3x3<T: Float>(c: &Mat3<T>, f: &Mat3<T>) -> Mat3<T> {
+    let mut out = [T::zero();9];
+    out[0] = c[0] * f[0] + c[1] * f[3] + c[2] * f[6];
+    out[1] = c[0] * f[1] + c[1] * f[4] + c[2] * f[7];
+    out[2] = c[0] * f[2] + c[1] * f[5] + c[2] * f[8];
+
+    out[3] = c[3] * f[0] + c[4] * f[3] + c[5] * f[6];
+    out[4] = c[3] * f[1] + c[4] * f[4] + c[5] * f[7];
+    out[5] = c[3] * f[2] + c[4] * f[5] + c[5] * f[8];
+
+    out[6] = c[6] * f[0] + c[7] * f[3] + c[8] * f[6];
+    out[7] = c[6] * f[1] + c[7] * f[4] + c[8] * f[7];
+    out[8] = c[6] * f[2] + c[7] * f[5] + c[8] * f[8];
+
+    out
+}
+
+///Invert a 3x3 matrix and panic if matrix is not invertable.
+pub fn matrix_inverse<T: Float>(a: &Mat3<T>) -> Mat3<T> {
+    let d0 = a[4] * a[8] - a[5] * a[7];
+    let d1 = a[3] * a[8] - a[5] * a[6];
+    let d2 = a[3] * a[7] - a[4] * a[6];
+    let det =  a[0] * d0 - a[1] * d1 + a[2] * d2;
+    if !det.is_normal() {
+        panic!("The given matrix is not invertable")
+    }
+    let d3 = a[1] * a[8] - a[2] * a[7];
+    let d4 = a[0] * a[8] - a[2] * a[6];
+    let d5 = a[0] * a[7] - a[1] * a[6];
+    let d6 = a[1] * a[5] - a[2] * a[4];
+    let d7 = a[0] * a[5] - a[2] * a[3];
+    let d8 = a[0] * a[4] - a[1] * a[3];
+
+    [d0/det, -d3/det, d6/det, -d1/det, d4/det, -d7/det, d2/det, -d5/det, d8/det]
+}
+
+
+#[cfg(test)]
+mod test {
+    use Xyz;
+    use super::{matrix_inverse, multiply_3x3, multiply_xyz};
+    #[test]
+    fn matrix_multiply_3x3() {
+        let inp1 = [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
+        let inp2 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
+        let expected = [28.0, 33.0, 29.0, 28.0, 31.0, 31.0, 26.0, 33.0, 31.0];
+
+        let computed = multiply_3x3(&inp1, &inp2);
+        assert_eq!(expected, computed)
+    }
+
+    #[test]
+    fn matrix_multiply_xyz() {
+        let inp1 = [0.1, 0.2, 0.3, 0.3, 0.2, 0.1, 0.2, 0.1, 0.3];
+        let inp2 = Xyz::new(0.4, 0.6, 0.8);
+
+        let expected = Xyz::new(0.4, 0.32, 0.38);
+
+        let computed = multiply_xyz(&inp1, &inp2);
+        assert_relative_eq!(expected, computed)
+    }
+
+    #[test]
+    fn matrix_inverse_check_1() {
+        let input: [f64; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
+
+        let expected: [f64; 9] = [0.2, 0.2, 0.0, -0.2, 0.3, 1.0, 0.2, -0.3, 0.0];
+        let computed = matrix_inverse(&input);
+        assert_eq!(expected, computed);
+    }
+    #[test]
+    fn matrix_inverse_check_2() {
+        let input: [f64; 9] = [1.0, 0.0, 1.0, 0.0, 2.0, 1.0, 1.0, 1.0, 1.0];
+
+        let expected: [f64; 9] = [-1.0, -1.0, 2.0, -1.0, 0.0, 1.0, 2.0, 1.0, -2.0];
+        let computed = matrix_inverse(&input);
+        assert_eq!(expected, computed);
+    }
+    #[test]
+    #[should_panic]
+    fn matrix_inverse_panic() {
+        let input: [f64; 9] = [1.0, 0.0, 0.0, 2.0, 0.0, 0.0, -4.0, 6.0, 1.0];
+        matrix_inverse(&input);
+    }
+}

--- a/src/pixel/srgb.rs
+++ b/src/pixel/srgb.rs
@@ -1,8 +1,11 @@
 use num::Float;
 
+use std::marker::PhantomData;
+
 use {Color, Alpha, Rgb, Rgba, clamp, flt};
 
 use pixel::RgbPixel;
+use white_point::{WhitePoint, D65};
 
 ///An sRGB encoded color.
 ///
@@ -18,8 +21,11 @@ use pixel::RgbPixel;
 ///let c: Rgb = Srgb::new(0.5, 0.3, 0.1).into();
 ///assert_eq!((0.5f32, 0.3, 0.1), Srgb::from(c).to_pixel());
 ///```
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Srgb<T: Float = f32> {
+#[derive(Debug, PartialEq)]
+pub struct Srgb<Wp = D65, T = f32>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
     ///The red component, where 0.0 is no red light and 1.0 is the
     ///highest displayable amount.
     pub red: T,
@@ -35,43 +41,100 @@ pub struct Srgb<T: Float = f32> {
     ///The transparency of the color. 0.0 is completely transparent and 1.0 is
     ///completely opaque.
     pub alpha: T,
+
+    ///The white point associated with the color's illuminant and observer.
+///D65 for 2 degree observer is used by default.
+pub white_point: PhantomData<Wp>,
 }
 
-impl<T: Float> Srgb<T> {
+impl<Wp, T> Copy for Srgb<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{}
+
+impl<Wp, T> Clone for Srgb<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn clone(&self) -> Srgb<Wp, T> { *self }
+}
+
+impl<T> Srgb<D65, T>
+    where T: Float,
+{
     ///Create a new opaque sRGB encoded color.
-    pub fn new(red: T, green: T, blue: T) -> Srgb<T> {
+    pub fn new(red: T, green: T, blue: T) -> Srgb<D65, T> {
         Srgb::with_alpha(red, green, blue, T::one())
     }
 
     ///Create a new sRGB encoded color with transparency.
-    pub fn with_alpha(red: T, green: T, blue: T, alpha: T) -> Srgb<T> {
+    pub fn with_alpha(red: T, green: T, blue: T, alpha: T) -> Srgb<D65, T> {
         Srgb {
             red: red,
             green: green,
             blue: blue,
             alpha: alpha,
+            white_point: PhantomData,
         }
     }
 
     ///Create a new opaque sRGB encoded color from `u8` values.
-    pub fn new_u8(red: u8, green: u8, blue: u8) -> Srgb<T> {
+    pub fn new_u8(red: u8, green: u8, blue: u8) -> Srgb<D65, T> {
         Srgb::with_alpha_u8(red, green, blue, 255)
     }
 
     ///Create a new sRGB encoded color, with transparency, from `u8` values.
-    pub fn with_alpha_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Srgb<T> {
+    pub fn with_alpha_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Srgb<D65, T> {
         Srgb {
             red: flt::<T,_>(red) / flt(255.0),
             green: flt::<T,_>(green) / flt(255.0),
             blue: flt::<T,_>(blue) / flt(255.0),
             alpha: flt::<T,_>(alpha) / flt(255.0),
+            white_point: PhantomData,
+        }
+    }
+}
+
+impl<Wp, T> Srgb<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    ///Create a new opaque sRGB encoded color.
+    pub fn with_wp(red: T, green: T, blue: T) -> Srgb<Wp, T> {
+        Srgb::with_wp_alpha(red, green, blue, T::one())
+    }
+
+    ///Create a new sRGB encoded color with transparency.
+    pub fn with_wp_alpha(red: T, green: T, blue: T, alpha: T) -> Srgb<Wp, T> {
+        Srgb {
+            red: red,
+            green: green,
+            blue: blue,
+            alpha: alpha,
+            white_point: PhantomData,
+        }
+    }
+
+    ///Create a new opaque sRGB encoded color from `u8` values.
+    pub fn with_wp_u8(red: u8, green: u8, blue: u8) -> Srgb<Wp, T> {
+        Srgb::with_wp_alpha_u8(red, green, blue, 255)
+    }
+
+    ///Create a new sRGB encoded color, with transparency, from `u8` values.
+    pub fn with_wp_alpha_u8(red: u8, green: u8, blue: u8, alpha: u8) -> Srgb<Wp, T> {
+        Srgb {
+            red: flt::<T,_>(red) / flt(255.0),
+            green: flt::<T,_>(green) / flt(255.0),
+            blue: flt::<T,_>(blue) / flt(255.0),
+            alpha: flt::<T,_>(alpha) / flt(255.0),
+            white_point: PhantomData,
         }
     }
 
     ///Create a new sRGB encoded color from a pixel value.
-    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> Srgb<T> {
+    pub fn from_pixel<P: RgbPixel<T>>(pixel: &P) -> Srgb<Wp, T> {
         let (r, g, b, a) = pixel.to_rgba();
-        Srgb::with_alpha(r, g, b, a)
+        Srgb::with_wp_alpha(r, g, b, a)
     }
 
     ///Transform this color into a pixel representation.
@@ -85,48 +148,58 @@ impl<T: Float> Srgb<T> {
     }
 
     ///Convert linear color components to sRGB encoding.
-    pub fn from_linear<C: Into<Rgba<T>>>(color: C) -> Srgb<T> {
+    pub fn from_linear<C: Into<Rgba<Wp, T>>>(color: C) -> Srgb<Wp, T> {
         let rgb = color.into();
         Srgb {
             red: to_srgb(rgb.red),
             green: to_srgb(rgb.green),
             blue: to_srgb(rgb.blue),
             alpha: rgb.alpha,
+            white_point: PhantomData,
         }
     }
 
     ///Decode this color to a linear representation.
-    pub fn to_linear(&self) -> Rgba<T> {
+    pub fn to_linear(&self) -> Rgba<Wp, T> {
         Alpha {
-            color: Rgb {
-                red: from_srgb(self.red),
-                green: from_srgb(self.green),
-                blue: from_srgb(self.blue),
-            },
+            color: Rgb::with_wp(
+                from_srgb(self.red),
+                from_srgb(self.green),
+                from_srgb(self.blue),
+            ),
             alpha: self.alpha,
         }
     }
 
     ///Shortcut to convert a linear color to an sRGB encoded pixel.
-    pub fn linear_to_pixel<C: Into<Rgba<T>>, P: RgbPixel<T>>(color: C) -> P {
+    pub fn linear_to_pixel<C: Into<Rgba<Wp, T>>, P: RgbPixel<T>>(color: C) -> P {
         Srgb::from_linear(color).to_pixel()
     }
 }
 
-impl<T: Float> From<Rgb<T>> for Srgb<T> {
-    fn from(rgb: Rgb<T>) -> Srgb<T> {
+impl<Wp, T> From<Rgb<Wp, T>> for Srgb<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn from(rgb: Rgb<Wp, T>) -> Srgb<Wp, T> {
         Rgba::from(rgb).into()
     }
 }
 
-impl<T: Float> From<Rgba<T>> for Srgb<T> {
-    fn from(rgba: Rgba<T>) -> Srgb<T> {
+impl<Wp, T> From<Rgba<Wp, T>> for Srgb<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn from(rgba: Rgba<Wp, T>) -> Srgb<Wp, T> {
         Srgb::from_linear(rgba)
     }
 }
 
-impl<T: Float> From<Color<T>> for Srgb<T> {
-    fn from(color: Color<T>) -> Srgb<T> {
+impl<Wp, T> From<Color<Wp, T>> for Srgb<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn from(color: Color<Wp, T>) -> Srgb<Wp, T> {
         Rgb::from(color).into()
     }
 }

--- a/src/rgb_primaries.rs
+++ b/src/rgb_primaries.rs
@@ -1,0 +1,103 @@
+//!This module defines the red, blue and green primaries for the common Rgb color spaces
+use num::Float;
+
+
+use {Yxy, Xyz, Rgb, IntoColor};
+use white_point::WhitePoint;
+use matrix::{Mat3, matrix_inverse, multiply_xyz_to_rgb};
+use flt;
+
+///Represents the tristimulus values for the Rgb primaries
+pub trait RgbPrimaries<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>,
+{
+    ///Tristimulus values for red
+    fn red() -> Yxy<Wp, T>;
+    ///Tristimulus values for green
+    fn green() -> Yxy<Wp, T>;
+    ///Tristimulus values for blue
+    fn blue() -> Yxy<Wp, T>;
+}
+
+///Srgb color space with default D65 white point
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SrgbSpace;
+
+impl<Wp, T> RgbPrimaries<Wp, T> for SrgbSpace
+    where T: Float,
+        Wp: WhitePoint<T>,
+{
+    fn red() -> Yxy<Wp, T> {
+        Yxy::with_wp(flt(0.6400), flt(0.3300), flt(0.212656))
+    }
+    fn green() -> Yxy<Wp, T> {
+        Yxy::with_wp(flt(0.3000), flt(0.6000), flt(0.715158))
+    }
+    fn blue() -> Yxy<Wp, T> {
+        Yxy::with_wp(flt(0.1500), flt(0.0600), flt(0.072186))
+    }
+
+}
+
+///Geneartes to Srgb to Xyz transformation matrix for the given white point
+pub fn rgb_to_xyz_matrix<Wp: WhitePoint<T>, T: Float>() -> Mat3<T> {
+    let r: Xyz<Wp, T> = SrgbSpace::red().into_xyz();
+    let g: Xyz<Wp, T> = SrgbSpace::green().into_xyz();
+    let b: Xyz<Wp, T> = SrgbSpace::blue().into_xyz();
+
+    let mut transform_matrix = mat3_from_primaries(r, g, b);
+
+    let s_matrix: Rgb<Wp, T> = multiply_xyz_to_rgb(&matrix_inverse(&transform_matrix), &Wp::get_xyz());
+    transform_matrix[0] = transform_matrix[0] * s_matrix.red;
+    transform_matrix[1] = transform_matrix[1] * s_matrix.green;
+    transform_matrix[2] = transform_matrix[2] * s_matrix.blue;
+    transform_matrix[3] = transform_matrix[3] * s_matrix.red;
+    transform_matrix[4] = transform_matrix[4] * s_matrix.green;
+    transform_matrix[5] = transform_matrix[5] * s_matrix.blue;
+    transform_matrix[6] = transform_matrix[6] * s_matrix.red;
+    transform_matrix[7] = transform_matrix[7] * s_matrix.green;
+    transform_matrix[8] = transform_matrix[8] * s_matrix.blue;
+
+    transform_matrix
+
+}
+
+fn mat3_from_primaries<T: Float, Wp: WhitePoint<T>>(r: Xyz<Wp, T>, g: Xyz<Wp, T>, b: Xyz<Wp, T>) -> Mat3<T> {
+    [
+        r.x, g.x, b.x,
+        r.y, g.y, b.y,
+        r.z, g.z, b.z,
+    ]
+}
+
+#[cfg(test)]
+mod test {
+    use Rgb;
+    use chromatic_adaptation::AdaptInto;
+    use white_point::{D65,D50};
+    use super::rgb_to_xyz_matrix;
+
+    #[test]
+    fn d65_rgb_conversion_matrix() {
+        let expected = [
+            0.4124564, 0.3575761, 0.1804375,
+            0.2126729, 0.7151522, 0.0721750,
+            0.0193339, 0.1191920, 0.9503041
+        ];
+        let computed = rgb_to_xyz_matrix::<D65, f64>();
+        for (e, c) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(e, c, epsilon = 0.000001)
+        }
+    }
+
+    #[test]
+    fn d65_to_d50() {
+        let input: Rgb<D65> = Rgb::new(1.0, 1.0, 1.0);
+        let expected: Rgb<D50> = Rgb::with_wp(1.0, 1.0, 1.0);
+
+        let computed: Rgb<D50> = input.adapt_into();
+        assert_relative_eq!(expected, computed, epsilon = 0.000001);
+    }
+
+}

--- a/src/tristimulus.rs
+++ b/src/tristimulus.rs
@@ -1,3 +1,0 @@
-pub const X_N: f64 = 0.95047;
-pub const Y_N: f64 = 1.0;
-pub const Z_N: f64 = 1.08883;

--- a/src/white_point.rs
+++ b/src/white_point.rs
@@ -1,0 +1,188 @@
+//!Defines the tristimulus values of the CIE Illuminants.
+//!
+//!White point is the reference white or target white as seen by a standard observer under a
+//!standard illuminant. For example, photographs taken indoors may be lit by incandescent lights,
+//!which are relatively orange compared to daylight. Defining "white" as daylight will give
+//!unacceptable results when attempting to color-correct a photograph taken with incandescent lighting.
+
+
+use num::Float;
+
+use {Xyz, flt};
+
+///WhitePoint defines the Xyz color co-ordinates for a given white point.
+///
+///A white point (often referred to as reference white or target white in technical documents)
+///is a set of tristimulus values or chromaticity coordinates that serve to define the color
+///"white" in image capture, encoding, or reproduction.
+///
+///Custom white points can be easily defined on an empty struct with the tristimulus values
+///and can be used in place of the ones defined in this library. 
+pub trait WhitePoint<T: Float>: Sized {
+    ///Get the Xyz chromacity co-ordinates for the white point.
+    fn get_xyz() -> Xyz<Self, T>;
+}
+
+///CIE standard illuminant A
+///
+///CIE standard illuminant A is intended to represent typical, domestic, tungsten-filament lighting.
+///Its relative spectral power distribution is that of a Planckian radiator at a temperature of approximately 2856 K.
+///Uses the CIE 1932 2° Standard Observer
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct A;
+impl<T: Float> WhitePoint<T> for A {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(1.09850), T::one(), flt(0.35585))
+    }
+}
+///CIE standard illuminant B
+///
+///CIE standard illuminant B represents noon sunlight, with a correlated color temperature (CCT) of 4874 K
+///Uses the CIE 1932 2° Standard Observer
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct B;
+impl<T: Float> WhitePoint<T> for B {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.99072), T::one(), flt(0.85223))
+    }
+}
+///CIE standard illuminant C
+///
+///CIE standard illuminant C represents the average day light with a CCT of 6774 K
+///Uses the CIE 1932 2° Standard Observer
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct C;
+impl<T: Float> WhitePoint<T> for C {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.98074), T::one(), flt(1.18232))
+    }
+}
+///CIE D series standard illuminant - D50
+///
+///D50 White Point is the natural daylight with a color temperature of around 5000K
+///for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D50;
+impl<T: Float> WhitePoint<T> for D50 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.96422), T::one(), flt(0.82521))
+    }
+}
+///CIE D series standard illuminant - D55
+///
+///D55 White Point is the natural daylight with a color temperature of around 5500K
+///for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D55;
+impl<T: Float> WhitePoint<T> for D55 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.95682), T::one(), flt(0.92149))
+    }
+}
+///CIE D series standard illuminant - D65
+///
+///D65 White Point is the natural daylight with a color temperature of 6500K
+///for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D65;
+impl<T: Float> WhitePoint<T> for D65 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.95047), T::one(), flt(1.08883))
+    }
+}
+///CIE D series standard illuminant - D75
+///
+///D75 White Point is the natural daylight with a color temperature of around 7500K
+///for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D75;
+impl<T: Float> WhitePoint<T> for D75 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.94972), T::one(), flt(1.22638))
+    }
+}
+///CIE standard illuminant E
+///
+///CIE standard illuminant E represents the equal energy radiator
+///Uses the CIE 1932 2° Standard Observer
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct E;
+impl<T: Float> WhitePoint<T> for E {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(T::one(), T::one(),  T::one())
+    }
+}
+///CIE fluorescent illuminant series - F2
+///
+///F2 represents a semi-broadband fluorescent lamp for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct F2;
+impl<T: Float> WhitePoint<T> for F2 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.99186), T::one(), flt(0.67393))
+    }
+}
+///CIE fluorescent illuminant series - F7
+///
+///F7 represents a broadband fluorescent lamp for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct F7;
+impl<T: Float> WhitePoint<T> for F7 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.95041), T::one(), flt(1.08747))
+    }
+}
+///CIE fluorescent illuminant series - F11
+///
+///F11 represents a narrowband fluorescent lamp for 2° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct F11;
+impl<T: Float> WhitePoint<T> for F11 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(1.00962), T::one(), flt(0.64350))
+    }
+}
+///CIE D series standard illuminant - D50
+///
+///D50 White Point is the natural daylight with a color temperature of around 5000K
+///for 10° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D50Degree10;
+impl<T: Float> WhitePoint<T> for D50Degree10 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.9672), T::one(), flt(0.8143))
+    }
+}
+///CIE D series standard illuminant - D55
+///
+///D55 White Point is the natural daylight with a color temperature of around 5500K
+///for 10° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D55Degree10;
+impl<T: Float> WhitePoint<T> for D55Degree10 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.958), T::one(), flt(0.9093))
+    }
+}
+///CIE D series standard illuminant - D65
+///
+///D65 White Point is the natural daylight with a color temperature of 6500K
+///for 10° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D65Degree10;
+impl<T: Float> WhitePoint<T> for D65Degree10 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.9481), T::one(), flt(1.073))
+    }
+}
+///CIE D series standard illuminant - D75
+///
+///D75 White Point is the natural daylight with a color temperature of around 7500K
+///for 10° Standard Observer.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct D75Degree10;
+impl<T: Float> WhitePoint<T> for D75Degree10 {
+    fn get_xyz() -> Xyz<Self, T> {
+        Xyz::with_wp(flt(0.94416), T::one(), flt(1.2064))
+    }
+}

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -1,16 +1,15 @@
 use num::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
+use std::marker::PhantomData;
 
 use {Alpha, Luma, Xyz};
-use {Limited, Mix, Shade, FromColor, ComponentWise};
-use {clamp, flt};
-
-const D65_X: f64 = 0.312727;
-const D65_Y: f64 = 0.329023;
+use {Limited, Mix, Shade, FromColor, IntoColor, ComponentWise};
+use white_point::{WhitePoint, D65};
+use clamp;
 
 ///CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation in `Alpha`](struct.Alpha.html#Yxya).
-pub type Yxya<T = f32> = Alpha<Yxy<T>, T>;
+pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 
 ///The CIE 1931 Yxy (xyY)  color space.
 ///
@@ -18,11 +17,12 @@ pub type Yxya<T = f32> = Alpha<Yxy<T>, T>;
 ///color space. It is widely used to define colors. The chromacity diagrams
 ///for the color spaces are a plot of this color space's x and y coordiantes.
 ///
-///Conversions and operations on this color space assumes the CIE Standard
-///Illuminant D65 as the white point, and the 2° standard colorimetric
-///observer.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Yxy<T: Float = f32> {
+///Conversions and operations on this color space depend on the white point.
+#[derive(Debug, PartialEq)]
+pub struct Yxy<Wp = D65, T = f32>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
 
     ///x chromacity co-ordinate derived from XYZ color space as X/(X+Y+Z).
     ///Typical range is between 0 and 1
@@ -36,33 +36,85 @@ pub struct Yxy<T: Float = f32> {
     ///It is the same as the Y from the XYZ color space. Its range is from
     ///0 to 1, where 0 is black and 1 is white.
     pub luma: T,
+
+    ///The white point associated with the color's illuminant and observer.
+    ///D65 for 2 degree observer is used by default.
+    pub white_point: PhantomData<Wp>,
 }
 
-impl<T: Float> Yxy<T> {
-    ///CIE Yxy.
-    pub fn new(x: T, y: T, luma: T,) -> Yxy<T> {
+impl<Wp, T> Copy for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{}
+
+impl<Wp, T> Clone for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn clone(&self) -> Yxy<Wp, T> { *self }
+}
+
+impl<T> Yxy<D65, T>
+    where T: Float,
+{
+    ///CIE Yxy with white point D65.
+    pub fn new(x: T, y: T, luma: T,) -> Yxy<D65, T> {
         Yxy {
             x: x,
             y: y,
             luma: luma,
+            white_point: PhantomData,
+        }
+    }
+}
+
+impl<Wp, T> Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    ///CIE Yxy.
+    pub fn with_wp(x: T, y: T, luma: T,) -> Yxy<Wp, T> {
+        Yxy {
+            x: x,
+            y: y,
+            luma: luma,
+            white_point: PhantomData,
         }
     }
 }
 
 ///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
-impl<T: Float> Alpha<Yxy<T>, T> {
-    ///CIE Yxy and transparency.
-    pub fn new(x: T, y: T, luma: T, alpha: T) -> Yxya<T> {
+impl<T> Alpha<Yxy<D65, T>, T>
+    where T: Float,
+{
+    ///CIE Yxy and transparency with white point D65.
+    pub fn new(x: T, y: T, luma: T, alpha: T) -> Yxya<D65, T> {
         Alpha {
             color: Yxy::new(x, y, luma),
             alpha: alpha,
         }
     }
 }
+///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
+impl<Wp, T> Alpha<Yxy<Wp, T>, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    ///CIE Yxy and transparency.
+    pub fn with_wp(x: T, y: T, luma: T, alpha: T) -> Yxya<Wp, T> {
+        Alpha {
+            color: Yxy::with_wp(x, y, luma),
+            alpha: alpha,
+        }
+    }
+}
 
-impl<T: Float> FromColor<T> for Yxy<T> {
-    fn from_xyz(xyz: Xyz<T>) -> Self {
-        let mut yxy = Yxy{ x: T::zero(), y: T::zero(), luma: xyz.y };
+impl<Wp, T> FromColor<Wp, T> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn from_xyz(xyz: Xyz<Wp, T>) -> Self {
+        let mut yxy = Yxy{ x: T::zero(), y: T::zero(), luma: xyz.y, white_point: PhantomData };
         let sum = xyz.x + xyz.y + xyz.z;
         // If denominator is zero, NAN or INFINITE leave x and y at the default 0
         if sum.is_normal() {
@@ -72,25 +124,28 @@ impl<T: Float> FromColor<T> for Yxy<T> {
         yxy
     }
 
-    fn from_yxy(yxy: Yxy<T>) -> Self {
+    fn from_yxy(yxy: Yxy<Wp, T>) -> Self {
         yxy
     }
 
     // direct conversion implemented in Luma
-    fn from_luma(luma: Luma<T>) -> Self {
+    fn from_luma(luma: Luma<Wp, T>) -> Self {
         Yxy { luma: luma.luma, ..Default::default() }
     }
 
 }
 
-impl<T: Float> Limited for Yxy<T> {
+impl<Wp, T> Limited for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
     fn is_valid(&self) -> bool {
         self.x >= T::zero() && self.x <= T::one() &&
         self.y >= T::zero() && self.y <= T::one() &&
         self.luma >= T::zero() && self.luma <= T::one()
     }
 
-    fn clamp(&self) -> Yxy<T> {
+    fn clamp(&self) -> Yxy<Wp, T> {
         let mut c = *self;
         c.clamp_self();
         c
@@ -103,154 +158,203 @@ impl<T: Float> Limited for Yxy<T> {
     }
 }
 
-impl<T: Float> Mix for Yxy<T> {
+impl<Wp, T> Mix for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
     type Scalar = T;
 
-    fn mix(&self, other: &Yxy<T>, factor: T) -> Yxy<T> {
+    fn mix(&self, other: &Yxy<Wp, T>, factor: T) -> Yxy<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
 
         Yxy {
             x: self.x + factor * (other.x - self.x),
             y: self.y + factor * (other.y - self.y),
             luma: self.luma + factor * (other.luma - self.luma),
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Shade for Yxy<T> {
+impl<Wp, T> Shade for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Yxy<T> {
+    fn lighten(&self, amount: T) -> Yxy<Wp, T> {
         Yxy {
             x: self.x,
             y: self.y,
             luma: self.luma + amount,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> ComponentWise for Yxy<T> {
+impl<Wp, T> ComponentWise for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
     type Scalar = T;
 
-    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Yxy<T>, mut f: F) -> Yxy<T> {
+    fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Yxy<Wp, T>, mut f: F) -> Yxy<Wp, T> {
         Yxy {
             x: f(self.x, other.x),
             y: f(self.y, other.y),
             luma: f(self.luma, other.luma),
+            white_point: PhantomData,
         }
     }
 
-    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Yxy<T> {
+    fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Yxy<Wp, T> {
         Yxy {
             x: f(self.x),
             y: f(self.y),
             luma: f(self.luma),
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Default for Yxy<T> {
-    fn default() -> Yxy<T> {
+impl<Wp, T> Default for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    fn default() -> Yxy<Wp, T> {
         // The default for x and y are the white point x and y ( from the default D65).
         // Since Y (luma) is 0.0, this makes the default color black just like for other colors.
         // The reason for not using 0 for x and y is that this outside the usual color gamut and might
         // cause scaling issues.
-        Yxy::new(flt(D65_X), flt(D65_Y), T::zero())
+        let yxy_wp = Wp::get_xyz().into_yxy();
+        Yxy::with_wp(yxy_wp.x, yxy_wp.y, T::zero())
     }
 }
 
-impl<T: Float> Add<Yxy<T>> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Add<Yxy<Wp, T>> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn add(self, other: Yxy<T>) -> Yxy<T> {
+    fn add(self, other: Yxy<Wp, T>) -> Yxy<Wp, T> {
         Yxy {
             x: self.x + other.x,
             y: self.y + other.y,
             luma: self.luma + other.luma,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Add<T> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Add<T> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn add(self, c: T) -> Yxy<T> {
+    fn add(self, c: T) -> Yxy<Wp, T> {
         Yxy {
             x: self.x + c,
             y: self.y + c,
             luma: self.luma + c,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Sub<Yxy<T>> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Sub<Yxy<Wp, T>> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn sub(self, other: Yxy<T>) -> Yxy<T> {
+    fn sub(self, other: Yxy<Wp, T>) -> Yxy<Wp, T> {
         Yxy {
             x: self.x - other.x,
             y: self.y - other.y,
             luma: self.luma - other.luma,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Sub<T> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Sub<T> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn sub(self, c: T) -> Yxy<T> {
+    fn sub(self, c: T) -> Yxy<Wp, T> {
         Yxy {
             x: self.x - c,
             y: self.y - c,
             luma: self.luma - c,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Mul<Yxy<T>> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Mul<Yxy<Wp, T>> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn mul(self, other: Yxy<T>) -> Yxy<T> {
+    fn mul(self, other: Yxy<Wp, T>) -> Yxy<Wp, T> {
         Yxy {
             x: self.x * other.x,
             y: self.y * other.y,
             luma: self.luma * other.luma,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Mul<T> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Mul<T> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn mul(self, c: T) -> Yxy<T> {
+    fn mul(self, c: T) -> Yxy<Wp, T> {
         Yxy {
             x: self.x * c,
             y: self.y * c,
             luma: self.luma * c,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Div<Yxy<T>> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Div<Yxy<Wp, T>> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn div(self, other: Yxy<T>) -> Yxy<T> {
+    fn div(self, other: Yxy<Wp, T>) -> Yxy<Wp, T> {
         Yxy {
             x: self.x / other.x,
             y: self.y / other.y,
             luma: self.luma / other.luma,
+            white_point: PhantomData,
         }
     }
 }
 
-impl<T: Float> Div<T> for Yxy<T> {
-    type Output = Yxy<T>;
+impl<Wp, T> Div<T> for Yxy<Wp, T>
+    where T: Float,
+        Wp: WhitePoint<T>
+{
+    type Output = Yxy<Wp, T>;
 
-    fn div(self, c: T) -> Yxy<T> {
+    fn div(self, c: T) -> Yxy<Wp, T> {
         Yxy {
             x: self.x / c,
             y: self.y / c,
             luma: self.luma / c,
+            white_point: PhantomData,
         }
     }
 }

--- a/tests/convert/data_cie_15_2004.rs
+++ b/tests/convert/data_cie_15_2004.rs
@@ -9,6 +9,7 @@ Tests XYZ and YXY conversion
 
 use csv;
 use palette::{Xyz, Yxy,IntoColor};
+use palette::white_point::D65;
 
 #[derive(RustcDecodable, PartialEq)]
 struct Cie2004Raw{
@@ -22,8 +23,8 @@ struct Cie2004Raw{
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct Cie2004 {
-    xyz: Xyz<f32>,
-    yxy: Yxy<f32>,
+    xyz: Xyz<D65, f32>,
+    yxy: Yxy<D65, f32>,
 }
 
 impl From<Cie2004Raw> for Cie2004 {

--- a/tests/convert/data_color_mine.rs
+++ b/tests/convert/data_color_mine.rs
@@ -4,6 +4,7 @@ List of color from www.colormine.org
 use csv;
 use palette::{Lch, Lab, Xyz, Yxy, Rgb, Hsl, Hsv, Hwb, IntoColor};
 use palette::pixel::Srgb;
+use palette::white_point::D65;
 
 pub const COLOR_MINE_FILE_FULL: &'static str = "tests/convert/data_color_mine.csv";
 pub const COLOR_MINE_FILE_MINI: &'static str = "tests/convert/data_color_mine_mini.csv";
@@ -59,15 +60,15 @@ pub struct ColorMineRaw {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct ColorMine {
-    lab: Lab<f32>,
-    xyz: Xyz<f32>,
-    yxy: Yxy<f32>,
-    lch: Lch<f32>,
-    rgb: Rgb<f32>,
-    linear_rgb: Rgb<f32>,
-    hsl: Hsl<f32>,
-    hsv: Hsv<f32>,
-    hwb: Hwb<f32>,
+    lab: Lab<D65, f32>,
+    xyz: Xyz<D65, f32>,
+    yxy: Yxy<D65, f32>,
+    lch: Lch<D65, f32>,
+    rgb: Rgb<D65, f32>,
+    linear_rgb: Rgb<D65, f32>,
+    hsl: Hsl<D65, f32>,
+    hsv: Hsv<D65, f32>,
+    hwb: Hwb<D65, f32>,
 }
 
 impl From<ColorMineRaw> for ColorMine {
@@ -88,8 +89,8 @@ impl From<ColorMineRaw> for ColorMine {
 
 macro_rules! impl_from_color {
     ($self_ty:ident) => {
-        impl From<$self_ty<f32>> for ColorMine {
-            fn from(color: $self_ty<f32>) -> ColorMine {
+        impl From<$self_ty<D65, f32>> for ColorMine {
+            fn from(color: $self_ty<D65, f32>) -> ColorMine {
                 ColorMine {
                     lab: color.into_lab(),
                     xyz: color.into_xyz(),

--- a/tests/convert/lab_lch.rs
+++ b/tests/convert/lab_lch.rs
@@ -1,10 +1,10 @@
 use palette::{Lab, Lch, IntoColor};
+use palette::white_point::D65;
 
 #[test]
 fn lab_lch_green() {
     let lab = Lab::new(0.4623,-0.517,0.499);
-    let lch = Lch::new(0.4623,	0.7185,	136.02.into());
-
+    let lch = Lch::<D65, f64>::new(0.4623, 0.7185, 136.02.into());
     let expect_lab = lch.into_lab();
     let expect_lch = lab.into_lch();
 
@@ -15,7 +15,7 @@ fn lab_lch_green() {
 #[test]
 fn lab_lch_magenta() {
     let lab = Lab::new(0.6032, 0.9825, -0.6084);
-    let lch = Lch::new(0.6032, 1.1557, 328.23.into());
+    let lch = Lch::<D65, f64>::new(0.6032, 1.1557, 328.23.into());
 
     let expect_lab = lch.into_lab();
     let expect_lch = lab.into_lch();
@@ -28,7 +28,7 @@ fn lab_lch_magenta() {
 fn lab_lch_blue() {
 
     let lab = Lab::new(0.323, 0.792, -1.0786);
-    let lch = Lch::new(0.323, 1.3382, 306.29.into());
+    let lch = Lch::<D65, f64>::new(0.323, 1.3382, 306.29.into());
 
     let expect_lab = lch.into_lab();
     let expect_lch = lab.into_lch();


### PR DESCRIPTION
This is a breaking change.
 
- All colors now have an additional trait bound on WhitePoint.
- All "new" methods on colors now assume a default white point of D65. Use "with_wp" method to get color with another white point.
- Delete tristimulus module.
- Add Xyz values for standard observers and illuminants (D65, D50 etc).
- Implement methods for chromatic adaptation using Bradford, VonKries and Xyz scaling.
- Add Srgb primaries for Rgb <-> Xyz converison.
- Make Rgb to luma conversion to convert via xyz. 

closes #14 