### PR TITLE
Change dependency `num` to `num_traits` to shrink dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ named = []
 strict = []
 
 [dependencies]
-num = "0.1"
+num-traits = "0.1"
 approx = "0.1"
 
 [dependencies.phf]

--- a/examples/readme_examples.rs
+++ b/examples/readme_examples.rs
@@ -1,6 +1,6 @@
 extern crate image;
 extern crate palette;
-extern crate num;
+extern crate num_traits;
 
 use image::{RgbImage, GenericImage};
 

--- a/src/alpha.rs
+++ b/src/alpha.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut, Add, Sub, Mul, Div};
 
-use num::Float;
+use num_traits::Float;
 
 use approx::ApproxEq;
 
@@ -34,7 +34,7 @@ impl<C, T: Float> DerefMut for Alpha<C, T> {
 
 impl<C: Mix> Mix for Alpha<C, C::Scalar> {
     type Scalar = C::Scalar;
-    
+
     fn mix(&self, other: &Alpha<C, C::Scalar>, factor: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
             color: self.color.mix(&other.color, factor),

--- a/src/blend/blend.rs
+++ b/src/blend/blend.rs
@@ -1,4 +1,4 @@
-use num::{Float, One, Zero};
+use num_traits::{Float, One, Zero};
 
 use {ComponentWise, clamp, flt};
 use blend::{PreAlpha, BlendFunction};

--- a/src/blend/equations.rs
+++ b/src/blend/equations.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use {ComponentWise, Blend};
 use blend::{PreAlpha, BlendFunction};

--- a/src/blend/pre_alpha.rs
+++ b/src/blend/pre_alpha.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Sub, Mul, Div, Deref, DerefMut};
 use approx::ApproxEq;
-use num::Float;
+use num_traits::Float;
 
 use {Alpha, ComponentWise, Mix, Blend, clamp};
 
@@ -86,7 +86,7 @@ impl<C, T> Blend for PreAlpha<C, T> where
 
 impl<C: Mix> Mix for PreAlpha<C, C::Scalar> {
     type Scalar = C::Scalar;
-    
+
     fn mix(&self, other: &PreAlpha<C, C::Scalar>, factor: C::Scalar) -> PreAlpha<C, C::Scalar> {
         PreAlpha {
             color: self.color.mix(&other.color, factor),

--- a/src/chromatic_adaptation.rs
+++ b/src/chromatic_adaptation.rs
@@ -22,7 +22,7 @@
 //!//Should print {x: 0.257963, y: 0.139776,z: 0.058825}
 //!println!("{:?}", c)
 //!```
-use num::Float;
+use num_traits::Float;
 
 use {Xyz, FromColor, IntoColor, flt};
 use white_point::WhitePoint;

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use {Alpha, Rgb, Luma, Xyz, Yxy, Lab, Lch, Hsv, Hwb, Hsl, Color};
 use white_point::{WhitePoint, D65};

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 use approx::ApproxEq;
 
 use {Xyz, Yxy, Lab, Lch, Rgb, Hsl, Hsv, Hwb, Luma, LabHue, RgbHue, flt};

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -1,6 +1,6 @@
 //!Types for interpolation between multiple colors.
 
-use num::{Float, One, Zero};
+use num_traits::{Float, One, Zero};
 use std::cmp::max;
 use approx::ApproxEq;
 

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub};
 use std::marker::PhantomData;

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub};
 use std::marker::PhantomData;

--- a/src/hues.rs
+++ b/src/hues.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::f64::consts::PI;
 use std::cmp::PartialEq;

--- a/src/hwb.rs
+++ b/src/hwb.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub};
 use std::marker::PhantomData;

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 use std::marker::PhantomData;

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub};
 use std::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,12 @@
 #[cfg_attr(test, macro_use)]
 extern crate approx;
 
-extern crate num;
+extern crate num_traits;
 
 #[cfg(feature = "phf")]
 extern crate phf;
 
-use num::{Float, ToPrimitive, NumCast};
+use num_traits::{Float, ToPrimitive, NumCast};
 
 use approx::ApproxEq;
 
@@ -692,6 +692,6 @@ pub trait ComponentWise {
 }
 
 ///A convenience function to convert a constant number to Float Type
-fn flt<T: num::Float, P: ToPrimitive>(prim: P) -> T {
+fn flt<T: num_traits::Float, P: ToPrimitive>(prim: P) -> T {
     NumCast::from(prim).unwrap()
 }

--- a/src/luma.rs
+++ b/src/luma.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 use std::marker::PhantomData;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,7 +1,7 @@
 //!This module provides simple matrix operations on 3x3 matrix to aid in chromatic adaptation and
 //!conversion calculations.
 
-use num::Float;
+use num_traits::Float;
 
 use std::marker::PhantomData;
 

--- a/src/pixel/gamma_rgb.rs
+++ b/src/pixel/gamma_rgb.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::marker::PhantomData;
 

--- a/src/pixel/mod.rs
+++ b/src/pixel/mod.rs
@@ -1,6 +1,6 @@
 //!Pixel encodings and pixel format conversion.
 
-use num::Float;
+use num_traits::Float;
 
 use {clamp, flt};
 

--- a/src/pixel/srgb.rs
+++ b/src/pixel/srgb.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::marker::PhantomData;
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 use std::marker::PhantomData;

--- a/src/rgb_primaries.rs
+++ b/src/rgb_primaries.rs
@@ -1,5 +1,5 @@
 //!This module defines the red, blue and green primaries for the common Rgb color spaces
-use num::Float;
+use num_traits::Float;
 
 
 use {Yxy, Xyz, Rgb, IntoColor};

--- a/src/white_point.rs
+++ b/src/white_point.rs
@@ -6,7 +6,7 @@
 //!unacceptable results when attempting to color-correct a photograph taken with incandescent lighting.
 
 
-use num::Float;
+use num_traits::Float;
 
 use {Xyz, flt};
 
@@ -17,7 +17,7 @@ use {Xyz, flt};
 ///"white" in image capture, encoding, or reproduction.
 ///
 ///Custom white points can be easily defined on an empty struct with the tristimulus values
-///and can be used in place of the ones defined in this library. 
+///and can be used in place of the ones defined in this library.
 pub trait WhitePoint<T: Float>: Sized {
     ///Get the Xyz chromacity co-ordinates for the white point.
     fn get_xyz() -> Xyz<Self, T>;

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 use std::marker::PhantomData;

--- a/src/yxy.rs
+++ b/src/yxy.rs
@@ -1,4 +1,4 @@
-use num::Float;
+use num_traits::Float;
 
 use std::ops::{Add, Sub, Mul, Div};
 use std::marker::PhantomData;

--- a/tests/color_checker.rs
+++ b/tests/color_checker.rs
@@ -2,7 +2,7 @@
 extern crate approx;
 #[macro_use]
 extern crate lazy_static;
-extern crate num;
+extern crate num_traits;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;

--- a/tests/pointer_convert.rs
+++ b/tests/pointer_convert.rs
@@ -2,7 +2,7 @@
 extern crate approx;
 #[macro_use]
 extern crate lazy_static;
-extern crate num;
+extern crate num_traits;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;

--- a/tests/pointer_dataset/pointer_data.rs
+++ b/tests/pointer_dataset/pointer_data.rs
@@ -11,7 +11,7 @@ u', v'		0.2008907213	0.4608888395
 Note: The xyz and yxy conversions do not use the updated conversion formula. So they are not used.
 */
 
-use num::{Float, ToPrimitive, NumCast};
+use num_traits::{Float, ToPrimitive, NumCast};
 use csv;
 use palette::{Xyz, Lch, Lab, IntoColor};
 use palette::white_point::WhitePoint;


### PR DESCRIPTION
This crate only uses traits from the `num` crate. These traits live in
their own crate called `num_traits` which has way fewer dependencies. By
default, `num` pulls all its children crates such as `num-bigint` in. This
in turn brings some heavy crates such as `rand` into the dependency tree.

I tried to use this crate in a wasm project and `rand` currently doesn't compile for the new wasm target. That's the way I found out. 

Changing dependencies like that is probably a breaking change? Or is it? Since `num` in turn had `num_traits` as a dependency? Maybe it's fine...

Btw: awesome crate :)