### PR TITLE
Add serde support as an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ palette = "0.3"
 
 These features are enabled by default:
 
- * `"named"` - Enables color constants, located in the `named` module.
- * `"named_from_str"` - Enables the `named::from_str`, which maps name string to colors.
+* `"named"` - Enables color constants, located in the `named` module.
+* `"named_from_str"` - Enables the `named::from_str`, which maps name string to colors.
 
-# Linear?
+These features are disabled by default:
+
+* `"serde"` - Enables color serializing and deserializing.
+
+## Linear?
 
 Colors in, for example, images are often "gamma corrected" or stored in sRGB
 format as a compression method and to prevent banding. This is also a bit of a
@@ -41,12 +45,12 @@ any operations on the colors are accurate. This library uses a completely
 linear work flow, and comes with the tools for transitioning between linear
 and non-linear RGB.
 
-# What Can It Do?
+## What Can It Do?
 
 Palette provides tools for both color manipulation and conversion between
 color spaces. These are some highlights.
 
-## Color Spaces
+### Color Spaces
 
 RGB is probably the most widely known color space, but it's not the only one.
 You have probably used a color picker with a rainbow wheel and a brightness
@@ -75,7 +79,7 @@ This results in the following two colors:
 
 ![Hue Shift Comparison](gfx/readme_color_spaces.png)
 
-## Manipulation
+### Manipulation
 
 Palette comes with a number of color manipulation tools, that are implemented
 as traits. These includes lighten/darken, saturate/desaturate and hue shift.
@@ -104,8 +108,7 @@ This results in the following three colors:
 
 ![Manipulation Comparison](gfx/readme_manipulation.png)
 
-
-## Gradients
+### Gradients
 
 There is also a linear gradient type which makes it easy to interpolate
 between a series of colors. This gradient can be used in any color space and
@@ -134,12 +137,12 @@ hue:
 
 ![Gradient Comparison](gfx/readme_gradients.png)
 
-# What It Isn't
+## What It Isn't
 
 This library is only meant for color manipulation and conversion. It's not...
 
- * ...an image manipulation library. It will only handle colors, and not whole images.
- * ...an optimal pixel storage format. The colors are represented by linear floats, which is not a compact format and not meant to be displayed.
+* ...an image manipulation library. It will only handle colors, and not whole images.
+* ...an optimal pixel storage format. The colors are represented by linear floats, which is not a compact format and not meant to be displayed.
 
 You will have to look elsewhere for those particular features. There are,
 however, tools and traits in the [`pixel`][pixel_module] module for converting
@@ -148,18 +151,18 @@ Palette and other graphical libraries.
 
 [pixel_module]: https://ogeon.github.io/docs/palette/master/palette/pixel/index.html
 
-# Contributing
+## Contributing
 
 All sorts of contributions are welcome, no matter how huge or tiny, so take a
 look at [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, if you are
 interested.
 
-# License
+## License
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -29,6 +29,12 @@ approx = "0.1"
 version = "0.7"
 optional = true
 
+[dependencies.serde]
+#feature
+version = "1"
+features = ["serde_derive"]
+optional = true
+
 [dev-dependencies]
 image = "0.18"
 clap = "2"
@@ -36,6 +42,7 @@ csv = "1.0.0-beta.3"
 serde = "1"
 serde_derive = "1"
 lazy_static = "1"
+serde_json = "1"
 
 [build-dependencies.phf_codegen]
 version = "0.7"

--- a/palette/examples/color_scheme.rs
+++ b/palette/examples/color_scheme.rs
@@ -111,7 +111,7 @@ fn main() {
 
             vec![
                 primary.shift_hue(shift),
-                primary.shift_hue((-shift)),
+                primary.shift_hue(-shift),
             ]
         }
         ("analogous", matches) => {
@@ -125,7 +125,7 @@ fn main() {
 
             vec![
                 primary.shift_hue(shift),
-                primary.shift_hue((-shift)),
+                primary.shift_hue(-shift),
             ]
         }
         ("rectangle", matches) => {

--- a/palette/src/alpha.rs
+++ b/palette/src/alpha.rs
@@ -10,9 +10,11 @@ use encoding::pixel::RawPixel;
 
 ///An alpha component wrapper for colors.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Alpha<C, T> {
     ///The color.
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub color: C,
 
     ///The transparency component. 0.0 is fully transparent and 1.0 is fully
@@ -307,5 +309,28 @@ impl<C, T: Component> From<C> for Alpha<C, T> {
             color: color,
             alpha: T::max_intensity(),
         }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+mod test {
+    use rgb::Rgba;
+    use encoding::Srgb;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Rgba::<Srgb>::new(0.3, 0.8, 0.1, 0.5)).unwrap();
+
+        assert_eq!(serialized, r#"{"red":0.3,"green":0.8,"blue":0.1,"alpha":0.5}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Rgba<Srgb> = ::serde_json::from_str(r#"{"red":0.3,"green":0.8,"blue":0.1,"alpha":0.5}"#).unwrap();
+
+        assert_eq!(deserialized, Rgba::<Srgb>::new(0.3, 0.8, 0.1, 0.5));
     }
 }

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -26,6 +26,7 @@ pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 ///
 ///See [HSV](struct.Hsv.html) for a very similar color space, with brightness instead of lightness.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_rgb_space = "S"]
 #[palette_white_point = "S::WhitePoint"]
@@ -51,6 +52,7 @@ where
 
     ///The white point and RGB primaries this color is adapted to. The default
     ///is the sRGB standard.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub space: PhantomData<S>,
 }
 
@@ -578,4 +580,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Hsl<Srgb>: hue, saturation, lightness);
     raw_pixel_conversion_fail_tests!(Hsl<Srgb>: hue, saturation, lightness);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Hsl::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"hue":0.3,"saturation":0.8,"lightness":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Hsl = ::serde_json::from_str(r#"{"hue":0.3,"saturation":0.8,"lightness":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Hsl::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -25,6 +25,7 @@ pub type Hsva<S = Srgb, T = f32> = Alpha<Hsv<S, T>, T>;
 ///and white (100% R, 100% G, 100% B) has the same brightness (or value), but
 ///not the same lightness.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_white_point = "S::WhitePoint"]
 #[palette_rgb_space = "S"]
@@ -51,6 +52,7 @@ where
 
     ///The white point and RGB primaries this color is adapted to. The default
     ///is the sRGB standard.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub space: PhantomData<S>,
 }
 
@@ -587,4 +589,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Hsv<Srgb>: hue, saturation, value);
     raw_pixel_conversion_fail_tests!(Hsv<Srgb>: hue, saturation, value);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Hsv::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"hue":0.3,"saturation":0.8,"value":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Hsv = ::serde_json::from_str(r#"{"hue":0.3,"saturation":0.8,"value":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Hsv::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -16,6 +16,7 @@ macro_rules! make_hues {
         /// also have some surprising effects if it's expected to act as a
         /// linear number.
         #[derive(Clone, Copy, Debug, Default)]
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         #[repr(C)]
         pub struct $name<T: Float = f32>(T);
 
@@ -311,5 +312,21 @@ mod test {
 
             assert_eq!(RgbHue::from(degs), RgbHue::from(pos_degs));
         }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&RgbHue::from_degrees(10.2)).unwrap();
+
+        assert_eq!(serialized, "10.2");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: RgbHue = ::serde_json::from_str("10.2").unwrap();
+
+        assert_eq!(deserialized, RgbHue::from_degrees(10.2));
     }
 }

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -23,6 +23,7 @@ pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 ///
 ///It is very intuitive for humans to use and many color-pickers are based on the HWB color system
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_rgb_space = "S"]
 #[palette_white_point = "S::WhitePoint"]
@@ -52,6 +53,7 @@ where
 
     ///The white point and RGB primaries this color is adapted to. The default
     ///is the sRGB standard.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub space: PhantomData<S>,
 }
 
@@ -521,4 +523,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Hwb<Srgb>: hue, whiteness, blackness);
     raw_pixel_conversion_fail_tests!(Hwb<Srgb>: hue, whiteness, blackness);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Hwb::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"hue":0.3,"whiteness":0.8,"blackness":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Hwb = ::serde_json::from_str(r#"{"hue":0.3,"whiteness":0.8,"blackness":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Hwb::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -25,6 +25,7 @@ pub type Laba<Wp, T = f32> = Alpha<Lab<Wp, T>, T>;
 ///The parameters of L\*a\*b\* are quite different, compared to many other color
 ///spaces, so manipulating them manually may be unintuitive.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_white_point = "Wp"]
 #[palette_component = "T"]
@@ -47,6 +48,7 @@ where
 
     ///The white point associated with the color's illuminant and observer.
     ///D65 for 2 degree observer is used by default.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub white_point: PhantomData<Wp>,
 }
 
@@ -497,4 +499,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Lab<D65>: l, a, b);
     raw_pixel_conversion_fail_tests!(Lab<D65>: l, a, b);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Lab::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"l":0.3,"a":0.8,"b":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Lab = ::serde_json::from_str(r#"{"l":0.3,"a":0.8,"b":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Lab::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -20,6 +20,7 @@ pub type Lcha<Wp, T = f32> = Alpha<Lch<Wp, T>, T>;
 ///[HSV](struct.Hsv.html). This gives it the same ability to directly change
 ///the hue and colorfulness of a color, while preserving other visual aspects.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_white_point = "Wp"]
 #[palette_component = "T"]
@@ -46,6 +47,7 @@ where
 
     ///The white point associated with the color's illuminant and observer.
     ///D65 for 2 degree observer is used by default.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub white_point: PhantomData<Wp>,
 }
 
@@ -393,4 +395,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Lch<D65>: l, chroma, hue);
     raw_pixel_conversion_fail_tests!(Lch<D65>: l, chroma, hue);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Lch::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"l":0.3,"chroma":0.8,"hue":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Lch = ::serde_json::from_str(r#"{"l":0.3,"chroma":0.8,"hue":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Lch::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -80,6 +80,12 @@ extern crate num_traits;
 #[cfg(feature = "phf")]
 extern crate phf;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+#[cfg(all(test, feature = "serde"))]
+extern crate serde_json;
+
 use num_traits::{Float, NumCast, ToPrimitive, Zero};
 
 use approx::ApproxEq;

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -27,6 +27,7 @@ pub type Lumaa<S = Srgb, T = f32> = Alpha<Luma<S, T>, T>;
 ///XYZ](struct.Xyz.html). The lack of any form of hue representation limits
 ///the set of operations that can be performed on it.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_white_point = "S::WhitePoint"]
 #[palette_component = "T"]
@@ -41,6 +42,7 @@ where
     pub luma: T,
 
     /// The kind of RGB standard. sRGB is the default.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub standard: PhantomData<S>,
 }
 
@@ -552,4 +554,20 @@ mod test {
     }
 
     raw_pixel_conversion_tests!(Luma<Srgb>: luma);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Luma::<Srgb>::new(0.3)).unwrap();
+
+        assert_eq!(serialized, r#"{"luma":0.3}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Luma<Srgb> = ::serde_json::from_str(r#"{"luma":0.3}"#).unwrap();
+
+        assert_eq!(deserialized, Luma::<Srgb>::new(0.3));
+    }
 }

--- a/palette/src/named.rs
+++ b/palette/src/named.rs
@@ -1,5 +1,5 @@
-//!A collection of named color constants. Can be toggled with the `"named"`
-//!Cargo feature.
+//!A collection of named color constants. Can be toggled with the `"named"` and `"named_from_str"`
+//!Cargo features.
 //!
 //!They are taken from the [SVG keyword
 //!colors](https://www.w3.org/TR/SVG/types.html#ColorKeywords) (same as in
@@ -11,12 +11,12 @@
 //!
 //!//From constant
 //!let from_const = Srgb::<f32>::from_format(named::OLIVE).into_linear();
-//!
-//!//From name string
-//!let olive = named::from_str("olive").expect("unknown color");
-//!let from_str = Srgb::<f32>::from_format(olive).into_linear();
-//!
-//!assert_eq!(from_const, from_str);
+#![cfg_attr(feature = "named_from_str", doc = "")]
+#![cfg_attr(feature = "named_from_str", doc = "//From name string")]
+#![cfg_attr(feature = "named_from_str", doc = "let olive = named::from_str(\"olive\").expect(\"unknown color\");")]
+#![cfg_attr(feature = "named_from_str", doc = "let from_str = Srgb::<f32>::from_format(olive).into_linear();")]
+#![cfg_attr(feature = "named_from_str", doc = "")]
+#![cfg_attr(feature = "named_from_str", doc = "assert_eq!(from_const, from_str);")]
 //!```
 
 include!(concat!(env!("OUT_DIR"), "/named.rs"));

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -35,6 +35,7 @@ pub type Rgba<S = Srgb, T = f32> = Alpha<Rgb<S, T>, T>;
 /// displayable RGB, such as sRGB. See the [`pixel`](pixel/index.html) module
 /// for encoding formats.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_rgb_space = "S::Space"]
 #[palette_white_point = "<S::Space as RgbSpace>::WhitePoint"]
@@ -55,6 +56,7 @@ pub struct Rgb<S: RgbStandard = Srgb, T: Component = f32> {
     pub blue: T,
 
     /// The kind of RGB standard. sRGB is the default.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub standard: PhantomData<S>,
 }
 
@@ -775,4 +777,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Rgb<Srgb>: red, green, blue);
     raw_pixel_conversion_fail_tests!(Rgb<Srgb>: red, green, blue);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Rgb::<Srgb>::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"red":0.3,"green":0.8,"blue":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Rgb<Srgb> = ::serde_json::from_str(r#"{"red":0.3,"green":0.8,"blue":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Rgb::<Srgb>::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -25,6 +25,7 @@ pub type Xyza<Wp = D65, T = f32> = Alpha<Xyz<Wp, T>, T>;
 ///
 ///Conversions and operations on this color space depend on the defined white point
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_white_point = "Wp"]
 #[palette_component = "T"]
@@ -49,6 +50,7 @@ where
 
     ///The white point associated with the color's illuminant and observer.
     ///D65 for 2 degree observer is used by default.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub white_point: PhantomData<Wp>,
 }
 
@@ -513,4 +515,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Xyz<D65>: x, y, z);
     raw_pixel_conversion_fail_tests!(Xyz<D65>: x, y, z);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Xyz::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"x":0.3,"y":0.8,"z":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Xyz = ::serde_json::from_str(r#"{"x":0.3,"y":0.8,"z":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Xyz::new(0.3, 0.8, 0.1));
+    }
 }

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -22,6 +22,7 @@ pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 ///
 ///Conversions and operations on this color space depend on the white point.
 #[derive(Debug, PartialEq, FromColor)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[palette_internal]
 #[palette_white_point = "Wp"]
 #[palette_component = "T"]
@@ -47,6 +48,7 @@ where
 
     ///The white point associated with the color's illuminant and observer.
     ///D65 for 2 degree observer is used by default.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub white_point: PhantomData<Wp>,
 }
 
@@ -478,4 +480,20 @@ mod test {
 
     raw_pixel_conversion_tests!(Yxy<D65>: x, y, luma);
     raw_pixel_conversion_fail_tests!(Yxy<D65>: x, y, luma);
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize() {
+        let serialized = ::serde_json::to_string(&Yxy::new(0.3, 0.8, 0.1)).unwrap();
+
+        assert_eq!(serialized, r#"{"x":0.3,"y":0.8,"luma":0.1}"#);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize() {
+        let deserialized: Yxy = ::serde_json::from_str(r#"{"x":0.3,"y":0.8,"luma":0.1}"#).unwrap();
+
+        assert_eq!(deserialized, Yxy::new(0.3, 0.8, 0.1));
+    }
 }

--- a/scripts/test_features.sh
+++ b/scripts/test_features.sh
@@ -35,11 +35,11 @@ done < "Cargo.toml"
 echo -e "features: $features\n"
 
 #Test without any optional feature
-echo compiling with --no-default-features --features "$required_features"
-cargo build --no-default-features --features "$required_features"
+echo testing with --no-default-features --features "$required_features"
+cargo test --no-default-features --features "$required_features"
 
 #Isolated test of each optional feature
 for feature in $features; do
-	echo compiling with --no-default-features --features "\"$feature $required_features\""
-	cargo build --no-default-features --features "$feature $required_features"
+	echo testing with --no-default-features --features "\"$feature $required_features\""
+	cargo test --no-default-features --features "$feature $required_features"
 done


### PR DESCRIPTION
This add serialization support to the color spaces, with and without transparency.

Closes #83