### PR TITLE
Add Extended Conversion Trait 

### DIFF
--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -520,7 +520,11 @@ impl<T> OutOfBounds<T> {
     }
 }
 
-impl<T: Debug> error::Error for OutOfBounds<T> {}
+impl<T: Debug> error::Error for OutOfBounds<T> {
+    fn description(&self) -> &str {
+        "Color conversion is out of bounds"
+    }
+}
 
 impl<T> Display for OutOfBounds<T> {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -534,8 +534,6 @@ impl<T> Display for OutOfBounds<T> {
 }
 
 ///A trait for converting a color into another.
-///
-///`convert_unclamped` currently wraps the underlying `Into` implementation.
 pub trait ConvertInto<T>: Into<T> {
     ///Convert into T with values clamped to the color defined bounds
     ///
@@ -561,9 +559,7 @@ pub trait ConvertInto<T>: Into<T> {
     ///assert!(!rgb.is_valid());
     ///```
     #[inline]
-    fn convert_unclamped_into(self) -> T {
-        self.into()
-    }
+    fn convert_unclamped_into(self) -> T;
 
     ///Convert into T, returning ok if the color is inside of its defined range,
     ///otherwise an `OutOfBounds` error is returned which contains the unclamped color.
@@ -585,7 +581,7 @@ pub trait ConvertInto<T>: Into<T> {
 
 ///A trait for converting one color from another.
 ///
-///`convert_unclamped` currently wraps the underlying `Into` implementation.
+///`convert_unclamped` currently wraps the underlying `From` implementation.
 pub trait ConvertFrom<T>: From<T> {
     ///Convert from T with values clamped to the color defined bounds
     ///
@@ -660,22 +656,15 @@ impl<T, U> ConvertInto<U> for T where U: ConvertFrom<T> {
     }
 
     #[inline]
+    fn convert_unclamped_into(self) -> U {
+        U::convert_unclamped_from(self)
+    }
+
+    #[inline]
     fn try_convert_into(self) -> Result<U, OutOfBounds<U>> {
         U::try_convert_from(self)
     }
 }
-
-/*
-impl_convert!(impl<S: RgbStandard> Rgb<S>);
-impl_convert!(impl<S: LumaStandard> Luma<S>);
-impl_convert!(float_component impl<S: RgbSpace> Hsl<S>);
-impl_convert!(float_component impl<S: RgbSpace> Hsv<S>);
-impl_convert!(float_component impl<S: RgbSpace> Hwb<S>);
-impl_convert!(float_component impl<Wp: WhitePoint> Lab<Wp>);
-impl_convert!(float_component impl<Wp: WhitePoint> Lch<Wp>);
-impl_convert!(float_component impl<Wp: WhitePoint> Xyz<Wp>);
-impl_convert!(float_component impl<Wp: WhitePoint> Yxy<Wp>);
-*/
 
 macro_rules! impl_into_color {
     ($self_ty: ident, $from_fn: ident) => {

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -182,7 +182,7 @@ pub use rgb::{GammaSrgb, GammaSrgba, LinSrgb, LinSrgba, Srgb, Srgba};
 pub use xyz::{Xyz, Xyza};
 pub use yxy::{Yxy, Yxya};
 
-pub use convert::{FromColor, IntoColor};
+pub use convert::{Convert, ConvertWith, FromColor, IntoColor};
 pub use encoding::pixel::Pixel;
 pub use hues::{LabHue, RgbHue};
 pub use matrix::Mat3;

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -182,7 +182,7 @@ pub use rgb::{GammaSrgb, GammaSrgba, LinSrgb, LinSrgba, Srgb, Srgba};
 pub use xyz::{Xyz, Xyza};
 pub use yxy::{Yxy, Yxya};
 
-pub use convert::{Convert, ConvertWith, FromColor, IntoColor};
+pub use convert::{Convert, ResultExt, OutOfBounds, FromColor, IntoColor};
 pub use encoding::pixel::Pixel;
 pub use hues::{LabHue, RgbHue};
 pub use matrix::Mat3;

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -182,7 +182,7 @@ pub use rgb::{GammaSrgb, GammaSrgba, LinSrgb, LinSrgba, Srgb, Srgba};
 pub use xyz::{Xyz, Xyza};
 pub use yxy::{Yxy, Yxya};
 
-pub use convert::{Convert, ResultExt, OutOfBounds, FromColor, IntoColor};
+pub use convert::{ConvertFrom, ConvertInto, OutOfBounds, FromColor, IntoColor};
 pub use encoding::pixel::Pixel;
 pub use hues::{LabHue, RgbHue};
 pub use matrix::Mat3;


### PR DESCRIPTION
This commit tries to implement a conversion trait similar to the one mentioned in #41 mimicking the `From`/`Into` traits of the `std` library.

`convert_*` clamps the resulting color to its color space limitations.
`convert_unclamped_*` simply converts the color.
`try_convert_*` converts the color and returns it in a `Result` depending on it being valid or not.