### PR TITLE
Add non-quantized support for Rec.601 and Rec.709

### DIFF
--- a/palette/src/encoding/itu.rs
+++ b/palette/src/encoding/itu.rs
@@ -185,19 +185,19 @@ impl DifferenceFn for DifferenceFn601 {
         [cast(r), cast(g), cast(b)]
     }
 
-    fn norm_blue<T: Float>(denorm: T) -> T {
+    fn normalize_blue<T: Float>(denorm: T) -> T {
         denorm / cast(BT601_BLUE_NORM)
     }
 
-    fn denorm_blue<T: Float>(norm: T) -> T {
+    fn denormalize_blue<T: Float>(norm: T) -> T {
         norm * cast(BT601_BLUE_NORM)
     }
 
-    fn norm_red<T: Float>(denorm: T) -> T {
+    fn normalize_red<T: Float>(denorm: T) -> T {
         denorm / cast(BT601_RED_NORM)
     }
 
-    fn denorm_red<T: Float>(norm: T) -> T {
+    fn denormalize_red<T: Float>(norm: T) -> T {
         norm * cast(BT601_RED_NORM)
     }
 }
@@ -209,19 +209,19 @@ impl DifferenceFn for DifferenceFn709 {
         [cast(r), cast(g), cast(b)]
     }
 
-    fn norm_blue<T: Float>(denorm: T) -> T {
+    fn normalize_blue<T: Float>(denorm: T) -> T {
         denorm / cast(BT709_BLUE_NORM)
     }
 
-    fn denorm_blue<T: Float>(norm: T) -> T {
+    fn denormalize_blue<T: Float>(norm: T) -> T {
         norm * cast(BT709_BLUE_NORM)
     }
 
-    fn norm_red<T: Float>(denorm: T) -> T {
+    fn normalize_red<T: Float>(denorm: T) -> T {
         denorm / cast(BT709_RED_NORM)
     }
 
-    fn denorm_red<T: Float>(norm: T) -> T {
+    fn denormalize_red<T: Float>(norm: T) -> T {
         norm * cast(BT709_RED_NORM)
     }
 }

--- a/palette/src/encoding/itu.rs
+++ b/palette/src/encoding/itu.rs
@@ -225,3 +225,72 @@ impl DifferenceFn for DifferenceFn709 {
         norm * cast(BT709_RED_NORM)
     }
 }
+
+/// Forwards to the `DifferenceFn` of the yuv standard.
+impl DifferenceFn for BT601_525 {
+    fn luminance<T: Float>() -> [T; 3] {
+        DifferenceFn601::luminance()
+    }
+
+    fn normalize_blue<T: Float>(denorm: T) -> T {
+        DifferenceFn601::normalize_blue(denorm)
+    }
+
+    fn denormalize_blue<T: Float>(norm: T) -> T {
+        DifferenceFn601::denormalize_blue(norm)
+    }
+
+    fn normalize_red<T: Float>(denorm: T) -> T {
+        DifferenceFn601::normalize_red(denorm)
+    }
+
+    fn denormalize_red<T: Float>(norm: T) -> T {
+        DifferenceFn601::denormalize_red(norm)
+    }
+}
+
+/// Forwards to the `DifferenceFn` of the yuv standard.
+impl DifferenceFn for BT601_625 {
+    fn luminance<T: Float>() -> [T; 3] {
+        DifferenceFn601::luminance()
+    }
+
+    fn normalize_blue<T: Float>(denorm: T) -> T {
+        DifferenceFn601::normalize_blue(denorm)
+    }
+
+    fn denormalize_blue<T: Float>(norm: T) -> T {
+        DifferenceFn601::denormalize_blue(norm)
+    }
+
+    fn normalize_red<T: Float>(denorm: T) -> T {
+        DifferenceFn601::normalize_red(denorm)
+    }
+
+    fn denormalize_red<T: Float>(norm: T) -> T {
+        DifferenceFn601::denormalize_red(norm)
+    }
+}
+
+/// Forwards to the `DifferenceFn` of the yuv standard.
+impl DifferenceFn for BT709 {
+    fn luminance<T: Float>() -> [T; 3] {
+        DifferenceFn709::luminance()
+    }
+
+    fn normalize_blue<T: Float>(denorm: T) -> T {
+        DifferenceFn709::normalize_blue(denorm)
+    }
+
+    fn denormalize_blue<T: Float>(norm: T) -> T {
+        DifferenceFn709::denormalize_blue(norm)
+    }
+
+    fn normalize_red<T: Float>(denorm: T) -> T {
+        DifferenceFn709::normalize_red(denorm)
+    }
+
+    fn denormalize_red<T: Float>(norm: T) -> T {
+        DifferenceFn709::denormalize_red(norm)
+    }
+}

--- a/palette/src/encoding/itu.rs
+++ b/palette/src/encoding/itu.rs
@@ -1,0 +1,134 @@
+use float::Float;
+
+use rgb::{Primaries, RgbSpace, RgbStandard};
+use luma::LumaStandard;
+use encoding::TransferFn;
+use white_point::{D65, WhitePoint};
+use {cast, Component, Yxy};
+
+///The color space of ITU-R BT601 for 525-line.
+///
+/// See [ITU-R Rec.601].
+///
+/// [ITU-R Rec.601]: https://www.itu.int/rec/R-REC-BT.601/
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BT601_525;
+
+/// The color space of ITU-R BT601 for 625-line.
+///
+/// See [ITU-R Rec.601].
+///
+/// [ITU-R Rec.601]: https://www.itu.int/rec/R-REC-BT.601/
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BT601_625;
+
+/// The color space of ITU-R BT709.
+///
+/// See [ITU-R Rec.709].
+///
+/// [ITU-R Rec.709]: https://www.itu.int/rec/R-REC-BT.709/
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BT709;
+
+/// This transfer function is shared between `BT601` and `BT709`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Transfer601And709;
+
+impl Primaries for BT601_525 {
+    fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.6300), cast(0.3400), cast(0.2990))
+    }
+    fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.3100), cast(0.5950), cast(0.5870))
+    }
+    fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.1550), cast(0.0700), cast(0.1140))
+    }
+}
+
+impl Primaries for BT601_625 {
+    fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(0.2990))
+    }
+    fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.2900), cast(0.6000), cast(0.5870))
+    }
+    fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(0.1140))
+    }
+}
+
+impl Primaries for BT709 {
+    fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(0.212656))
+    }
+    fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.3000), cast(0.6000), cast(0.715158))
+    }
+    fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
+        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(0.072186))
+    }
+}
+
+impl RgbSpace for BT601_525 {
+    type Primaries = BT601_525;
+    type WhitePoint = D65;
+}
+
+impl RgbSpace for BT601_625 {
+    type Primaries = BT601_625;
+    type WhitePoint = D65;
+}
+
+impl RgbSpace for BT709 {
+    type Primaries = BT709;
+    type WhitePoint = D65;
+}
+
+impl RgbStandard for BT601_525 {
+    type Space = BT601_525;
+    type TransferFn = Transfer601And709;
+}
+
+impl RgbStandard for BT601_625 {
+    type Space = BT601_625;
+    type TransferFn = Transfer601And709;
+}
+
+impl RgbStandard for BT709 {
+    type Space = BT709;
+    type TransferFn = Transfer601And709;
+}
+
+impl LumaStandard for BT601_525 {
+    type WhitePoint = D65;
+    type TransferFn = Transfer601And709;
+}
+
+impl LumaStandard for BT601_625 {
+    type WhitePoint = D65;
+    type TransferFn = Transfer601And709;
+}
+
+impl LumaStandard for BT709 {
+    type WhitePoint = D65;
+    type TransferFn = Transfer601And709;
+}
+
+impl TransferFn for Transfer601And709 {
+    fn into_linear<T: Float>(x: T) -> T {
+        if x <= cast(0.0091) {
+            x / cast(4.500)
+        } else {
+            ((x + cast(0.099)) / cast(1.099)).powf(T::one() / cast(0.45))
+        }
+    }
+
+    fn from_linear<T: Float>(x: T) -> T {
+        if x <= cast(0.0018) {
+            x * cast(4.500)
+        } else {
+            x.powf(cast(0.45)) * cast(1.099) - cast(0.099)
+        }
+    }
+}

--- a/palette/src/encoding/itu.rs
+++ b/palette/src/encoding/itu.rs
@@ -1,8 +1,10 @@
+//! Encodings derived from ITU (International Telecommunication Union) recommendations.
 use float::Float;
 
+use encoding::TransferFn;
 use rgb::{Primaries, RgbSpace, RgbStandard};
 use luma::LumaStandard;
-use encoding::TransferFn;
+use yuv::{DifferenceFn, YuvStandard};
 use white_point::{D65, WhitePoint};
 use {cast, Component, Yxy};
 
@@ -34,39 +36,64 @@ pub struct BT709;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Transfer601And709;
 
+/// The Yuv encoding difference functions for BT601.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct DifferenceFn601;
+
+/// The Yuv encoding difference functions for BT709.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct DifferenceFn709;
+
+// See 2.5.1 (page 2). RGB primary luminances.
+const BT601_LUMINANCE: (f64, f64, f64) = (0.2990, 0.5870, 0.1140);
+// Divisor to renormalize the blue difference signal.
+const BT601_BLUE_NORM: f64 = 1.772;
+// Divisor to renormalize the red difference signal.
+const BT601_RED_NORM: f64 = 1.402;
+
+// Exact primary luminances derived from the color space primaries.
+const BT709_LUMINANCE: (f64, f64, f64) = (0.212656, 0.715158, 0.072186);
+// Luminances for the sake of exact specification compliance for YUV luminance.
+// See 3.2 (page 4)
+const BT709_WEIGHTS: (f64, f64, f64) = (0.2126, 0.7152, 0.07212);
+// Divisor to renormalize the blue difference signal.
+const BT709_BLUE_NORM: f64 = 1.8556;
+// Divisor to renormalize the red difference signal.
+const BT709_RED_NORM: f64 = 1.5748;
+
 impl Primaries for BT601_525 {
     fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.6300), cast(0.3400), cast(0.2990))
+        Yxy::with_wp(cast(0.6300), cast(0.3400), cast(BT601_LUMINANCE.0))
     }
     fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.3100), cast(0.5950), cast(0.5870))
+        Yxy::with_wp(cast(0.3100), cast(0.5950), cast(BT601_LUMINANCE.1))
     }
     fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.1550), cast(0.0700), cast(0.1140))
+        Yxy::with_wp(cast(0.1550), cast(0.0700), cast(BT601_LUMINANCE.2))
     }
 }
 
 impl Primaries for BT601_625 {
     fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(0.2990))
+        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(BT601_LUMINANCE.0))
     }
     fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.2900), cast(0.6000), cast(0.5870))
+        Yxy::with_wp(cast(0.2900), cast(0.6000), cast(BT601_LUMINANCE.1))
     }
     fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(0.1140))
+        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(BT601_LUMINANCE.2))
     }
 }
 
 impl Primaries for BT709 {
     fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(0.212656))
+        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(BT709_LUMINANCE.0))
     }
     fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.3000), cast(0.6000), cast(0.715158))
+        Yxy::with_wp(cast(0.3000), cast(0.6000), cast(BT709_LUMINANCE.1))
     }
     fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(0.072186))
+        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(BT709_LUMINANCE.2))
     }
 }
 
@@ -115,6 +142,24 @@ impl LumaStandard for BT709 {
     type TransferFn = Transfer601And709;
 }
 
+impl YuvStandard for BT601_525 {
+    type RgbSpace = Self;
+    type TransferFn = Transfer601And709;
+    type DifferenceFn = DifferenceFn601;
+}
+
+impl YuvStandard for BT601_625 {
+    type RgbSpace = Self;
+    type TransferFn = Transfer601And709;
+    type DifferenceFn = DifferenceFn601;
+}
+
+impl YuvStandard for BT709 {
+    type RgbSpace = Self;
+    type TransferFn = Transfer601And709;
+    type DifferenceFn = DifferenceFn709;
+}
+
 impl TransferFn for Transfer601And709 {
     fn into_linear<T: Float>(x: T) -> T {
         if x <= cast(0.0091) {
@@ -130,5 +175,53 @@ impl TransferFn for Transfer601And709 {
         } else {
             x.powf(cast(0.45)) * cast(1.099) - cast(0.099)
         }
+    }
+}
+
+impl DifferenceFn for DifferenceFn601 {
+    fn luminance<T: Float>() -> [T; 3] {
+        // Full intensity matches whitepoint, these are exactly the Y component of primares.
+        let (r, g, b) = BT601_LUMINANCE;
+        [cast(r), cast(g), cast(b)]
+    }
+
+    fn norm_blue<T: Float>(denorm: T) -> T {
+        denorm / cast(BT601_BLUE_NORM)
+    }
+
+    fn denorm_blue<T: Float>(norm: T) -> T {
+        norm * cast(BT601_BLUE_NORM)
+    }
+
+    fn norm_red<T: Float>(denorm: T) -> T {
+        denorm / cast(BT601_RED_NORM)
+    }
+
+    fn denorm_red<T: Float>(norm: T) -> T {
+        norm * cast(BT601_RED_NORM)
+    }
+}
+
+impl DifferenceFn for DifferenceFn709 {
+    fn luminance<T: Float>() -> [T; 3] {
+        // Full intensity matches whitepoint, these are exactly the Y component of primares.
+        let (r, g, b) = BT709_WEIGHTS;
+        [cast(r), cast(g), cast(b)]
+    }
+
+    fn norm_blue<T: Float>(denorm: T) -> T {
+        denorm / cast(BT709_BLUE_NORM)
+    }
+
+    fn denorm_blue<T: Float>(norm: T) -> T {
+        norm * cast(BT709_BLUE_NORM)
+    }
+
+    fn norm_red<T: Float>(denorm: T) -> T {
+        denorm / cast(BT709_RED_NORM)
+    }
+
+    fn denorm_red<T: Float>(norm: T) -> T {
+        norm * cast(BT709_RED_NORM)
     }
 }

--- a/palette/src/encoding/mod.rs
+++ b/palette/src/encoding/mod.rs
@@ -10,6 +10,7 @@ pub mod srgb;
 pub mod gamma;
 pub mod linear;
 pub mod pixel;
+pub mod itu;
 
 /// A transfer function to and from linear space.
 pub trait TransferFn {

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -361,6 +361,7 @@ mod lch;
 pub mod luma;
 pub mod rgb;
 mod xyz;
+pub mod yuv;
 mod yxy;
 
 mod hues;

--- a/palette/src/yuv/mod.rs
+++ b/palette/src/yuv/mod.rs
@@ -1,0 +1,73 @@
+//! YUV types, spaces and standards.
+use float::Float;
+
+use encoding::{TransferFn};
+use rgb::RgbSpace;
+use {Component};
+
+mod yuv;
+
+/// A YUV standard with digital quantization function.
+pub trait YuvStandard {
+    /// Underlying color space of the RGB signal.
+    type RgbSpace: RgbSpace;
+
+    /// The transfer function from linear RGB space.
+    type TransferFn: TransferFn;
+
+    /// The normalized color difference space.
+    type Differences: Differences;
+}
+
+/// Gives the YUV space values of each primary.
+pub trait Differences {
+    /// The weights of the luminance transform.
+    ///
+    /// The linear transform is assumed to happen after the opto-electric transfer function is
+    /// applied to each color value. This is true for all ITU-R standards. Nevertheless, A
+    /// different form of encoding exists, called YcCbcCbr or constant luminance, which calculates
+    /// the luminance value from the linear RGB values instead to optimize the accuracy of its
+    /// result.
+    fn luminance<T: Float>() -> [T; 3];
+
+    /// Normalize the difference of luminance and blue channel.
+    fn norm_blue<T: Float>(denorm: T) -> T;
+
+    /// Denormalize the difference of luminance and blue channel.
+    fn denorm_blue<T: Float>(norm: T) -> T;
+
+    /// Normalize the difference of luminance and red channel.
+    fn norm_red<T: Float>(denorm: T) -> T;
+
+    /// Denormalize the difference of luminance and red channel.
+    fn denorm_red<T: Float>(norm: T) -> T;
+}
+
+/// A digital encoding of a YUV color model.
+///
+/// While the difference conversion is mostly performed in an analog signal space free of
+/// quantization errors, the final digital output is quantized to some number of bits defined in
+/// individual standards.
+///
+/// The direct conversion of digitally quantized, gamma pre-corrected RGB is also possible. This
+/// yields minor differences compared to a conversion to analog signals and quantization. A strict
+/// integer arithmetic quantization is available as well where performance concerns make the
+/// floating point conversion less reasonable.
+pub trait QuantizationFn<Y: YuvStandard> {
+    type Output: Component;
+
+    /// Quantize an analog yuv pixel.
+    fn quantize<F: Component + Float>(yuv: [F; 3]) -> [Self::Output; 3];
+
+    /// Quantize from an rgb value directly.
+    fn quantize_direct<F: Component + Float>(rgb: [F; 3]) -> [Self::Output; 3];
+
+    /// Transfer a quantized color value.
+    fn quantized_rgb(rgb: [Self::Output; 3]) -> [Self::Output; 3];
+}
+
+impl<R: RgbSpace, T: TransferFn, D: Differences> YuvStandard for (R, T, D) {
+    type RgbSpace = R;
+    type TransferFn = T;
+    type Differences = D;
+}

--- a/palette/src/yuv/mod.rs
+++ b/palette/src/yuv/mod.rs
@@ -40,25 +40,30 @@ pub trait DifferenceFn {
     fn luminance<T: Float>() -> [T; 3];
 
     /// Normalize the difference of luminance and blue channel.
-    fn norm_blue<T: Float>(denorm: T) -> T;
+    fn normalize_blue<T: Float>(denorm: T) -> T;
 
     /// Denormalize the difference of luminance and blue channel.
-    fn denorm_blue<T: Float>(norm: T) -> T;
+    fn denormalize_blue<T: Float>(norm: T) -> T;
 
     /// Normalize the difference of luminance and red channel.
-    fn norm_red<T: Float>(denorm: T) -> T;
+    fn normalize_red<T: Float>(denorm: T) -> T;
 
     /// Denormalize the difference of luminance and red channel.
-    fn denorm_red<T: Float>(norm: T) -> T;
+    fn denormalize_red<T: Float>(norm: T) -> T;
 }
 
 /// A digital encoding of a YUV color model.
+///
+/// This is not a mere type conversion. Instead, it is a standardized encoding depending on the bit
+/// length of the output symbols. This also ensures that the symbol space is not completely
+/// exhausted by color information and therefore keeps some headroom in the produced digital
+/// signal.
 ///
 /// While the difference conversion is mostly performed in an analog signal space free of
 /// quantization errors, the final digital output is quantized to some number of bits defined in
 /// individual standards.
 ///
-// TODO:
+// TODO: See https://github.com/Ogeon/palette/issues/121
 // The direct conversion of digitally quantized, gamma pre-corrected RGB is also possible. This
 // yields minor differences compared to a conversion to analog signals and quantization. A strict
 // integer arithmetic quantization is available as well where performance concerns make the

--- a/palette/src/yuv/mod.rs
+++ b/palette/src/yuv/mod.rs
@@ -5,9 +5,13 @@ use encoding::{TransferFn};
 use rgb::RgbSpace;
 use {Component};
 
+mod quant;
 mod yuv;
 
-/// A YUV standard with digital quantization function.
+/// A YUV standard for analog signal conversion.
+///
+/// In precise terms, YUV identifies an analog encoding of color signal while YCbCr is the digital,
+/// quantized version of that signal.
 pub trait YuvStandard {
     /// Underlying color space of the RGB signal.
     type RgbSpace: RgbSpace;
@@ -16,11 +20,11 @@ pub trait YuvStandard {
     type TransferFn: TransferFn;
 
     /// The normalized color difference space.
-    type Differences: Differences;
+    type DifferenceFn: DifferenceFn;
 }
 
 /// Gives the YUV space values of each primary.
-pub trait Differences {
+pub trait DifferenceFn {
     /// The weights of the luminance transform.
     ///
     /// The linear transform is assumed to happen after the opto-electric transfer function is
@@ -28,6 +32,11 @@ pub trait Differences {
     /// different form of encoding exists, called YcCbcCbr or constant luminance, which calculates
     /// the luminance value from the linear RGB values instead to optimize the accuracy of its
     /// result.
+    ///
+    /// The luminance weights correspond closely to the `Y` components of the `yxy`
+    /// parameterization of the color space primaries. However, they may add up to a value smaller
+    /// than `1` to represent colors appearing brighter than the white point i.e. offer a larger
+    /// dynamic range than otherwise possible.
     fn luminance<T: Float>() -> [T; 3];
 
     /// Normalize the difference of luminance and blue channel.
@@ -49,25 +58,26 @@ pub trait Differences {
 /// quantization errors, the final digital output is quantized to some number of bits defined in
 /// individual standards.
 ///
-/// The direct conversion of digitally quantized, gamma pre-corrected RGB is also possible. This
-/// yields minor differences compared to a conversion to analog signals and quantization. A strict
-/// integer arithmetic quantization is available as well where performance concerns make the
-/// floating point conversion less reasonable.
-pub trait QuantizationFn<Y: YuvStandard> {
+// TODO:
+// The direct conversion of digitally quantized, gamma pre-corrected RGB is also possible. This
+// yields minor differences compared to a conversion to analog signals and quantization. A strict
+// integer arithmetic quantization is available as well where performance concerns make the
+// floating point conversion less reasonable. Note that for Rec.601 there is an extensive
+// standardized table of integer coefficients for the conversion depending on the required accuracy
+// (8-16 bits) of the intermediates.
+pub trait QuantizationFn {
+    /// The quantized integer representation of the color value.
     type Output: Component;
 
     /// Quantize an analog yuv pixel.
-    fn quantize<F: Component + Float>(yuv: [F; 3]) -> [Self::Output; 3];
+    fn quantize_yuv<F: Component + Float>(yuv: [F; 3]) -> [Self::Output; 3];
 
-    /// Quantize from an rgb value directly.
-    fn quantize_direct<F: Component + Float>(rgb: [F; 3]) -> [Self::Output; 3];
-
-    /// Transfer a quantized color value.
-    fn quantized_rgb(rgb: [Self::Output; 3]) -> [Self::Output; 3];
+    /// Quantize an rgb value.
+    fn quantize_rgb<F: Component + Float>(rgb: [F; 3]) -> [Self::Output; 3];
 }
 
-impl<R: RgbSpace, T: TransferFn, D: Differences> YuvStandard for (R, T, D) {
+impl<R: RgbSpace, T: TransferFn, D: DifferenceFn> YuvStandard for (R, T, D) {
     type RgbSpace = R;
     type TransferFn = T;
-    type Differences = D;
+    type DifferenceFn = D;
 }

--- a/palette/src/yuv/quant.rs
+++ b/palette/src/yuv/quant.rs
@@ -1,0 +1,56 @@
+use super::QuantizationFn;
+
+use {clamp, cast, Float};
+
+/// Shared 8-bit quantization functions.
+pub struct QuantU8;
+
+impl QuantU8 {
+    fn quantize_yuv<F: Float>([y, u, v]: [F; 3]) -> [u8; 3] {
+        let y = y*cast(219.) + cast(16.);
+        let u = u*cast(224.) + cast(128.);
+        let v = v*cast(224.) + cast(128.);
+        [int_u8(y), int_u8(u), int_u8(v)]
+    }
+
+    fn quantize_rgb<F: Float>([r, g, b]: [F; 3]) -> [u8; 3] {
+        let r = r*cast(219.) + cast(16.);
+        let g = g*cast(219.) + cast(16.);
+        let b = b*cast(219.) + cast(16.);
+        [int_u8(r), int_u8(g), int_u8(b)]
+    }
+}
+
+impl QuantizationFn for QuantU8 {
+    type Output = u8;
+
+    fn quantize_yuv<F: Float>(yuv: [F; 3]) -> [u8; 3] {
+        Self::quantize_yuv(yuv)
+    }
+
+    fn quantize_rgb<F: Float>(rgb: [F; 3]) -> [u8; 3] {
+        Self::quantize_rgb(rgb)
+    }
+}
+
+/// Round to 8-bit integer in valid signal range.
+fn int_u8<F: Float>(value: F) -> u8 {
+    // Note: signal level below 1 and the level 255 and above are reserved.
+    cast(clamp(value.round(), cast(1.), cast(254.)))
+}
+
+// TODO: 10bit quantization. Already here as a reference for encoding to 10 bit quantized values.
+#[allow(unused)]
+fn to_u10<F: Float>(value: F) -> u16 {
+    // Representation of 254.75 with 2 fractional bits.
+    const UPPER_MAX: u16 = 4*254 + 3; // = 1019
+    // Representation of 1.0 with 2 fraction bits.
+    const LOWER_MIN: u16 = 4;
+
+    // Add two fractional bits.
+    let value = value*cast(4.);
+
+    // Note: signal level below 1 and the level 255 and above are reserved.
+    cast(clamp(value.round(), cast(LOWER_MIN), cast(UPPER_MAX)))
+    // Final division is only conceptual, output has 2 fractional bits.
+}

--- a/palette/src/yuv/yuv.rs
+++ b/palette/src/yuv/yuv.rs
@@ -68,8 +68,8 @@ impl<S: YuvStandard, T: Float> Yuv<S, T> {
         let rgb = Rgb::<(S::RgbSpace, S::TransferFn), T>::from(xyz);
         let weights = S::DifferenceFn::luminance::<T>();
         let luminance = weights[0]*rgb.red + weights[1]*rgb.green + weights[2]*rgb.blue;
-        let blue_diff = S::DifferenceFn::norm_blue(luminance - rgb.blue);
-        let red_diff = S::DifferenceFn::norm_red(luminance - rgb.red);
+        let blue_diff = S::DifferenceFn::denormalize_blue(luminance - rgb.blue);
+        let red_diff = S::DifferenceFn::denormalize_red(luminance - rgb.red);
 
         Yuv {
             luminance,

--- a/palette/src/yuv/yuv.rs
+++ b/palette/src/yuv/yuv.rs
@@ -1,13 +1,14 @@
 use core::marker::PhantomData;
 
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use float::Float;
 
 use encoding::Linear;
 use luma::{Luma, LumaStandard};
 use rgb::{Rgb, RgbSpace};
 use yuv::{DifferenceFn, YuvStandard};
-use {Component, Pixel};
-use {Xyz};
+use {clamp};
+use {Component, FromColor, Limited, Pixel};
 
 /// Generic YUV.
 ///
@@ -64,12 +65,11 @@ impl<S: YuvStandard, T: Float> Yuv<S, T> {
         T: Component,
         Sp: RgbSpace<WhitePoint = <S::RgbSpace as RgbSpace>::WhitePoint>,
     {
-        let xyz = Xyz::<<S::RgbSpace as RgbSpace>::WhitePoint, T>::from(rgb);
-        let rgb = Rgb::<(S::RgbSpace, S::TransferFn), T>::from(xyz);
+        let rgb = Rgb::<(S::RgbSpace, S::TransferFn), T>::from_rgb(rgb);
         let weights = S::DifferenceFn::luminance::<T>();
         let luminance = weights[0]*rgb.red + weights[1]*rgb.green + weights[2]*rgb.blue;
-        let blue_diff = S::DifferenceFn::denormalize_blue(luminance - rgb.blue);
-        let red_diff = S::DifferenceFn::denormalize_red(luminance - rgb.red);
+        let blue_diff = S::DifferenceFn::normalize_blue(rgb.blue - luminance);
+        let red_diff = S::DifferenceFn::normalize_red(rgb.red - luminance);
 
         Yuv {
             luminance,
@@ -80,11 +80,37 @@ impl<S: YuvStandard, T: Float> Yuv<S, T> {
     }
 }
 
+impl<S, T> Limited for Yuv<S, T>
+where
+    S: YuvStandard,
+    T: Float,
+{
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn is_valid(&self) -> bool {
+        let half = T::one()/(T::one() + T::one());
+        self.luminance >= T::zero() && self.luminance <= T::one() &&
+        self.red_diff >= -half && self.red_diff <= half &&
+        self.blue_diff >= -half && self.blue_diff <= half
+    }
+
+    fn clamp(&self) -> Yuv<S, T> {
+        let mut c = *self;
+        c.clamp_self();
+        c
+    }
+
+    fn clamp_self(&mut self) {
+        let half = T::one()/(T::one() + T::one());
+        self.luminance = clamp(self.luminance, T::zero(), T::one());
+        self.red_diff = clamp(self.red_diff, -half, half);
+        self.blue_diff = clamp(self.blue_diff, -half, half);
+    }
+}
 
 impl<S, T> Default for Yuv<S, T>
 where
-    T: Float,
     S: YuvStandard,
+    T: Float,
 {
     fn default() -> Yuv<S, T> {
         Yuv::new(T::zero(), T::zero(), T::zero())
@@ -99,5 +125,143 @@ where
 {
     fn from(color: Luma<St, T>) -> Self {
         Yuv::new(color.luma, T::zero(), T::zero())
+    }
+}
+
+impl<S, T> AbsDiffEq for Yuv<S, T>
+where
+    T: Float + AbsDiffEq,
+    T::Epsilon: Copy,
+    S: YuvStandard + PartialEq,
+{
+    type Epsilon = T::Epsilon;
+
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        self.luminance.abs_diff_eq(&other.luminance, epsilon) &&
+            self.red_diff.abs_diff_eq(&other.red_diff, epsilon) &&
+            self.blue_diff.abs_diff_eq(&other.blue_diff, epsilon)
+    }
+}
+
+impl<S, T> RelativeEq for Yuv<S, T>
+where
+    T: Float + RelativeEq,
+    T::Epsilon: Copy,
+    S: YuvStandard + PartialEq,
+{
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn relative_eq(
+        &self,
+        other: &Self,
+        epsilon: Self::Epsilon,
+        max_relative: Self::Epsilon,
+    ) -> bool {
+        self.luminance.relative_eq(&other.luminance, epsilon, max_relative) &&
+            self.red_diff.relative_eq(&other.red_diff, epsilon, max_relative) &&
+            self.blue_diff.relative_eq(&other.blue_diff, epsilon, max_relative)
+    }
+}
+
+impl<S, T> UlpsEq for Yuv<S, T>
+where
+    T: Float + UlpsEq,
+    T::Epsilon: Copy,
+    S: YuvStandard + PartialEq,
+{
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps()
+    }
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
+        self.luminance.ulps_eq(&other.luminance, epsilon, max_ulps) &&
+            self.red_diff.ulps_eq(&other.red_diff, epsilon, max_ulps) &&
+            self.blue_diff.ulps_eq(&other.blue_diff, epsilon, max_ulps)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Yuv};
+
+    use encoding::itu::{BT601_525, BT601_625, BT709};
+    use rgb::Rgb;
+    use yuv::DifferenceFn;
+
+    #[test]
+    fn ranges() {
+        assert_ranges!{
+            Yuv<BT709, f64>;
+            limited {
+                luminance: 0.0 => 1.0,
+                red_diff: -0.5 => 0.5,
+                blue_diff: -0.5 => 0.5
+            }
+            limited_min {}
+            unlimited {}
+        }
+    }
+
+    #[test]
+    fn bt601_data_sheets() {
+        macro_rules! assert_yuv_eq_rgb {
+            ($st:ty, ($y:expr, $u:expr, $v:expr), ($r:expr, $g:expr, $b:expr)) => {{
+                assert_eq!(
+                    Yuv::<$st>::new($y, <$st as DifferenceFn>::normalize_blue($u), <$st as DifferenceFn>::normalize_red($v)),
+                    Yuv::<$st>::from(Rgb::<$st>::new($r, $g, $b)));
+            }};
+
+            ($st:ty, ($y:expr, $u:expr, $v:expr), ($r:expr, $g:expr, $b:expr), ulps) => {{
+                assert_ulps_eq!(
+                    Yuv::<$st>::new($y, <$st as DifferenceFn>::normalize_blue($u), <$st as DifferenceFn>::normalize_red($v)),
+                    Yuv::<$st>::from(Rgb::<$st>::new($r, $g, $b)));
+            }};
+        };
+
+        assert_yuv_eq_rgb!(BT601_525, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0));
+        assert_yuv_eq_rgb!(BT601_525, (1.0, 0.0, 0.0), (1.0, 1.0, 1.0));
+        assert_yuv_eq_rgb!(BT601_625, (0.0, 0.0, 0.0), (0.0, 0.0, 0.0));
+        assert_yuv_eq_rgb!(BT601_625, (1.0, 0.0, 0.0), (1.0, 1.0, 1.0));
+
+        // Table from https://www.itu.int/rec/R-REC-BT.601-7-201103-I page 3
+        // blue difference and red difference swapped compared to document.
+        assert_yuv_eq_rgb!(BT601_525, (0.299, -0.299, 0.701), (1.0, 0.0, 0.0));
+        assert_yuv_eq_rgb!(BT601_625, (0.299, -0.299, 0.701), (1.0, 0.0, 0.0));
+        assert_yuv_eq_rgb!(BT601_525, (0.587, -0.587, -0.587), (0.0, 1.0, 0.0));
+        assert_yuv_eq_rgb!(BT601_625, (0.587, -0.587, -0.587), (0.0, 1.0, 0.0));
+        assert_yuv_eq_rgb!(BT601_525, (0.114, 0.886, -0.114), (0.0, 0.0, 1.0));
+        assert_yuv_eq_rgb!(BT601_625, (0.114, 0.886, -0.114), (0.0, 0.0, 1.0));
+
+        // These involve floating point computation. Check for ulps.
+        assert_yuv_eq_rgb!(BT601_525, (0.886, -0.886, 0.114), (1.0, 1.0, 0.0), ulps);
+        assert_yuv_eq_rgb!(BT601_625, (0.886, -0.886, 0.114), (1.0, 1.0, 0.0), ulps);
+        assert_yuv_eq_rgb!(BT601_525, (0.701, 0.299, -0.701), (0.0, 1.0, 1.0), ulps);
+        assert_yuv_eq_rgb!(BT601_625, (0.701, 0.299, -0.701), (0.0, 1.0, 1.0), ulps);
+        assert_yuv_eq_rgb!(BT601_525, (0.413, 0.587, 0.587), (1.0, 0.0, 1.0), ulps);
+        assert_yuv_eq_rgb!(BT601_625, (0.413, 0.587, 0.587), (1.0, 0.0, 1.0), ulps);
+    }
+
+    #[test]
+    fn bt709_baseline() {
+        // Otherwise we trust the table tests from the other encodings and the hardcoded constants.
+        assert_eq!(
+            Yuv::<BT709>::new(0.0, 0.0, 0.0),
+            Yuv::<BT709>::from(Rgb::<BT709>::new(0.0, 0.0, 0.0)));
+
+        // Note: not exactly equal as the specification has factors *slightly* different from the
+        // exact luminance values of the primaries (derived from weight point and primary
+        // coordinates). This means that floating point actually does some calcuation here.
+        assert_abs_diff_eq!(
+            Yuv::<BT709>::new(1.0, 0.0, 0.0),
+            Yuv::<BT709>::from(Rgb::<BT709>::new(1.0, 1.0, 1.0)),
+            epsilon = 1.0e-4); // > 12 bit accuracy
     }
 }

--- a/palette/src/yuv/yuv.rs
+++ b/palette/src/yuv/yuv.rs
@@ -1,0 +1,103 @@
+use core::marker::PhantomData;
+
+use float::Float;
+
+use encoding::Linear;
+use luma::{Luma, LumaStandard};
+use rgb::{Rgb, RgbSpace};
+use yuv::{YuvStandard, Differences};
+use {Component, Pixel};
+use {Xyz};
+
+/// Generic YUV.
+///
+/// YUV is an alternate representation for an RGB color space with a focus on separating luminance
+/// from chroma components.
+#[derive(Debug, PartialEq, FromColor, Pixel)]
+#[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
+#[palette_internal]
+#[palette_rgb_space = "S::RgbSpace"]
+#[palette_white_point = "<S::RgbSpace as RgbSpace>::WhitePoint"]
+#[palette_component = "T"]
+#[palette_manual_from(Luma, Rgb = "from_rgb_internal")]
+#[repr(C)]
+pub struct Yuv<S: YuvStandard, T: Float = f32> {
+    /// The lumnance signal where `0.0f` is no light and `1.0f` means a maximum displayable amount
+    /// of all colors.
+    pub luminance: T,
+
+    /// The difference between overall brightness and the blue signal. This is centered around
+    /// `0.0f` but its maximum absolute value depends on the standard.
+    pub blue_diff: T,
+
+    /// The difference between overall brightness and the red signal. This is centered around
+    /// `0.0f` but its maximum absolute value depends on the standard.
+    pub red_diff: T,
+
+    /// The kind of YUV standard.
+    #[cfg_attr(feature = "serializing", serde(skip))]
+    #[palette_unsafe_zero_sized]
+    pub standard: PhantomData<S>,
+}
+
+impl<S: YuvStandard, T: Float> Copy for Yuv<S, T> {}
+
+impl<S: YuvStandard, T: Float> Clone for Yuv<S, T> {
+    fn clone(&self) -> Yuv<S, T> {
+        *self
+    }
+}
+
+impl<S: YuvStandard, T: Float> Yuv<S, T> {
+    /// Create an YUV color (in YCbCr order)
+    pub fn new(luminance: T, blue_diff: T, red_diff: T) -> Yuv<S, T> {
+        Yuv {
+            luminance,
+            red_diff,
+            blue_diff,
+            standard: PhantomData,
+        }
+    }
+
+    fn from_rgb_internal<Sp>(rgb: Rgb<Linear<Sp>, T>) -> Self
+    where
+        T: Component,
+        Sp: RgbSpace<WhitePoint = <S::RgbSpace as RgbSpace>::WhitePoint>,
+    {
+        let xyz = Xyz::<<S::RgbSpace as RgbSpace>::WhitePoint, T>::from(rgb);
+        let rgb = Rgb::<(S::RgbSpace, S::TransferFn), T>::from(xyz);
+        let weights = S::Differences::luminance::<T>();
+        let luminance = weights[0]*rgb.red + weights[1]*rgb.green + weights[2]*rgb.blue;
+        let blue_diff = S::Differences::norm_blue(luminance - rgb.blue);
+        let red_diff = S::Differences::norm_red(luminance - rgb.red);
+
+        Yuv {
+            luminance,
+            blue_diff,
+            red_diff,
+            standard: PhantomData,
+        }
+    }
+}
+
+
+impl<S, T> Default for Yuv<S, T>
+where
+    T: Float,
+    S: YuvStandard,
+{
+    fn default() -> Yuv<S, T> {
+        Yuv::new(T::zero(), T::zero(), T::zero())
+    }
+}
+
+impl<S, T, St> From<Luma<St, T>> for Yuv<S, T>
+where
+    S: YuvStandard,
+    T: Component + Float,
+    St: LumaStandard<WhitePoint = <S::RgbSpace as RgbSpace>::WhitePoint>,
+{
+    fn from(color: Luma<St, T>) -> Self {
+        Yuv::new(color.luma, T::zero(), T::zero())
+    }
+}

--- a/palette/src/yuv/yuv.rs
+++ b/palette/src/yuv/yuv.rs
@@ -5,7 +5,7 @@ use float::Float;
 use encoding::Linear;
 use luma::{Luma, LumaStandard};
 use rgb::{Rgb, RgbSpace};
-use yuv::{YuvStandard, Differences};
+use yuv::{DifferenceFn, YuvStandard};
 use {Component, Pixel};
 use {Xyz};
 
@@ -66,10 +66,10 @@ impl<S: YuvStandard, T: Float> Yuv<S, T> {
     {
         let xyz = Xyz::<<S::RgbSpace as RgbSpace>::WhitePoint, T>::from(rgb);
         let rgb = Rgb::<(S::RgbSpace, S::TransferFn), T>::from(xyz);
-        let weights = S::Differences::luminance::<T>();
+        let weights = S::DifferenceFn::luminance::<T>();
         let luminance = weights[0]*rgb.red + weights[1]*rgb.green + weights[2]*rgb.blue;
-        let blue_diff = S::Differences::norm_blue(luminance - rgb.blue);
-        let red_diff = S::Differences::norm_red(luminance - rgb.red);
+        let blue_diff = S::DifferenceFn::norm_blue(luminance - rgb.blue);
+        let red_diff = S::DifferenceFn::norm_red(luminance - rgb.red);
 
         Yuv {
             luminance,


### PR DESCRIPTION
Adds the color spaces and transfer functions for the color spaces defined in 
ITU-R BT601 and ITU-R BT709 (aka. Rec.601 and Rec.709). Also adds the
notion of quantization functions for these two standards but only implements 
8-bit quantization for the moment. The available implementation is partially
intended as reference, with future additions adding more comprehensive
support for conversion.

Addresses pieces of #121 and lays groundwork for the other recommendations.