### PR TITLE
Round to nearest instead of down when converting components to integers.

### DIFF
--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -204,9 +204,9 @@ use encoding::Linear;
 ///     assert_eq!(
 ///         css_color,
 ///         CssRgb {
-///             red: 187,
+///             red: 188,
 ///             green: 0,
-///             blue: 254,
+///             blue: 255,
 ///             alpha: 0.3,
 ///         }
 ///     );
@@ -338,7 +338,7 @@ where
 ///     // Convert the color to sRGB.
 ///     let rgb: Srgb = xyz.into();
 ///
-///     assert_eq!(rgb.into_format(), Srgb::new(195u8, 237, 154));
+///     assert_eq!(rgb.into_format(), Srgb::new(196u8, 238, 154));
 /// }
 /// ```
 ///

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -550,7 +550,7 @@ impl Component for f32 {
         let scaled = *self * cast::<f32, _>(T::max_intensity());
 
         if T::LIMITED {
-            cast(clamp(scaled, 0.0, cast(T::max_intensity())))
+            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -568,7 +568,7 @@ impl Component for f64 {
         let scaled = *self * cast::<f64, _>(T::max_intensity());
 
         if T::LIMITED {
-            cast(clamp(scaled, 0.0, cast(T::max_intensity())))
+            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -587,7 +587,7 @@ impl Component for u8 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled, 0.0, cast(T::max_intensity())))
+            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -606,7 +606,7 @@ impl Component for u16 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled, 0.0, cast(T::max_intensity())))
+            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -625,7 +625,7 @@ impl Component for u32 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled, 0.0, cast(T::max_intensity())))
+            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -644,7 +644,7 @@ impl Component for u64 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled, 0.0, cast(T::max_intensity())))
+            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }


### PR DESCRIPTION
This is the rounding part of #117, rebased to include changes on `master` since it was submitted. Big thanks to @PeterHatch for making me realize my mistake and for submitting the fix.