### PR TITLE
Fix no_std build failure

### DIFF
--- a/palette/src/float.rs
+++ b/palette/src/float.rs
@@ -57,6 +57,8 @@ mod no_std_float_trait {
         /// `y.atan2(x)` computes the inverse tangent of `y / x`, in the
         /// corresponding quadrant
         fn atan2(self, other: Self) -> Self;
+        /// `x.round()` returns the nearest integer to a number. Round half-way cases away from 0.0.
+        fn round(self) -> Self;
     }
 
     impl Float for f32 {
@@ -78,6 +80,9 @@ mod no_std_float_trait {
         fn atan2(self, other: f32) -> f32 {
             F32Ext::atan2(self, other)
         }
+        fn round(self) -> f32 {
+            F32Ext::round(self)
+        }
     }
 
     impl Float for f64 {
@@ -98,6 +103,9 @@ mod no_std_float_trait {
         }
         fn atan2(self, other: f64) -> f64 {
             F64Ext::atan2(self, other)
+        }
+        fn round(self) -> f64 {
+            F64Ext::round(self)
         }
     }
 }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -550,7 +550,7 @@ impl Component for f32 {
         let scaled = *self * cast::<f32, _>(T::max_intensity());
 
         if T::LIMITED {
-            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
+            cast(clamp(Float::round(scaled), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -568,7 +568,7 @@ impl Component for f64 {
         let scaled = *self * cast::<f64, _>(T::max_intensity());
 
         if T::LIMITED {
-            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
+            cast(clamp(Float::round(scaled), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -587,7 +587,7 @@ impl Component for u8 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
+            cast(clamp(Float::round(scaled), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -606,7 +606,7 @@ impl Component for u16 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
+            cast(clamp(Float::round(scaled), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -625,7 +625,7 @@ impl Component for u32 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
+            cast(clamp(Float::round(scaled), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }
@@ -644,7 +644,7 @@ impl Component for u64 {
             * (cast::<f64, _>(*self) / cast::<f64, _>(Self::max_intensity()));
 
         if T::LIMITED {
-            cast(clamp(scaled.round(), 0.0, cast(T::max_intensity())))
+            cast(clamp(Float::round(scaled), 0.0, cast(T::max_intensity())))
         } else {
             cast(scaled)
         }


### PR DESCRIPTION
{f32|f64}::round() does not exist with just core, so libm's implementation is used instead when the `std` feature is not activated.