### PR TITLE
bump syn, quote and proc-macro2 to version 1.0

### DIFF
--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -14,9 +14,9 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", features = ["extra-traits"] }
-quote = "0.6"
-proc-macro2 = "0.4"
+syn = { version = "^1.0", features = ["extra-traits"] }
+quote = "^1.0"
+proc-macro2 = "^1.0"
 
 [features]
 

--- a/palette_derive/src/convert/shared.rs
+++ b/palette_derive/src/convert/shared.rs
@@ -25,7 +25,7 @@ pub fn find_in_generics(
                     },
             })) = component
             {
-                let first = component.first().map(|s| s.into_value());
+                let first = component.first();
                 let is_ident_path = leading_colon.is_none()
                     && component.len() == 1
                     && first.unwrap().arguments.is_empty()
@@ -45,7 +45,7 @@ pub fn find_in_generics(
                     },
             })) = white_point
             {
-                let first = white_point.first().map(|s| s.into_value());
+                let first = white_point.first();
                 let is_ident_path = leading_colon.is_none()
                     && white_point.len() == 1
                     && first.unwrap().arguments.is_empty()

--- a/palette_derive/src/meta.rs
+++ b/palette_derive/src/meta.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::parse::{Parse, Parser, ParseStream, Result};
+use syn::parse::{Parse, ParseStream, Parser, Result};
 use syn::punctuated::Punctuated;
 use syn::{parenthesized, Attribute, Data, Field, Fields, Ident, Index, LitStr, Token, Type};
 
@@ -8,14 +8,7 @@ pub fn parse_attributes<T: MetaParser>(attributes: Vec<Attribute>) -> T {
     let mut result = T::default();
 
     for attribute in attributes {
-        let attribute_name = attribute
-            .path
-            .segments
-            .first()
-            .unwrap()
-            .into_value()
-            .ident
-            .clone();
+        let attribute_name = attribute.path.segments.first().unwrap().ident.clone();
         let is_palette_attribute = attribute_name.to_string().starts_with("palette_");
 
         if attribute.path.segments.len() > 1 {
@@ -31,10 +24,10 @@ pub fn parse_attributes<T: MetaParser>(attributes: Vec<Attribute>) -> T {
         }
 
         if attribute_name == "palette_internal" {
-            assert_empty_attribute(&attribute_name, attribute.tts);
+            assert_empty_attribute(&attribute_name, attribute.tokens);
             result.internal();
         } else {
-            result.parse_attribute(attribute_name, attribute.tts);
+            result.parse_attribute(attribute_name, attribute.tokens);
         }
     }
 
@@ -72,14 +65,7 @@ pub fn parse_struct_field_attributes<T: DataMetaParser>(
             .unwrap_or_else(|| IdentOrIndex::Index(index.into()));
 
         for attribute in field.attrs {
-            let attribute_name = attribute
-                .path
-                .segments
-                .first()
-                .unwrap()
-                .into_value()
-                .ident
-                .clone();
+            let attribute_name = attribute.path.segments.first().unwrap().ident.clone();
             if !attribute_name.to_string().starts_with("palette_") {
                 continue;
             }
@@ -96,7 +82,7 @@ pub fn parse_struct_field_attributes<T: DataMetaParser>(
                 identifier.clone(),
                 field.ty.clone(),
                 attribute_name,
-                attribute.tts,
+                attribute.tokens,
             );
         }
     }
@@ -112,10 +98,7 @@ pub fn assert_empty_attribute(attribute_name: &Ident, tts: TokenStream) {
     }
 }
 
-pub fn parse_tuple_attribute<T: Parse>(
-    attribute_name: &Ident,
-    tts: TokenStream,
-) -> Vec<T> {
+pub fn parse_tuple_attribute<T: Parse>(attribute_name: &Ident, tts: TokenStream) -> Vec<T> {
     fn parse_generic_tuple<T: Parse>(input: ParseStream) -> Result<Vec<T>> {
         let content;
         parenthesized!(content in input);
@@ -178,10 +161,7 @@ impl Parse for KeyValuePair {
             None => None,
             Some(_) => Some(input.parse::<LitStr>()?.parse::<Ident>()?),
         };
-        Ok(KeyValuePair {
-            key,
-            value
-        })
+        Ok(KeyValuePair { key, value })
     }
 }
 


### PR DESCRIPTION
Just a simple version bump for the dependencies, and a few line fixes where the api changed. This currently does not get rid of the old versions in the `Cargo.lock` due to `num-derive`'s newest version not having upgraded to the 1.0 releases yet. From what I've seen that will be fixed once https://github.com/rust-num/num-derive/pull/29 lands there.