### PR TITLE
Convert remaining float asserts to approx

### DIFF
--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -100,8 +100,6 @@ use encoding::Linear;
 ///
 /// ```rust
 /// #[macro_use]
-/// extern crate palette;
-/// #[macro_use]
 /// extern crate approx;
 ///
 /// use palette::{Component, FromColor, Hsv, Pixel, Srgb};
@@ -160,7 +158,7 @@ use encoding::Linear;
 ///
 /// ```rust
 /// #[macro_use]
-/// extern crate palette;
+/// extern crate approx;
 ///
 /// use palette::{FromColor, LinSrgba, Srgb};
 /// use palette::rgb::{Rgb, RgbSpace};
@@ -346,8 +344,6 @@ where
 ///
 /// ```rust
 /// #[macro_use]
-/// extern crate palette;
-/// #[macro_use]
 /// extern crate approx;
 ///
 /// use palette::{Component, Hsv, IntoColor, Pixel, Srgb};
@@ -402,8 +398,6 @@ where
 /// With alpha component:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate palette;
 /// #[macro_use]
 /// extern crate approx;
 ///

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -157,9 +157,6 @@ use encoding::Linear;
 /// With alpha component:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
-///
 /// use palette::{FromColor, LinSrgba, Srgb};
 /// use palette::rgb::{Rgb, RgbSpace};
 /// use palette::encoding::Linear;

--- a/palette/src/encoding/pixel/mod.rs
+++ b/palette/src/encoding/pixel/mod.rs
@@ -35,7 +35,7 @@ mod raw;
 ///
 /// ```rust
 /// #[macro_use]
-/// extern crate palette;
+/// extern crate approx;
 ///
 /// use palette::Pixel;
 ///
@@ -68,7 +68,7 @@ mod raw;
 ///
 /// ```rust
 /// #[macro_use]
-/// extern crate palette;
+/// extern crate approx;
 ///
 /// use std::marker::PhantomData;
 ///

--- a/palette/src/encoding/pixel/mod.rs
+++ b/palette/src/encoding/pixel/mod.rs
@@ -34,9 +34,6 @@ mod raw;
 /// Basic use:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
-///
 /// use palette::Pixel;
 ///
 /// #[derive(PartialEq, Debug, Pixel)]
@@ -67,9 +64,6 @@ mod raw;
 /// Heterogenous field types:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
-///
 /// use std::marker::PhantomData;
 ///
 /// use palette::{Pixel, RgbHue};

--- a/palette/src/gradient.rs
+++ b/palette/src/gradient.rs
@@ -451,21 +451,21 @@ mod test {
     #[test]
     fn range_clamp() {
         let range: Range<f64> = (0.0..1.0).into();
-        assert_eq!(range.clamp(-1.0), 0.0);
-        assert_eq!(range.clamp(2.0), 1.0);
-        assert_eq!(range.clamp(0.5), 0.5);
+        assert_relative_eq!(range.clamp(-1.0), 0.0);
+        assert_relative_eq!(range.clamp(2.0), 1.0);
+        assert_relative_eq!(range.clamp(0.5), 0.5);
     }
 
     #[test]
     fn range_constrain() {
         let range: Range<f64> = (0.0..1.0).into();
-        assert_eq!(range.constrain(&(-3.0..-5.0).into()), (0.0..0.0).into());
-        assert_eq!(range.constrain(&(-3.0..0.8).into()), (0.0..0.8).into());
+        assert_relative_eq!(range.constrain(&(-3.0..-5.0).into()), (0.0..0.0).into());
+        assert_relative_eq!(range.constrain(&(-3.0..0.8).into()), (0.0..0.8).into());
 
-        assert_eq!(range.constrain(&(3.0..5.0).into()), (1.0..1.0).into());
-        assert_eq!(range.constrain(&(0.2..5.0).into()), (0.2..1.0).into());
+        assert_relative_eq!(range.constrain(&(3.0..5.0).into()), (1.0..1.0).into());
+        assert_relative_eq!(range.constrain(&(0.2..5.0).into()), (0.2..1.0).into());
 
-        assert_eq!(range.constrain(&(0.2..0.8).into()), (0.2..0.8).into());
+        assert_relative_eq!(range.constrain(&(0.2..0.8).into()), (0.2..0.8).into());
     }
 
     #[test]
@@ -492,12 +492,15 @@ mod test {
 
         let v1: Vec<_> = g.take(10).collect::<Vec<_>>().iter().rev().cloned().collect();
         let v2: Vec<_> = g.take(10).rev().collect();
-        assert_eq!(v1, v2);
-
+        for (t1, t2) in v1.iter().zip(v2.iter()) {
+            assert_relative_eq!(t1, t2);
+        }
         //make sure `take(1).rev()` doesn't produce NaN results
         let v1: Vec<_> = g.take(1).collect::<Vec<_>>().iter().rev().cloned().collect();
         let v2: Vec<_> = g.take(1).rev().collect();
-        assert_eq!(v1, v2);
+        for (t1, t2) in v1.iter().zip(v2.iter()) {
+            assert_relative_eq!(t1, t2);
+        }
     }
 
     #[test]
@@ -512,10 +515,10 @@ mod test {
         assert_eq!(v1.len(), 0);
         //`Take` produces minimum gradient boundary for n=1
         let v1: Vec<_> = g.take(1).collect();
-        assert_eq!(v1[0], LinSrgb::new(1.0, 1.0, 0.0));
+        assert_relative_eq!(v1[0], LinSrgb::new(1.0, 1.0, 0.0));
         //`Take` includes the maximum gradient color
         let v1: Vec<_> = g.take(5).collect();
-        assert_eq!(v1[0], LinSrgb::new(1.0, 1.0, 0.0));
-        assert_eq!(v1[4], LinSrgb::new(0.0, 0.0, 1.0));
+        assert_relative_eq!(v1[0], LinSrgb::new(1.0, 1.0, 0.0));
+        assert_relative_eq!(v1[4], LinSrgb::new(0.0, 0.0, 1.0));
     }
 }

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -312,7 +312,7 @@ mod test {
 
         let result: Vec<f32> = inp.iter().map(|x| normalize_angle_positive(*x)).collect();
         for (res, exp) in result.iter().zip(expected.iter()) {
-            assert_eq!(res, exp);
+            assert_relative_eq!(res, exp);
         }
     }
 
@@ -351,7 +351,7 @@ mod test {
 
         let result: Vec<f32> = inp.iter().map(|x| normalize_angle(*x)).collect();
         for (res, exp) in result.iter().zip(expected.iter()) {
-            assert_eq!(res, exp);
+            assert_relative_eq!(res, exp);
         }
     }
 
@@ -366,7 +366,7 @@ mod test {
             let pos_degs = hue.to_positive_degrees();
             assert!(pos_degs >= 0.0 && pos_degs < 360.0);
 
-            assert_eq!(RgbHue::from(degs), RgbHue::from(pos_degs));
+            assert_relative_eq!(RgbHue::from(degs), RgbHue::from(pos_degs));
         }
     }
 

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -400,14 +400,19 @@ pub trait Limited {
 /// A trait for linear color interpolation.
 ///
 /// ```
+/// #[macro_use]
+/// extern crate approx;
+///
 /// use palette::{LinSrgb, Mix};
 ///
-/// let a = LinSrgb::new(0.0, 0.5, 1.0);
-/// let b = LinSrgb::new(1.0, 0.5, 0.0);
+/// fn main() {
+///     let a = LinSrgb::new(0.0, 0.5, 1.0);
+///     let b = LinSrgb::new(1.0, 0.5, 0.0);
 ///
-/// assert_eq!(a.mix(&b, 0.0), a);
-/// assert_eq!(a.mix(&b, 0.5), LinSrgb::new(0.5, 0.5, 0.5));
-/// assert_eq!(a.mix(&b, 1.0), b);
+///     assert_relative_eq!(a.mix(&b, 0.0), a);
+///     assert_relative_eq!(a.mix(&b, 0.5), LinSrgb::new(0.5, 0.5, 0.5));
+///     assert_relative_eq!(a.mix(&b, 1.0), b);
+/// }
 /// ```
 pub trait Mix {
     ///The type of the mixing factor.
@@ -424,12 +429,17 @@ pub trait Mix {
 /// The `Shade` trait allows a color to be lightened or darkened.
 ///
 /// ```
+/// #[macro_use]
+/// extern crate approx;
+///
 /// use palette::{LinSrgb, Shade};
 ///
-/// let a = LinSrgb::new(0.4, 0.4, 0.4);
-/// let b = LinSrgb::new(0.6, 0.6, 0.6);
+/// fn main() {
+///     let a = LinSrgb::new(0.4, 0.4, 0.4);
+///     let b = LinSrgb::new(0.6, 0.6, 0.6);
 ///
-/// assert_eq!(a.lighten(0.1), b.darken(0.1));
+///     assert_relative_eq!(a.lighten(0.1), b.darken(0.1));
+/// }
 /// ```
 pub trait Shade: Sized {
     ///The type of the lighten/darken amount.
@@ -447,17 +457,22 @@ pub trait Shade: Sized {
 /// A trait for colors where a hue may be calculated.
 ///
 /// ```
+/// #[macro_use]
+/// extern crate approx;
+///
 /// use palette::{GetHue, LinSrgb};
 ///
-/// let red = LinSrgb::new(1.0f32, 0.0, 0.0);
-/// let green = LinSrgb::new(0.0f32, 1.0, 0.0);
-/// let blue = LinSrgb::new(0.0f32, 0.0, 1.0);
-/// let gray = LinSrgb::new(0.5f32, 0.5, 0.5);
+/// fn main() {
+///     let red = LinSrgb::new(1.0f32, 0.0, 0.0);
+///     let green = LinSrgb::new(0.0f32, 1.0, 0.0);
+///     let blue = LinSrgb::new(0.0f32, 0.0, 1.0);
+///     let gray = LinSrgb::new(0.5f32, 0.5, 0.5);
 ///
-/// assert_eq!(red.get_hue(), Some(0.0.into()));
-/// assert_eq!(green.get_hue(), Some(120.0.into()));
-/// assert_eq!(blue.get_hue(), Some(240.0.into()));
-/// assert_eq!(gray.get_hue(), None);
+///     assert_relative_eq!(red.get_hue().unwrap(), 0.0.into());
+///     assert_relative_eq!(green.get_hue().unwrap(), 120.0.into());
+///     assert_relative_eq!(blue.get_hue().unwrap(), 240.0.into());
+///     assert_eq!(gray.get_hue(), None);
+/// }
 /// ```
 pub trait GetHue {
     ///The kind of hue unit this color space uses.
@@ -488,12 +503,17 @@ pub trait Hue: GetHue {
 /// without conversion.
 ///
 /// ```
+/// #[macro_use]
+/// extern crate approx;
+///
 /// use palette::{Hsv, Saturate};
 ///
-/// let a = Hsv::new(0.0, 0.25, 1.0);
-/// let b = Hsv::new(0.0, 1.0, 1.0);
+/// fn main() {
+///     let a = Hsv::new(0.0, 0.25, 1.0);
+///     let b = Hsv::new(0.0, 1.0, 1.0);
 ///
-/// assert_eq!(a.saturate(1.0), b.desaturate(0.5));
+///     assert_relative_eq!(a.saturate(1.0), b.desaturate(0.5));
+/// }
 /// ```
 pub trait Saturate: Sized {
     ///The type of the (de)saturation factor.

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -43,10 +43,10 @@ macro_rules! raw_pixel_conversion_tests {
 
         let color_alpha: Alpha<$name<$($ty_param,)+ $float>, $float> = *Alpha::<$name<$($ty_param,)+ $float>, $float>::from_raw(&raw_plus_1);
 
-        assert_relative_eq!(color, $name::new($($component),+));
-        assert_relative_eq!(color_long, $name::new($($component),+));
+        assert_eq!(color, $name::new($($component),+));
+        assert_eq!(color_long, $name::new($($component),+));
 
-        assert_relative_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
+        assert_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
     };
 
     (@float_slice_test $float: ty, $name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
@@ -76,11 +76,11 @@ macro_rules! raw_pixel_conversion_tests {
         let color_alpha: Alpha<$name<$($ty_param,)+ $float>, $float> = *Alpha::<$name<$($ty_param,)+ $float>, $float>::from_raw(raw_plus_1);
         let color_alpha_long: Alpha<$name<$($ty_param,)+ $float>, $float> = *Alpha::<$name<$($ty_param,)+ $float>, $float>::from_raw(raw_plus_2);
 
-        assert_relative_eq!(color, $name::new($($component),+));
-        assert_relative_eq!(color_long, $name::new($($component),+));
+        assert_eq!(color, $name::new($($component),+));
+        assert_eq!(color_long, $name::new($($component),+));
 
-        assert_relative_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
-        assert_relative_eq!(color_alpha_long, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
+        assert_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
+        assert_eq!(color_alpha_long, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
     };
 }
 

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -43,10 +43,10 @@ macro_rules! raw_pixel_conversion_tests {
 
         let color_alpha: Alpha<$name<$($ty_param,)+ $float>, $float> = *Alpha::<$name<$($ty_param,)+ $float>, $float>::from_raw(&raw_plus_1);
 
-        assert_eq!(color, $name::new($($component),+));
-        assert_eq!(color_long, $name::new($($component),+));
+        assert_relative_eq!(color, $name::new($($component),+));
+        assert_relative_eq!(color_long, $name::new($($component),+));
 
-        assert_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
+        assert_relative_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
     };
 
     (@float_slice_test $float: ty, $name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
@@ -76,11 +76,11 @@ macro_rules! raw_pixel_conversion_tests {
         let color_alpha: Alpha<$name<$($ty_param,)+ $float>, $float> = *Alpha::<$name<$($ty_param,)+ $float>, $float>::from_raw(raw_plus_1);
         let color_alpha_long: Alpha<$name<$($ty_param,)+ $float>, $float> = *Alpha::<$name<$($ty_param,)+ $float>, $float>::from_raw(raw_plus_2);
 
-        assert_eq!(color, $name::new($($component),+));
-        assert_eq!(color_long, $name::new($($component),+));
+        assert_relative_eq!(color, $name::new($($component),+));
+        assert_relative_eq!(color_long, $name::new($($component),+));
 
-        assert_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
-        assert_eq!(color_alpha_long, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
+        assert_relative_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
+        assert_relative_eq!(color_alpha_long, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
     };
 }
 

--- a/palette/src/matrix.rs
+++ b/palette/src/matrix.rs
@@ -148,7 +148,9 @@ mod test {
         let expected = [28.0, 33.0, 29.0, 28.0, 31.0, 31.0, 26.0, 33.0, 31.0];
 
         let computed = multiply_3x3(&inp1, &inp2);
-        assert_eq!(expected, computed)
+        for (t1, t2) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(t1, t2);
+        }
     }
 
     #[test]
@@ -168,7 +170,9 @@ mod test {
 
         let expected: [f64; 9] = [0.2, 0.2, 0.0, -0.2, 0.3, 1.0, 0.2, -0.3, 0.0];
         let computed = matrix_inverse(&input);
-        assert_eq!(expected, computed);
+        for (t1, t2) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(t1, t2);
+        }
     }
     #[test]
     fn matrix_inverse_check_2() {
@@ -176,7 +180,9 @@ mod test {
 
         let expected: [f64; 9] = [-1.0, -1.0, 2.0, -1.0, 0.0, 1.0, 2.0, 1.0, -2.0];
         let computed = matrix_inverse(&input);
-        assert_eq!(expected, computed);
+        for (t1, t2) in expected.iter().zip(computed.iter()) {
+            assert_relative_eq!(t1, t2);
+        }
     }
     #[test]
     #[should_panic]


### PR DESCRIPTION
Closes #21. 

Converted `assert_eq!` to `assert_relative_eq!` for float comparisons not involving serialization in examples and tests.

Removed redundant `extern crate palette;` from example tests.
