### PR TITLE
Split the Component trait into more specific traits

### DIFF
--- a/palette/src/blend/blend.rs
+++ b/palette/src/blend/blend.rs
@@ -2,7 +2,7 @@ use float::Float;
 use num_traits::{One, Zero};
 
 use blend::{BlendFunction, PreAlpha};
-use {cast, clamp, ComponentWise};
+use {clamp, ComponentWise};
 
 ///A trait for colors that can be blended together.
 ///
@@ -353,6 +353,10 @@ where
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
         let two = one + one;
+        let three = two + one;
+        let four = two + two;
+        let twelve = four + four + four;
+        let sixteen = twelve + four;
 
         let src = self.into_premultiplied();
         let dst = other.into_premultiplied();
@@ -369,14 +373,11 @@ where
                     b * (src.alpha + (two * a - src.alpha) * (one - m))
                         + a * (one - dst.alpha)
                         + b * (one - src.alpha)
-                } else if b * cast(4.0) <= dst.alpha {
+                } else if b * four <= dst.alpha {
                     let m2 = m * m;
                     let m3 = m2 * m;
 
-                    dst.alpha
-                        * (two * a - src.alpha)
-                        * (m3 * cast(16.0) - m2 * cast(12.0) - m * cast(3.0))
-                        + a
+                    dst.alpha * (two * a - src.alpha) * (m3 * sixteen - m2 * twelve - m * three) + a
                         - a * dst.alpha
                         + b
                 } else {

--- a/palette/src/chromatic_adaptation.rs
+++ b/palette/src/chromatic_adaptation.rs
@@ -24,9 +24,10 @@
 //!```
 use float::Float;
 
-use {cast, Component, FromColor, IntoColor, Xyz};
+use from_f64;
+use matrix::{multiply_3x3, multiply_xyz, Mat3};
 use white_point::WhitePoint;
-use matrix::{multiply_xyz, Mat3, multiply_3x3};
+use {FloatComponent, FromColor, IntoColor, Xyz};
 
 ///Chromatic adaptation methods implemented in the library
 pub enum Method {
@@ -50,7 +51,7 @@ pub struct ConeResponseMatrices<T: Float> {
 ///one illuminant to another (Swp -> Dwp)
 pub trait TransformMatrix<Swp, Dwp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Swp: WhitePoint,
     Dwp: WhitePoint,
 {
@@ -86,7 +87,7 @@ where
 
 impl<Swp, Dwp, T> TransformMatrix<Swp, Dwp, T> for Method
 where
-    T: Component + Float,
+    T: FloatComponent,
     Swp: WhitePoint,
     Dwp: WhitePoint,
 {
@@ -95,38 +96,44 @@ where
         match *self {
              Method::Bradford => {
                 ConeResponseMatrices::<T> {
-                    ma: [cast(0.8951000), cast(0.2664000), cast(-0.1614000),
-                         cast(-0.7502000), cast(1.7135000), cast(0.0367000),
-                         cast(0.0389000), cast(-0.0685000), cast(1.0296000)
-                         ],
-                    inv_ma: [cast(0.9869929), cast(-0.1470543), cast(0.1599627),
-                             cast(0.4323053), cast(0.5183603), cast(0.0492912),
-                             cast(-0.0085287), cast(0.0400428), cast(0.9684867)
-                            ],
+                    ma: [
+                        from_f64(0.8951000), from_f64(0.2664000), from_f64(-0.1614000),
+                        from_f64(-0.7502000), from_f64(1.7135000), from_f64(0.0367000),
+                        from_f64(0.0389000), from_f64(-0.0685000), from_f64(1.0296000)
+                    ],
+                    inv_ma: [
+                        from_f64(0.9869929), from_f64(-0.1470543), from_f64(0.1599627),
+                        from_f64(0.4323053), from_f64(0.5183603), from_f64(0.0492912),
+                        from_f64(-0.0085287), from_f64(0.0400428), from_f64(0.9684867)
+                    ],
                 }
             }
              Method::VonKries => {
                 ConeResponseMatrices::<T> {
-                    ma: [cast(0.4002400), cast(0.7076000), cast(-0.0808100),
-                         cast(-0.2263000), cast(1.1653200), cast(0.0457000),
-                         cast(0.0000000), cast(0.0000000), cast(0.9182200)
-                         ],
-                    inv_ma: [cast(1.8599364), cast(-1.1293816), cast(0.2198974),
-                             cast(0.3611914), cast(0.6388125), cast(-0.0000064),
-                             cast(0.0000000), cast(0.0000000), cast(1.0890636)
-                             ],
+                    ma: [
+                        from_f64(0.4002400), from_f64(0.7076000), from_f64(-0.0808100),
+                        from_f64(-0.2263000), from_f64(1.1653200), from_f64(0.0457000),
+                        from_f64(0.0000000), from_f64(0.0000000), from_f64(0.9182200)
+                    ],
+                    inv_ma: [
+                        from_f64(1.8599364), from_f64(-1.1293816), from_f64(0.2198974),
+                        from_f64(0.3611914), from_f64(0.6388125), from_f64(-0.0000064),
+                        from_f64(0.0000000), from_f64(0.0000000), from_f64(1.0890636)
+                    ],
                 }
             }
              Method::XyzScaling => {
                 ConeResponseMatrices::<T> {
-                    ma: [cast(1.0000000), cast(0.0000000), cast(0.0000000),
-                         cast(0.0000000), cast(1.0000000), cast(0.0000000),
-                         cast(0.0000000), cast(0.0000000), cast(1.0000000)
-                         ],
-                    inv_ma: [cast(1.0000000), cast(0.0000000), cast(0.0000000),
-                             cast(0.0000000), cast(1.0000000), cast(0.0000000),
-                             cast(0.0000000), cast(0.0000000), cast(1.0000000)
-                             ],
+                    ma: [
+                        from_f64(1.0000000), from_f64(0.0000000), from_f64(0.0000000),
+                        from_f64(0.0000000), from_f64(1.0000000), from_f64(0.0000000),
+                        from_f64(0.0000000), from_f64(0.0000000), from_f64(1.0000000)
+                    ],
+                    inv_ma: [
+                        from_f64(1.0000000), from_f64(0.0000000), from_f64(0.0000000),
+                        from_f64(0.0000000), from_f64(1.0000000), from_f64(0.0000000),
+                        from_f64(0.0000000), from_f64(0.0000000), from_f64(1.0000000)
+                    ],
                 }
             }
         }
@@ -139,7 +146,7 @@ where
 ///Uses the bradford method for conversion by default.
 pub trait AdaptFrom<S, Swp, Dwp, T>: Sized
 where
-    T: Component + Float,
+    T: FloatComponent,
     Swp: WhitePoint,
     Dwp: WhitePoint,
 {
@@ -155,7 +162,7 @@ where
 
 impl<S, D, Swp, Dwp, T> AdaptFrom<S, Swp, Dwp, T> for D
 where
-    T: Component + Float,
+    T: FloatComponent,
     Swp: WhitePoint,
     Dwp: WhitePoint,
     S: IntoColor<Swp, T>,
@@ -175,7 +182,7 @@ where
 ///Uses the bradford method for conversion by default.
 pub trait AdaptInto<D, Swp, Dwp, T>: Sized
 where
-    T: Component + Float,
+    T: FloatComponent,
     Swp: WhitePoint,
     Dwp: WhitePoint,
 {
@@ -191,7 +198,7 @@ where
 
 impl<S, D, Swp, Dwp, T> AdaptInto<D, Swp, Dwp, T> for S
 where
-    T: Component + Float,
+    T: FloatComponent,
     Swp: WhitePoint,
     Dwp: WhitePoint,
     D: AdaptFrom<S, Swp, Dwp, T>,
@@ -204,9 +211,9 @@ where
 #[cfg(test)]
 mod test {
 
-    use Xyz;
-    use white_point::{D50, D65, A, C};
     use super::{AdaptFrom, AdaptInto, Method, TransformMatrix};
+    use white_point::{A, C, D50, D65};
+    use Xyz;
 
     #[test]
     fn d65_to_d50_matrix_xyz_scaling() {

--- a/palette/src/component.rs
+++ b/palette/src/component.rs
@@ -1,0 +1,181 @@
+use num_traits::Zero;
+
+use float::Float;
+use {clamp, FromF64};
+
+/// Common trait for color components.
+pub trait Component: Copy + Zero + PartialOrd {
+    /// The highest displayable value this component type can reach. Higher
+    /// values are allowed, but they may be lowered to this before
+    /// converting to another format.
+    fn max_intensity() -> Self;
+}
+
+/// Common trait for floating point color components.
+pub trait FloatComponent: Component + Float + FromF64 {}
+
+impl<T: Component + Float + FromF64> FloatComponent for T {}
+
+macro_rules! impl_float_components {
+    ($($ty: ident),+) => {
+        $(
+            impl Component for $ty {
+                fn max_intensity() -> Self {
+                    1.0
+                }
+            }
+        )*
+    };
+}
+
+impl_float_components!(f32, f64);
+
+macro_rules! impl_uint_components {
+    ($($ty: ident),+) => {
+        $(
+            impl Component for $ty {
+                fn max_intensity() -> Self {
+                    core::$ty::MAX
+                }
+            }
+        )*
+    };
+}
+
+impl_uint_components!(u8, u16, u32, u64, u128);
+
+/// Converts from a color component type, while performing the appropriate scaling, rounding and clamping.
+///
+/// ```
+/// use palette::FromComponent;
+///
+/// // Scales the value up to u8::MAX while converting.
+/// let u8_component = u8::from_component(1.0f32);
+/// assert_eq!(u8_component, 255);
+/// ```
+pub trait FromComponent<T: Component> {
+    /// Converts `other` into `Self`, while performing the appropriate scaling, rounding and clamping.
+    fn from_component(other: T) -> Self;
+}
+
+impl<T: Component, U: IntoComponent<T> + Component> FromComponent<U> for T {
+    #[inline]
+    fn from_component(other: U) -> T {
+        other.into_component()
+    }
+}
+
+/// Converts into a color component type, while performing the appropriate scaling, rounding and clamping.
+///
+/// ```
+/// use palette::IntoComponent;
+///
+/// // Scales the value up to u8::MAX while converting.
+/// let u8_component: u8 = 1.0f32.into_component();
+/// assert_eq!(u8_component, 255);
+/// ```
+pub trait IntoComponent<T: Component> {
+    /// Converts `self` into `T`, while performing the appropriate scaling, rounding and clamping.
+    fn into_component(self) -> T;
+}
+
+impl<T: Component> IntoComponent<T> for T {
+    #[inline]
+    fn into_component(self) -> T {
+        self
+    }
+}
+
+macro_rules! convert_float_to_uint {
+    ($float: ident; direct ($($direct_target: ident),+); $(via $temporary: ident ($($target: ident),+);)*) => {
+        $(
+            impl IntoComponent<$direct_target> for $float {
+                #[inline]
+                fn into_component(self) -> $direct_target {
+                    let max = $direct_target::max_intensity() as $float;
+                    let scaled = self * max;
+                    clamp(scaled.round(), 0.0, max) as $direct_target
+                }
+            }
+        )+
+
+        $(
+            $(
+                impl IntoComponent<$target> for $float {
+                    #[inline]
+                    fn into_component(self) -> $target {
+                        let max = $target::max_intensity() as $temporary;
+                        let scaled = self as $temporary * max;
+                        clamp(scaled.round(), 0.0, max) as $target
+                    }
+                }
+            )+
+        )*
+    };
+}
+
+macro_rules! convert_uint_to_float {
+    ($uint: ident; $(via $temporary: ident ($($target: ident),+);)*) => {
+        $(
+            $(
+                impl IntoComponent<$target> for $uint {
+                    #[inline]
+                    fn into_component(self) -> $target {
+                        let max = $uint::max_intensity() as $temporary;
+                        let scaled = self as $temporary / max;
+                        scaled as $target
+                    }
+                }
+            )+
+        )*
+    };
+}
+
+macro_rules! convert_uint_to_uint {
+    ($uint: ident; $(via $temporary: ident ($($target: ident),+);)*) => {
+        $(
+            $(
+                impl IntoComponent<$target> for $uint {
+                    #[inline]
+                    fn into_component(self) -> $target {
+                        let target_max = $target::max_intensity() as $temporary;
+                        let own_max = $uint::max_intensity() as $temporary;
+                        let scaled = (self as $temporary / own_max) * target_max;
+                        clamp(scaled.round(), 0.0, target_max) as $target
+                    }
+                }
+            )+
+        )*
+    };
+}
+
+impl IntoComponent<f64> for f32 {
+    #[inline]
+    fn into_component(self) -> f64 {
+        self as f64
+    }
+}
+convert_float_to_uint!(f32; direct (u8, u16); via f64 (u32, u64, u128););
+
+impl IntoComponent<f32> for f64 {
+    #[inline]
+    fn into_component(self) -> f32 {
+        self as f32
+    }
+}
+convert_float_to_uint!(f64; direct (u8, u16, u32, u64, u128););
+
+convert_uint_to_float!(u8; via f32 (f32); via f64 (f64););
+convert_uint_to_uint!(u8; via f32 (u16); via f64 (u32, u64, u128););
+
+convert_uint_to_float!(u16; via f32 (f32); via f64 (f64););
+convert_uint_to_uint!(u16; via f32 (u8); via f64 (u32, u64, u128););
+
+convert_uint_to_float!(u32; via f64 (f32, f64););
+convert_uint_to_uint!(u32; via f64 (u8, u16, u64, u128););
+
+convert_uint_to_float!(u64; via f64 (f32, f64););
+convert_uint_to_uint!(u64; via f64 (u8, u16, u32, u128););
+
+convert_uint_to_float!(u128; via f64 (f32, f64););
+convert_uint_to_uint!(u128; via f64 (u8, u16, u32, u64););

--- a/palette/src/encoding/gamma.rs
+++ b/palette/src/encoding/gamma.rs
@@ -4,11 +4,11 @@ use core::marker::PhantomData;
 
 use float::Float;
 
-use cast;
-use rgb::{RgbSpace, RgbStandard};
-use luma::LumaStandard;
 use encoding::TransferFn;
+use luma::LumaStandard;
+use rgb::{RgbSpace, RgbStandard};
 use white_point::WhitePoint;
+use {from_f64, FromF64};
 
 /// Gamma encoding.
 ///
@@ -40,25 +40,25 @@ impl<Wp: WhitePoint, N: Number> LumaStandard for Gamma<Wp, N> {
 pub struct GammaFn<N: Number = F2p2>(PhantomData<N>);
 
 impl<N: Number> TransferFn for GammaFn<N> {
-    fn into_linear<T: Float>(x: T) -> T {
-        x.powf(T::one() / cast(N::VALUE))
+    fn into_linear<T: Float + FromF64>(x: T) -> T {
+        x.powf(T::one() / from_f64(N::VALUE))
     }
 
-    fn from_linear<T: Float>(x: T) -> T {
-        x.powf(cast(N::VALUE))
+    fn from_linear<T: Float + FromF64>(x: T) -> T {
+        x.powf(from_f64(N::VALUE))
     }
 }
 
 /// A type level float constant.
 pub trait Number {
     /// The represented number.
-    const VALUE: f32;
+    const VALUE: f64;
 }
 
-/// Represents `2.2f32`.
+/// Represents `2.2f64`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F2p2;
 
 impl Number for F2p2 {
-    const VALUE: f32 = 2.2;
+    const VALUE: f64 = 2.2;
 }

--- a/palette/src/encoding/mod.rs
+++ b/palette/src/encoding/mod.rs
@@ -1,21 +1,22 @@
 //! Various encoding traits, types and standards.
 
 use float::Float;
+use FromF64;
 
-pub use self::srgb::Srgb;
 pub use self::gamma::{F2p2, Gamma};
 pub use self::linear::Linear;
+pub use self::srgb::Srgb;
 
-pub mod srgb;
 pub mod gamma;
 pub mod linear;
 pub mod pixel;
+pub mod srgb;
 
 /// A transfer function to and from linear space.
 pub trait TransferFn {
     /// Convert the color component `x` from linear space.
-    fn from_linear<T: Float>(x: T) -> T;
+    fn from_linear<T: Float + FromF64>(x: T) -> T;
 
     /// Convert the color component `x` into linear space.
-    fn into_linear<T: Float>(x: T) -> T;
+    fn into_linear<T: Float + FromF64>(x: T) -> T;
 }

--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -1,26 +1,26 @@
 //! The sRGB standard.
 
-use float::Float;
-
-use rgb::{Primaries, RgbSpace, RgbStandard};
-use luma::LumaStandard;
 use encoding::TransferFn;
-use white_point::{D65, WhitePoint};
-use {cast, Component, Yxy};
+use float::Float;
+use luma::LumaStandard;
+use rgb::{Primaries, RgbSpace, RgbStandard};
+use white_point::{WhitePoint, D65};
+use {from_f64, FromF64};
+use {FloatComponent, Yxy};
 
 ///The sRGB color space.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Srgb;
 
 impl Primaries for Srgb {
-    fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.6400), cast(0.3300), cast(0.212656))
+    fn red<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
+        Yxy::with_wp(from_f64(0.6400), from_f64(0.3300), from_f64(0.212656))
     }
-    fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.3000), cast(0.6000), cast(0.715158))
+    fn green<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
+        Yxy::with_wp(from_f64(0.3000), from_f64(0.6000), from_f64(0.715158))
     }
-    fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T> {
-        Yxy::with_wp(cast(0.1500), cast(0.0600), cast(0.072186))
+    fn blue<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
+        Yxy::with_wp(from_f64(0.1500), from_f64(0.0600), from_f64(0.072186))
     }
 }
 
@@ -40,19 +40,19 @@ impl LumaStandard for Srgb {
 }
 
 impl TransferFn for Srgb {
-    fn into_linear<T: Float>(x: T) -> T {
-        if x <= cast(0.04045) {
-            x / cast(12.92)
+    fn into_linear<T: Float + FromF64>(x: T) -> T {
+        if x <= from_f64(0.04045) {
+            x / from_f64(12.92)
         } else {
-            ((x + cast(0.055)) / cast(1.055)).powf(cast(2.4))
+            ((x + from_f64(0.055)) / from_f64(1.055)).powf(from_f64(2.4))
         }
     }
 
-    fn from_linear<T: Float>(x: T) -> T {
-        if x <= cast(0.0031308) {
-            x * cast(12.92)
+    fn from_linear<T: Float + FromF64>(x: T) -> T {
+        if x <= from_f64(0.0031308) {
+            x * from_f64(12.92)
         } else {
-            x.powf(T::one() / cast(2.4)) * cast(1.055) - cast(0.055)
+            x.powf(T::one() / from_f64(2.4)) * from_f64(1.055) - from_f64(0.055)
         }
     }
 }

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -9,8 +9,8 @@ use encoding::pixel::RawPixel;
 use encoding::Srgb;
 use rgb::RgbSpace;
 use {
-    clamp, Alpha, Component, FromColor, GetHue, Hsv, Hue, IntoColor, Limited, Mix, Pixel, RgbHue,
-    Shade, Xyz,
+    clamp, Alpha, Component, FloatComponent, FromColor, FromF64, GetHue, Hsv, Hue, IntoColor,
+    Limited, Mix, Pixel, RgbHue, Shade, Xyz,
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
@@ -36,7 +36,7 @@ pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 #[repr(C)]
 pub struct Hwb<S = Srgb, T = f32>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     ///The hue of the color, in degrees. Decides if it's red, blue, purple,
@@ -66,14 +66,14 @@ where
 
 impl<S, T> Copy for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
 }
 
 impl<S, T> Clone for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     fn clone(&self) -> Hwb<S, T> {
@@ -83,7 +83,7 @@ where
 
 impl<T> Hwb<Srgb, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
 {
     ///HWB for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, whiteness: T, blackness: T) -> Hwb<Srgb, T> {
@@ -98,7 +98,7 @@ where
 
 impl<S, T> Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     ///Linear HWB.
@@ -143,7 +143,7 @@ where
 ///<span id="Hwba"></span>[`Hwba`](type.Hwba.html) implementations.
 impl<T, A> Alpha<Hwb<Srgb, T>, A>
 where
-    T: Component + Float,
+    T: FloatComponent,
     A: Component,
 {
     ///HWB and transparency for linear sRGB.
@@ -158,7 +158,7 @@ where
 ///<span id="Hwba"></span>[`Hwba`](type.Hwba.html) implementations.
 impl<S, T, A> Alpha<Hwb<S, T>, A>
 where
-    T: Component + Float,
+    T: FloatComponent,
     A: Component,
     S: RgbSpace,
 {
@@ -185,7 +185,7 @@ where
 
 impl<S, T> From<Xyz<S::WhitePoint, T>> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     fn from(color: Xyz<S::WhitePoint, T>) -> Self {
@@ -196,7 +196,7 @@ where
 
 impl<S, T, Sp> From<Hsv<Sp, T>> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
     Sp: RgbSpace<WhitePoint = S::WhitePoint>,
 {
@@ -212,19 +212,19 @@ where
     }
 }
 
-impl<S: RgbSpace, T: Component + Float, H: Into<RgbHue<T>>> From<(H, T, T)> for Hwb<S, T> {
+impl<S: RgbSpace, T: FloatComponent, H: Into<RgbHue<T>>> From<(H, T, T)> for Hwb<S, T> {
     fn from(components: (H, T, T)) -> Self {
         Self::from_components(components)
     }
 }
 
-impl<S: RgbSpace, T: Component + Float> Into<(RgbHue<T>, T, T)> for Hwb<S, T> {
+impl<S: RgbSpace, T: FloatComponent> Into<(RgbHue<T>, T, T)> for Hwb<S, T> {
     fn into(self) -> (RgbHue<T>, T, T) {
         self.into_components()
     }
 }
 
-impl<S: RgbSpace, T: Component + Float, H: Into<RgbHue<T>>, A: Component> From<(H, T, T, A)>
+impl<S: RgbSpace, T: FloatComponent, H: Into<RgbHue<T>>, A: Component> From<(H, T, T, A)>
     for Alpha<Hwb<S, T>, A>
 {
     fn from(components: (H, T, T, A)) -> Self {
@@ -232,7 +232,7 @@ impl<S: RgbSpace, T: Component + Float, H: Into<RgbHue<T>>, A: Component> From<(
     }
 }
 
-impl<S: RgbSpace, T: Component + Float, A: Component> Into<(RgbHue<T>, T, T, A)>
+impl<S: RgbSpace, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
     for Alpha<Hwb<S, T>, A>
 {
     fn into(self) -> (RgbHue<T>, T, T, A) {
@@ -242,7 +242,7 @@ impl<S: RgbSpace, T: Component + Float, A: Component> Into<(RgbHue<T>, T, T, A)>
 
 impl<S, T> Limited for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -271,7 +271,7 @@ where
 
 impl<S, T> Mix for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Scalar = T;
@@ -291,7 +291,7 @@ where
 
 impl<S, T> Shade for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Scalar = T;
@@ -308,7 +308,7 @@ where
 
 impl<S, T> GetHue for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Hue = RgbHue<T>;
@@ -324,7 +324,7 @@ where
 
 impl<S, T> Hue for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Hwb<S, T> {
@@ -348,7 +348,7 @@ where
 
 impl<S, T> Default for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     fn default() -> Hwb<S, T> {
@@ -358,7 +358,7 @@ where
 
 impl<S, T> Add<Hwb<S, T>> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Output = Hwb<S, T>;
@@ -375,7 +375,7 @@ where
 
 impl<S, T> Add<T> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Output = Hwb<S, T>;
@@ -391,9 +391,9 @@ where
 }
 
 impl<S, T> AddAssign<Hwb<S, T>> for Hwb<S, T>
-    where
-        T: Component + Float + AddAssign,
-        S: RgbSpace,
+where
+    T: FloatComponent + AddAssign,
+    S: RgbSpace,
 {
     fn add_assign(&mut self, other: Hwb<S, T>) {
         self.hue += other.hue;
@@ -403,9 +403,9 @@ impl<S, T> AddAssign<Hwb<S, T>> for Hwb<S, T>
 }
 
 impl<S, T> AddAssign<T> for Hwb<S, T>
-    where
-        T: Component + Float + AddAssign,
-        S: RgbSpace,
+where
+    T: FloatComponent + AddAssign,
+    S: RgbSpace,
 {
     fn add_assign(&mut self, c: T) {
         self.hue += c;
@@ -416,7 +416,7 @@ impl<S, T> AddAssign<T> for Hwb<S, T>
 
 impl<S, T> Sub<Hwb<S, T>> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Output = Hwb<S, T>;
@@ -433,7 +433,7 @@ where
 
 impl<S, T> Sub<T> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
 {
     type Output = Hwb<S, T>;
@@ -448,11 +448,10 @@ where
     }
 }
 
-
 impl<S, T> SubAssign<Hwb<S, T>> for Hwb<S, T>
-    where
-        T: Component + Float + SubAssign,
-        S: RgbSpace,
+where
+    T: FloatComponent + SubAssign,
+    S: RgbSpace,
 {
     fn sub_assign(&mut self, other: Hwb<S, T>) {
         self.hue -= other.hue;
@@ -462,9 +461,9 @@ impl<S, T> SubAssign<Hwb<S, T>> for Hwb<S, T>
 }
 
 impl<S, T> SubAssign<T> for Hwb<S, T>
-    where
-        T: Component + Float + SubAssign,
-        S: RgbSpace,
+where
+    T: FloatComponent + SubAssign,
+    S: RgbSpace,
 {
     fn sub_assign(&mut self, c: T) {
         self.hue -= c;
@@ -475,7 +474,7 @@ impl<S, T> SubAssign<T> for Hwb<S, T>
 
 impl<S, T, P> AsRef<P> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
     P: RawPixel<T> + ?Sized,
 {
@@ -486,7 +485,7 @@ where
 
 impl<S, T, P> AsMut<P> for Hwb<S, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: RgbSpace,
     P: RawPixel<T> + ?Sized,
 {
@@ -497,8 +496,8 @@ where
 
 impl<S, T> AbsDiffEq for Hwb<S, T>
 where
-    T: Component + Float + AbsDiffEq,
-    T::Epsilon: Copy + Float,
+    T: FloatComponent + AbsDiffEq,
+    T::Epsilon: Copy + Float + FromF64,
     S: RgbSpace + PartialEq,
 {
     type Epsilon = T::Epsilon;
@@ -508,12 +507,8 @@ where
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        let equal_shade = self
-            .whiteness
-            .abs_diff_eq(&other.whiteness, epsilon)
-            && self
-            .blackness
-            .abs_diff_eq(&other.blackness, epsilon);
+        let equal_shade = self.whiteness.abs_diff_eq(&other.whiteness, epsilon)
+            && self.blackness.abs_diff_eq(&other.blackness, epsilon);
 
         // The hue doesn't matter that much when the color is gray, and may fluctuate
         // due to precision errors. This is a blunt tool, but works for now.
@@ -529,8 +524,8 @@ where
 
 impl<S, T> RelativeEq for Hwb<S, T>
 where
-    T: Component + Float + RelativeEq,
-    T::Epsilon: Copy + Float,
+    T: FloatComponent + RelativeEq,
+    T::Epsilon: Copy + Float + FromF64,
     S: RgbSpace + PartialEq,
 {
     fn default_max_relative() -> Self::Epsilon {
@@ -547,8 +542,8 @@ where
             .whiteness
             .relative_eq(&other.whiteness, epsilon, max_relative)
             && self
-            .blackness
-            .relative_eq(&other.blackness, epsilon, max_relative);
+                .blackness
+                .relative_eq(&other.blackness, epsilon, max_relative);
 
         // The hue doesn't matter that much when the color is gray, and may fluctuate
         // due to precision errors. This is a blunt tool, but works for now.
@@ -564,8 +559,8 @@ where
 
 impl<S, T> UlpsEq for Hwb<S, T>
 where
-    T: Component + Float + UlpsEq,
-    T::Epsilon: Copy + Float,
+    T: FloatComponent + UlpsEq,
+    T::Epsilon: Copy + Float + FromF64,
     S: RgbSpace + PartialEq,
 {
     fn default_max_ulps() -> u32 {
@@ -573,12 +568,8 @@ where
     }
 
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
-        let equal_shade = self
-            .whiteness
-            .ulps_eq(&other.whiteness, epsilon, max_ulps)
-            && self
-            .blackness
-            .ulps_eq(&other.blackness, epsilon, max_ulps);
+        let equal_shade = self.whiteness.ulps_eq(&other.whiteness, epsilon, max_ulps)
+            && self.blackness.ulps_eq(&other.blackness, epsilon, max_ulps);
 
         // The hue doesn't matter that much when the color is gray, and may fluctuate
         // due to precision errors. This is a blunt tool, but works for now.

--- a/palette/src/matrix.rs
+++ b/palette/src/matrix.rs
@@ -5,17 +5,17 @@ use float::Float;
 
 use core::marker::PhantomData;
 
-use {Component, Xyz};
-use white_point::WhitePoint;
-use rgb::{Primaries, Rgb, RgbSpace};
-use encoding::Linear;
 use convert::IntoColor;
+use encoding::Linear;
+use rgb::{Primaries, Rgb, RgbSpace};
+use white_point::WhitePoint;
+use {FloatComponent, Xyz};
 
 ///A 9 element array representing a 3x3 matrix
 pub type Mat3<T> = [T; 9];
 
 ///Multiply the 3x3 matrix with the XYZ color
-pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: Component + Float>(
+pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Xyz<Swp, T>,
 ) -> Xyz<Dwp, T> {
@@ -27,7 +27,7 @@ pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: Component + Float>(
     }
 }
 ///Multiply the 3x3 matrix with the XYZ color into RGB color
-pub fn multiply_xyz_to_rgb<S: RgbSpace, T: Component + Float>(
+pub fn multiply_xyz_to_rgb<S: RgbSpace, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Xyz<S::WhitePoint, T>,
 ) -> Rgb<Linear<S>, T> {
@@ -39,7 +39,7 @@ pub fn multiply_xyz_to_rgb<S: RgbSpace, T: Component + Float>(
     }
 }
 ///Multiply the 3x3 matrix with the  RGB into XYZ color
-pub fn multiply_rgb_to_xyz<S: RgbSpace, T: Component + Float>(
+pub fn multiply_rgb_to_xyz<S: RgbSpace, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Rgb<Linear<S>, T>,
 ) -> Xyz<S::WhitePoint, T> {
@@ -99,7 +99,7 @@ pub fn matrix_inverse<T: Float>(a: &Mat3<T>) -> Mat3<T> {
 }
 
 ///Geneartes to Srgb to Xyz transformation matrix for the given white point
-pub fn rgb_to_xyz_matrix<S: RgbSpace, T: Component + Float>() -> Mat3<T> {
+pub fn rgb_to_xyz_matrix<S: RgbSpace, T: FloatComponent>() -> Mat3<T> {
     let r: Xyz<S::WhitePoint, T> = S::Primaries::red().into_xyz();
     let g: Xyz<S::WhitePoint, T> = S::Primaries::green().into_xyz();
     let b: Xyz<S::WhitePoint, T> = S::Primaries::blue().into_xyz();
@@ -124,7 +124,7 @@ pub fn rgb_to_xyz_matrix<S: RgbSpace, T: Component + Float>() -> Mat3<T> {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-fn mat3_from_primaries<T: Component + Float, Wp: WhitePoint>(r: Xyz<Wp, T>, g: Xyz<Wp, T>, b: Xyz<Wp, T>) -> Mat3<T> {
+fn mat3_from_primaries<T: FloatComponent, Wp: WhitePoint>(r: Xyz<Wp, T>, g: Xyz<Wp, T>, b: Xyz<Wp, T>) -> Mat3<T> {
     [
         r.x, g.x, b.x,
         r.y, g.y, b.y,
@@ -134,12 +134,12 @@ fn mat3_from_primaries<T: Component + Float, Wp: WhitePoint>(r: Xyz<Wp, T>, g: X
 
 #[cfg(test)]
 mod test {
-    use Xyz;
-    use rgb::Rgb;
-    use encoding::{Linear, Srgb};
+    use super::{matrix_inverse, multiply_3x3, multiply_xyz, rgb_to_xyz_matrix};
     use chromatic_adaptation::AdaptInto;
+    use encoding::{Linear, Srgb};
+    use rgb::Rgb;
     use white_point::D50;
-    use super::{matrix_inverse, multiply_xyz, rgb_to_xyz_matrix, multiply_3x3};
+    use Xyz;
 
     #[test]
     fn matrix_multiply_3x3() {

--- a/palette/src/rgb/mod.rs
+++ b/palette/src/rgb/mod.rs
@@ -1,10 +1,9 @@
 //!RGB types, spaces and standards.
 
-use float::Float;
 use core::any::Any;
 
-use {Component, Yxy};
 use white_point::WhitePoint;
+use {Component, FloatComponent, FromComponent, Yxy};
 
 use encoding::{Linear, TransferFn};
 
@@ -64,17 +63,17 @@ impl<P: Primaries, W: WhitePoint> RgbSpace for (P, W) {
 ///Represents the red, green and blue primaries of an RGB space.
 pub trait Primaries: Any {
     ///Primary red.
-    fn red<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T>;
+    fn red<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T>;
     ///Primary green.
-    fn green<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T>;
+    fn green<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T>;
     ///Primary blue.
-    fn blue<Wp: WhitePoint, T: Component + Float>() -> Yxy<Wp, T>;
+    fn blue<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T>;
 }
 
 impl<T, U> From<LinSrgb<T>> for Srgb<U>
 where
-    T: Component + Float,
-    U: Component,
+    T: FloatComponent,
+    U: Component + FromComponent<T>,
 {
     fn from(lin_srgb: LinSrgb<T>) -> Self {
         let non_lin = Srgb::<T>::from_linear(lin_srgb);
@@ -84,19 +83,18 @@ where
 
 impl<T, U> From<Srgb<T>> for LinSrgb<U>
 where
-    T: Component + Float,
-    U: Component,
+    T: FloatComponent,
+    U: Component + FromComponent<T>,
 {
     fn from(srgb: Srgb<T>) -> Self {
-        srgb.into_linear()
-            .into_format()
+        srgb.into_linear().into_format()
     }
 }
 
 impl<T, U> From<LinSrgb<T>> for Srgba<U>
 where
-    T: Component + Float,
-    U: Component,
+    T: FloatComponent,
+    U: Component + FromComponent<T>,
 {
     fn from(lin_srgb: LinSrgb<T>) -> Self {
         let non_lin = Srgb::<T>::from_linear(lin_srgb);
@@ -107,8 +105,8 @@ where
 
 impl<T, U> From<LinSrgba<T>> for Srgba<U>
 where
-    T: Component + Float,
-    U: Component,
+    T: FloatComponent,
+    U: Component + FromComponent<T>,
 {
     fn from(lin_srgba: LinSrgba<T>) -> Self {
         let non_lin = Srgba::<T>::from_linear(lin_srgba);
@@ -118,23 +116,20 @@ where
 
 impl<T, U> From<Srgb<T>> for LinSrgba<U>
 where
-    T: Component + Float,
-    U: Component,
+    T: FloatComponent,
+    U: Component + FromComponent<T>,
 {
     fn from(srgb: Srgb<T>) -> Self {
-        srgb.into_linear()
-            .into_format()
-            .into()
+        srgb.into_linear().into_format().into()
     }
 }
 
 impl<T, U> From<Srgba<T>> for LinSrgba<U>
 where
-    T: Component + Float,
-    U: Component,
+    T: FloatComponent,
+    U: Component + FromComponent<T>,
 {
     fn from(srgba: Srgba<T>) -> Self {
-        srgba.into_linear()
-            .into_format()
+        srgba.into_linear().into_format()
     }
 }

--- a/palette/src/white_point.rs
+++ b/palette/src/white_point.rs
@@ -6,9 +6,7 @@
 //! unacceptable results when attempting to color-correct a photograph taken with incandescent
 //! lighting.
 
-use float::Float;
-
-use {cast, Component, Xyz};
+use {from_f64, FloatComponent, Xyz};
 
 ///WhitePoint defines the Xyz color co-ordinates for a given white point.
 ///
@@ -20,7 +18,7 @@ use {cast, Component, Xyz};
 ///and can be used in place of the ones defined in this library.
 pub trait WhitePoint {
     ///Get the Xyz chromacity co-ordinates for the white point.
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T>;
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T>;
 }
 
 /// CIE standard illuminant A
@@ -31,8 +29,8 @@ pub trait WhitePoint {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct A;
 impl WhitePoint for A {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(1.09850), T::one(), cast(0.35585))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(1.09850), T::one(), from_f64(0.35585))
     }
 }
 /// CIE standard illuminant B
@@ -42,8 +40,8 @@ impl WhitePoint for A {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct B;
 impl WhitePoint for B {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.99072), T::one(), cast(0.85223))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.99072), T::one(), from_f64(0.85223))
     }
 }
 ///CIE standard illuminant C
@@ -53,8 +51,8 @@ impl WhitePoint for B {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct C;
 impl WhitePoint for C {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.98074), T::one(), cast(1.18232))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.98074), T::one(), from_f64(1.18232))
     }
 }
 ///CIE D series standard illuminant - D50
@@ -64,8 +62,8 @@ impl WhitePoint for C {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50;
 impl WhitePoint for D50 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.96422), T::one(), cast(0.82521))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.96422), T::one(), from_f64(0.82521))
     }
 }
 ///CIE D series standard illuminant - D55
@@ -75,8 +73,8 @@ impl WhitePoint for D50 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55;
 impl WhitePoint for D55 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.95682), T::one(), cast(0.92149))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.95682), T::one(), from_f64(0.92149))
     }
 }
 ///CIE D series standard illuminant - D65
@@ -86,8 +84,8 @@ impl WhitePoint for D55 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65;
 impl WhitePoint for D65 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.95047), T::one(), cast(1.08883))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.95047), T::one(), from_f64(1.08883))
     }
 }
 ///CIE D series standard illuminant - D75
@@ -97,8 +95,8 @@ impl WhitePoint for D65 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75;
 impl WhitePoint for D75 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.94972), T::one(), cast(1.22638))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.94972), T::one(), from_f64(1.22638))
     }
 }
 ///CIE standard illuminant E
@@ -108,7 +106,7 @@ impl WhitePoint for D75 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct E;
 impl WhitePoint for E {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
         Xyz::with_wp(T::one(), T::one(), T::one())
     }
 }
@@ -118,8 +116,8 @@ impl WhitePoint for E {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F2;
 impl WhitePoint for F2 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.99186), T::one(), cast(0.67393))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.99186), T::one(), from_f64(0.67393))
     }
 }
 ///CIE fluorescent illuminant series - F7
@@ -128,8 +126,8 @@ impl WhitePoint for F2 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F7;
 impl WhitePoint for F7 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.95041), T::one(), cast(1.08747))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.95041), T::one(), from_f64(1.08747))
     }
 }
 ///CIE fluorescent illuminant series - F11
@@ -138,8 +136,8 @@ impl WhitePoint for F7 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F11;
 impl WhitePoint for F11 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(1.00962), T::one(), cast(0.64350))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(1.00962), T::one(), from_f64(0.64350))
     }
 }
 ///CIE D series standard illuminant - D50
@@ -149,8 +147,8 @@ impl WhitePoint for F11 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50Degree10;
 impl WhitePoint for D50Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.9672), T::one(), cast(0.8143))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.9672), T::one(), from_f64(0.8143))
     }
 }
 ///CIE D series standard illuminant - D55
@@ -160,8 +158,8 @@ impl WhitePoint for D50Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55Degree10;
 impl WhitePoint for D55Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.958), T::one(), cast(0.9093))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.958), T::one(), from_f64(0.9093))
     }
 }
 ///CIE D series standard illuminant - D65
@@ -171,8 +169,8 @@ impl WhitePoint for D55Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65Degree10;
 impl WhitePoint for D65Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.9481), T::one(), cast(1.073))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.9481), T::one(), from_f64(1.073))
     }
 }
 ///CIE D series standard illuminant - D75
@@ -182,7 +180,7 @@ impl WhitePoint for D65Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75Degree10;
 impl WhitePoint for D75Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
-        Xyz::with_wp(cast(0.94416), T::one(), cast(1.2064))
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.94416), T::one(), from_f64(1.2064))
     }
 }

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -1,14 +1,12 @@
-use float::Float;
-
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 use clamp;
 use encoding::pixel::RawPixel;
 use luma::LumaStandard;
-use white_point::{D65, WhitePoint};
+use white_point::{WhitePoint, D65};
 use {Alpha, Luma, Xyz};
-use {Component, ComponentWise, IntoColor, Limited, Mix, Pixel, Shade};
+use {Component, ComponentWise, FloatComponent, IntoColor, Limited, Mix, Pixel, Shade};
 
 /// CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation
 /// in `Alpha`](struct.Alpha.html#Yxya).
@@ -30,7 +28,7 @@ pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 #[repr(C)]
 pub struct Yxy<Wp = D65, T = f32>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     ///x chromacity co-ordinate derived from XYZ color space as X/(X+Y+Z).
@@ -55,14 +53,14 @@ where
 
 impl<Wp, T> Copy for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
 }
 
 impl<Wp, T> Clone for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     fn clone(&self) -> Yxy<Wp, T> {
@@ -72,7 +70,7 @@ where
 
 impl<T> Yxy<D65, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
 {
     ///CIE Yxy with white point D65.
     pub fn new(x: T, y: T, luma: T) -> Yxy<D65, T> {
@@ -87,7 +85,7 @@ where
 
 impl<Wp, T> Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     ///CIE Yxy.
@@ -114,7 +112,7 @@ where
 ///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
 impl<T, A> Alpha<Yxy<D65, T>, A>
 where
-    T: Component + Float,
+    T: FloatComponent,
     A: Component,
 {
     ///CIE Yxy and transparency with white point D65.
@@ -128,7 +126,7 @@ where
 ///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
 impl<Wp, T, A> Alpha<Yxy<Wp, T>, A>
 where
-    T: Component + Float,
+    T: FloatComponent,
     A: Component,
     Wp: WhitePoint,
 {
@@ -153,7 +151,7 @@ where
 
 impl<Wp, T> From<Xyz<Wp, T>> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     fn from(xyz: Xyz<Wp, T>) -> Self {
@@ -175,7 +173,7 @@ where
 
 impl<S, T> From<Luma<S, T>> for Yxy<S::WhitePoint, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     S: LumaStandard,
 {
     fn from(luma: Luma<S, T>) -> Self {
@@ -186,29 +184,25 @@ where
     }
 }
 
-impl<Wp: WhitePoint, T: Component + Float> From<(T, T, T)> for Yxy<Wp, T> {
+impl<Wp: WhitePoint, T: FloatComponent> From<(T, T, T)> for Yxy<Wp, T> {
     fn from(components: (T, T, T)) -> Self {
         Self::from_components(components)
     }
 }
 
-impl<Wp: WhitePoint, T: Component + Float> Into<(T, T, T)> for Yxy<Wp, T> {
+impl<Wp: WhitePoint, T: FloatComponent> Into<(T, T, T)> for Yxy<Wp, T> {
     fn into(self) -> (T, T, T) {
         self.into_components()
     }
 }
 
-impl<Wp: WhitePoint, T: Component + Float, A: Component> From<(T, T, T, A)>
-    for Alpha<Yxy<Wp, T>, A>
-{
+impl<Wp: WhitePoint, T: FloatComponent, A: Component> From<(T, T, T, A)> for Alpha<Yxy<Wp, T>, A> {
     fn from(components: (T, T, T, A)) -> Self {
         Self::from_components(components)
     }
 }
 
-impl<Wp: WhitePoint, T: Component + Float, A: Component> Into<(T, T, T, A)>
-    for Alpha<Yxy<Wp, T>, A>
-{
+impl<Wp: WhitePoint, T: FloatComponent, A: Component> Into<(T, T, T, A)> for Alpha<Yxy<Wp, T>, A> {
     fn into(self) -> (T, T, T, A) {
         self.into_components()
     }
@@ -216,7 +210,7 @@ impl<Wp: WhitePoint, T: Component + Float, A: Component> Into<(T, T, T, A)>
 
 impl<Wp, T> Limited for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -241,7 +235,7 @@ where
 
 impl<Wp, T> Mix for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Scalar = T;
@@ -260,7 +254,7 @@ where
 
 impl<Wp, T> Shade for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Scalar = T;
@@ -277,7 +271,7 @@ where
 
 impl<Wp, T> ComponentWise for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Scalar = T;
@@ -303,7 +297,7 @@ where
 
 impl<Wp, T> Default for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     fn default() -> Yxy<Wp, T> {
@@ -320,7 +314,7 @@ where
 
 impl<Wp, T> Add<Yxy<Wp, T>> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -337,7 +331,7 @@ where
 
 impl<Wp, T> Add<T> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -354,7 +348,7 @@ where
 
 impl<Wp, T> AddAssign<Yxy<Wp, T>> for Yxy<Wp, T>
 where
-    T: Component + Float + AddAssign,
+    T: FloatComponent + AddAssign,
     Wp: WhitePoint,
 {
     fn add_assign(&mut self, other: Yxy<Wp, T>) {
@@ -366,7 +360,7 @@ where
 
 impl<Wp, T> AddAssign<T> for Yxy<Wp, T>
 where
-    T: Component + Float + AddAssign,
+    T: FloatComponent + AddAssign,
     Wp: WhitePoint,
 {
     fn add_assign(&mut self, c: T) {
@@ -378,7 +372,7 @@ where
 
 impl<Wp, T> Sub<Yxy<Wp, T>> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -395,7 +389,7 @@ where
 
 impl<Wp, T> Sub<T> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -411,9 +405,9 @@ where
 }
 
 impl<Wp, T> SubAssign<Yxy<Wp, T>> for Yxy<Wp, T>
-    where
-        T: Component + Float + SubAssign,
-        Wp: WhitePoint,
+where
+    T: FloatComponent + SubAssign,
+    Wp: WhitePoint,
 {
     fn sub_assign(&mut self, other: Yxy<Wp, T>) {
         self.x -= other.x;
@@ -423,9 +417,9 @@ impl<Wp, T> SubAssign<Yxy<Wp, T>> for Yxy<Wp, T>
 }
 
 impl<Wp, T> SubAssign<T> for Yxy<Wp, T>
-    where
-        T: Component + Float + SubAssign,
-        Wp: WhitePoint,
+where
+    T: FloatComponent + SubAssign,
+    Wp: WhitePoint,
 {
     fn sub_assign(&mut self, c: T) {
         self.x -= c;
@@ -436,7 +430,7 @@ impl<Wp, T> SubAssign<T> for Yxy<Wp, T>
 
 impl<Wp, T> Mul<Yxy<Wp, T>> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -453,7 +447,7 @@ where
 
 impl<Wp, T> Mul<T> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -469,9 +463,9 @@ where
 }
 
 impl<Wp, T> MulAssign<Yxy<Wp, T>> for Yxy<Wp, T>
-    where
-        T: Component + Float + MulAssign,
-        Wp: WhitePoint,
+where
+    T: FloatComponent + MulAssign,
+    Wp: WhitePoint,
 {
     fn mul_assign(&mut self, other: Yxy<Wp, T>) {
         self.x *= other.x;
@@ -481,9 +475,9 @@ impl<Wp, T> MulAssign<Yxy<Wp, T>> for Yxy<Wp, T>
 }
 
 impl<Wp, T> MulAssign<T> for Yxy<Wp, T>
-    where
-        T: Component + Float + MulAssign,
-        Wp: WhitePoint,
+where
+    T: FloatComponent + MulAssign,
+    Wp: WhitePoint,
 {
     fn mul_assign(&mut self, c: T) {
         self.x *= c;
@@ -494,7 +488,7 @@ impl<Wp, T> MulAssign<T> for Yxy<Wp, T>
 
 impl<Wp, T> Div<Yxy<Wp, T>> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -511,7 +505,7 @@ where
 
 impl<Wp, T> Div<T> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
 {
     type Output = Yxy<Wp, T>;
@@ -527,9 +521,9 @@ where
 }
 
 impl<Wp, T> DivAssign<Yxy<Wp, T>> for Yxy<Wp, T>
-    where
-        T: Component + Float + DivAssign,
-        Wp: WhitePoint,
+where
+    T: FloatComponent + DivAssign,
+    Wp: WhitePoint,
 {
     fn div_assign(&mut self, other: Yxy<Wp, T>) {
         self.x /= other.x;
@@ -539,9 +533,9 @@ impl<Wp, T> DivAssign<Yxy<Wp, T>> for Yxy<Wp, T>
 }
 
 impl<Wp, T> DivAssign<T> for Yxy<Wp, T>
-    where
-        T: Component + Float + DivAssign,
-        Wp: WhitePoint,
+where
+    T: FloatComponent + DivAssign,
+    Wp: WhitePoint,
 {
     fn div_assign(&mut self, c: T) {
         self.x /= c;
@@ -552,7 +546,7 @@ impl<Wp, T> DivAssign<T> for Yxy<Wp, T>
 
 impl<Wp, T, P> AsRef<P> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
     P: RawPixel<T> + ?Sized,
 {
@@ -563,7 +557,7 @@ where
 
 impl<Wp, T, P> AsMut<P> for Yxy<Wp, T>
 where
-    T: Component + Float,
+    T: FloatComponent,
     Wp: WhitePoint,
     P: RawPixel<T> + ?Sized,
 {
@@ -609,7 +603,7 @@ mod test {
 
     #[test]
     fn ranges() {
-        assert_ranges!{
+        assert_ranges! {
             Yxy<D65, f64>;
             limited {
                 x: 0.0 => 1.0,

--- a/palette/tests/pointer_dataset/pointer_data.rs
+++ b/palette/tests/pointer_dataset/pointer_data.rs
@@ -11,16 +11,16 @@ u', v'		0.2008907213	0.4608888395
 Note: The xyz and yxy conversions do not use the updated conversion formula. So they are not used.
 */
 
+use csv;
 use num_traits::{NumCast, ToPrimitive};
 use palette::float::Float;
-use csv;
-use palette::{Component, IntoColor, Lab, Lch, Xyz};
 use palette::white_point::WhitePoint;
+use palette::{FloatComponent, IntoColor, Lab, Lch, Xyz};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PointerWP;
 impl WhitePoint for PointerWP {
-    fn get_xyz<Wp: WhitePoint, T: Component + Float>() -> Xyz<Wp, T> {
+    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
         Xyz::with_wp(flt(0.980722647624), T::one(), flt(1.182254189827))
     }
 }
@@ -68,8 +68,7 @@ macro_rules! impl_from_color_pointer {
                 }
             }
         }
-
-    }
+    };
 }
 
 impl_from_color_pointer!(Lch);

--- a/palette_derive/src/convert/shared.rs
+++ b/palette_derive/src/convert/shared.rs
@@ -77,7 +77,7 @@ pub fn rgb_space_type(rgb_space: Option<Type>, white_point: &Type, internal: boo
 }
 
 pub fn add_component_where_clause(component: &Type, generics: &mut Generics, internal: bool) {
-    let component_trait_path = util::path(&["Component"], internal);
+    let component_trait_path = util::path(&["FloatComponent"], internal);
 
     generics
         .make_where_clause()


### PR DESCRIPTION
This adds specific traits for converting and for floating point components. This makes the implementation of each trait simpler and hopefully more efficient (@PeterHatch was right all along), and reduces their requirements a bit. A side effect is that the `cast` hack function can be reduced to convert from `f64` values only (still not completely gone, but its use is more limited now), and become panic free. The downside is the extra `FromF64` trait, but it's at least not hard to implement and new float types should be rare enough.

This is a breaking change.