### PR TITLE
Migrate to Rust 2018 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Selecting the proper color space can have a big impact on how the resulting imag
 This example takes an sRGB color, converts it to CIE L\*C\*h°, shifts its hue by 180° and converts it back to RGB:
 
 ```Rust
-extern crate palette;
 use palette::{Srgb, LinSrgb, Lch, Hue};
 
 let lch_color: Lch = Srgb::new(0.8, 0.2, 0.1).into();
@@ -83,7 +82,6 @@ This may seem limiting, but the point is to avoid inconsistent behavior due to a
 The following example shows how the `Color` type is used to make a lighter and a desaturated version of the original.
 
 ```Rust
-extern crate palette;
 use palette::{Saturate, Shade, Srgb, Lch};
 
 let color = Srgb::new(0.8, 0.2, 0.1).into_linear();
@@ -102,7 +100,6 @@ There is also a linear gradient type which makes it easy to interpolate between 
 The following example shows three gradients between the same two endpoints, but the top is in RGB space while the middle and bottom are in HSV space. The bottom gradient is an example of using the color sequence iterator.
 
 ```Rust
-extern crate palette;
 use palette::{LinSrgb, Hsv, Gradient};
 
 let grad1 = Gradient::new(vec![

--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -6,6 +6,7 @@ exclude = []
 description = "Test crate for #[no_std]."
 repository = "https://github.com/Ogeon/palette"
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [dependencies.libc]
 version = "0.2"

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -1,11 +1,9 @@
 #![feature(lang_items, start)]
 #![no_std]
 
-extern crate libc;
-
-extern crate palette;
-
 use core::panic::PanicInfo;
+
+extern crate libc;
 
 #[start]
 fn start(_argc: isize, _argv: *const *const u8) -> isize {

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Ogeon/palette"
 readme = "README.md"
 keywords = ["color", "colour", "space", "linear"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 build = "build/main.rs"
 

--- a/palette/build/named.rs
+++ b/palette/build/named.rs
@@ -19,23 +19,23 @@ pub fn build() {
         let name = parts.next().expect("couldn't get the color name");
         let mut rgb = parts
             .next()
-            .expect(&format!("couldn't get color for {}", name))
+            .unwrap_or_else(|| panic!("couldn't get color for {}", name))
             .split(", ");
         let red: u8 = rgb
             .next()
             .and_then(|r| r.trim().parse().ok())
-            .expect(&format!("couldn't get red for {}", name));
+            .unwrap_or_else(|| panic!("couldn't get red for {}", name));
         let green: u8 = rgb
             .next()
             .and_then(|r| r.trim().parse().ok())
-            .expect(&format!("couldn't get green for {}", name));
+            .unwrap_or_else(|| panic!("couldn't get green for {}", name));
         let blue: u8 = rgb
             .next()
             .and_then(|r| r.trim().parse().ok())
-            .expect(&format!("couldn't get blue for {}", name));
+            .unwrap_or_else(|| panic!("couldn't get blue for {}", name));
 
         writeln!(writer, "\n///<div style=\"display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: {0};\"></div>", name).unwrap();
-        writeln!(writer, "pub const {}: ::rgb::Srgb<u8> = ::rgb::Srgb {{ red: {}, green: {}, blue: {}, standard: ::core::marker::PhantomData }};", name.to_uppercase(), red, green, blue).unwrap();
+        writeln!(writer, "pub const {}: crate::rgb::Srgb<u8> = crate::rgb::Srgb {{ red: {}, green: {}, blue: {}, standard: ::core::marker::PhantomData }};", name.to_uppercase(), red, green, blue).unwrap();
 
         entries.push((name.to_owned(), name.to_uppercase()));
     }
@@ -53,7 +53,7 @@ fn gen_from_str(writer: &mut File, entries: &[(String, String)]) {
     }
     write!(
         writer,
-        "static COLORS: ::phf::Map<&'static str, ::rgb::Srgb<u8>> = {};",
+        "static COLORS: ::phf::Map<&'static str, crate::rgb::Srgb<u8>> = {};",
         map.build()
     )
     .unwrap();

--- a/palette/examples/color_scheme.rs
+++ b/palette/examples/color_scheme.rs
@@ -1,7 +1,3 @@
-extern crate clap;
-extern crate image;
-extern crate palette;
-
 use palette::{Hue, Lch, LinSrgb, Pixel, Shade, Srgb};
 
 use image::{GenericImage, GenericImageView, RgbImage, SubImage};

--- a/palette/examples/gradient.rs
+++ b/palette/examples/gradient.rs
@@ -1,6 +1,3 @@
-extern crate image;
-extern crate palette;
-
 #[cfg(not(feature = "std"))]
 fn main() {
     println!("You can't use gradients without the standard library");

--- a/palette/examples/hue.rs
+++ b/palette/examples/hue.rs
@@ -1,6 +1,3 @@
-extern crate image;
-extern crate palette;
-
 use palette::{Hsl, Hue, Lch, Pixel, Srgb};
 
 fn main() {

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -1,7 +1,3 @@
-extern crate image;
-extern crate num_traits;
-extern crate palette;
-
 use image::{GenericImage, GenericImageView, RgbImage};
 
 #[cfg(feature = "std")]
@@ -9,7 +5,7 @@ use palette::{Gradient, LinSrgb, Mix};
 use palette::{Pixel, Srgb};
 
 mod color_spaces {
-    use display_colors;
+    use crate::display_colors;
     use palette::{Hue, Lch, LinSrgb, Srgb};
 
     pub fn run() {
@@ -27,7 +23,7 @@ mod color_spaces {
 }
 
 mod manipulation {
-    use display_colors;
+    use crate::display_colors;
     use palette::{Lch, Saturate, Shade, Srgb};
 
     pub fn run() {
@@ -48,7 +44,7 @@ mod manipulation {
 
 #[cfg(feature = "std")]
 mod gradients {
-    use display_gradients;
+    use crate::display_gradients;
     use palette::{Gradient, Hsv, LinSrgb};
 
     pub fn run() {

--- a/palette/examples/saturate.rs
+++ b/palette/examples/saturate.rs
@@ -1,6 +1,3 @@
-extern crate image;
-extern crate palette;
-
 use palette::{Hsl, Lch, Pixel, Saturate, Srgb};
 
 use image::{GenericImage, GenericImageView};

--- a/palette/examples/shade.rs
+++ b/palette/examples/shade.rs
@@ -1,6 +1,3 @@
-extern crate image;
-extern crate palette;
-
 use palette::{Hsv, Lab, LinSrgb, Pixel, Shade, Srgb};
 
 use image::{GenericImage, GenericImageView, RgbImage};

--- a/palette/src/alpha.rs
+++ b/palette/src/alpha.rs
@@ -1,25 +1,26 @@
 use core::fmt;
 use core::ops::{Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use float::Float;
-
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-use blend::PreAlpha;
-use encoding::pixel::RawPixel;
-use {clamp, Blend, Component, ComponentWise, GetHue, Hue, Limited, Mix, Pixel, Saturate, Shade};
+use crate::blend::PreAlpha;
+use crate::encoding::pixel::RawPixel;
+use crate::float::Float;
+use crate::{
+    clamp, Blend, Component, ComponentWise, GetHue, Hue, Limited, Mix, Pixel, Saturate, Shade,
+};
 
-///An alpha component wrapper for colors.
+/// An alpha component wrapper for colors.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Alpha<C, T> {
-    ///The color.
+    /// The color.
     #[cfg_attr(feature = "serializing", serde(flatten))]
     pub color: C,
 
-    ///The transparency component. 0.0 is fully transparent and 1.0 is fully
-    ///opaque.
+    /// The transparency component. 0.0 is fully transparent and 1.0 is fully
+    /// opaque.
     pub alpha: T,
 }
 
@@ -382,7 +383,7 @@ where
 impl<C, T: Component> From<C> for Alpha<C, T> {
     fn from(color: C) -> Alpha<C, T> {
         Alpha {
-            color: color,
+            color,
             alpha: T::max_intensity(),
         }
     }
@@ -424,8 +425,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use encoding::Srgb;
-    use rgb::Rgba;
+    use crate::encoding::Srgb;
+    use crate::rgb::Rgba;
 
     #[test]
     fn lower_hex() {

--- a/palette/src/blend/blend.rs
+++ b/palette/src/blend/blend.rs
@@ -1,53 +1,53 @@
-use float::Float;
 use num_traits::{One, Zero};
 
-use blend::{BlendFunction, PreAlpha};
-use {clamp, ComponentWise};
+use crate::blend::{BlendFunction, PreAlpha};
+use crate::float::Float;
+use crate::{clamp, ComponentWise};
 
-///A trait for colors that can be blended together.
+/// A trait for colors that can be blended together.
 ///
-///Blending can either be performed through the predefined blend modes, or a
-///custom blend functions.
+/// Blending can either be performed through the predefined blend modes, or a
+/// custom blend functions.
 ///
-///_Note: The default implementations of the blend modes are meant for color
-///components in the range [0.0, 1.0] and may otherwise produce strange
-///results._
+/// _Note: The default implementations of the blend modes are meant for color
+/// components in the range [0.0, 1.0] and may otherwise produce strange
+/// results._
 pub trait Blend: Sized
 where
     <Self::Color as ComponentWise>::Scalar: Float,
 {
-    ///The core color type. Typically `Self` for color types without alpha.
+    /// The core color type. Typically `Self` for color types without alpha.
     type Color: Blend<Color = Self::Color> + ComponentWise;
 
-    ///Convert the color to premultiplied alpha.
+    /// Convert the color to premultiplied alpha.
     fn into_premultiplied(self) -> PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>;
 
-    ///Convert the color from premultiplied alpha.
+    /// Convert the color from premultiplied alpha.
     fn from_premultiplied(
         color: PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>,
     ) -> Self;
 
-    ///Blend self, as the source color, with `destination`, using
-    ///`blend_function`. Anything that implements `BlendFunction` is
-    ///acceptable, including functions and closures.
+    /// Blend self, as the source color, with `destination`, using
+    /// `blend_function`. Anything that implements `BlendFunction` is
+    /// acceptable, including functions and closures.
     ///
-    ///```
-    ///use palette::{LinSrgb, LinSrgba, Blend};
-    ///use palette::blend::PreAlpha;
+    /// ```
+    /// use palette::{LinSrgb, LinSrgba, Blend};
+    /// use palette::blend::PreAlpha;
     ///
-    ///type PreRgba = PreAlpha<LinSrgb<f32>, f32>;
+    /// type PreRgba = PreAlpha<LinSrgb<f32>, f32>;
     ///
-    ///fn blend_mode(a: PreRgba, b: PreRgba) -> PreRgba {
+    /// fn blend_mode(a: PreRgba, b: PreRgba) -> PreRgba {
     ///    PreAlpha {
     ///        color: LinSrgb::new(a.red * b.green, a.green * b.blue, a.blue * b.red),
     ///        alpha: a.alpha * b.alpha,
     ///    }
-    ///}
+    /// }
     ///
-    ///let a = LinSrgba::new(0.2, 0.5, 0.1, 0.8);
-    ///let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
-    ///let c = a.blend(b, blend_mode);
-    ///```
+    /// let a = LinSrgba::new(0.2, 0.5, 0.1, 0.8);
+    /// let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
+    /// let c = a.blend(b, blend_mode);
+    /// ```
     fn blend<F>(self, destination: Self, blend_function: F) -> Self
     where
         F: BlendFunction<Self::Color>,
@@ -57,8 +57,8 @@ where
         )
     }
 
-    ///Place `self` over `other`. This is the good old common alpha
-    ///composition equation.
+    /// Place `self` over `other`. This is the good old common alpha
+    /// composition equation.
     fn over(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -76,8 +76,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Results in the parts of `self` that overlaps the visible parts of
-    ///`other`.
+    /// Results in the parts of `self` that overlaps the visible parts of
+    /// `other`.
     fn inside(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -93,8 +93,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Results in the parts of `self` that lies outside the visible parts of
-    ///`other`.
+    /// Results in the parts of `self` that lies outside the visible parts of
+    /// `other`.
     fn outside(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -110,7 +110,7 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Place `self` over only the visible parts of `other`.
+    /// Place `self` over only the visible parts of `other`.
     fn atop(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -128,7 +128,7 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Results in either `self` or `other`, where they do not overlap.
+    /// Results in either `self` or `other`, where they do not overlap.
     fn xor(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -151,8 +151,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Add `self` and `other`. This uses the alpha component to regulate the
-    ///effect, so it's not just plain component wise addition.
+    /// Add `self` and `other`. This uses the alpha component to regulate the
+    /// effect, so it's not just plain component wise addition.
     fn plus(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -168,8 +168,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Multiply `self` with `other`. This uses the alpha component to regulate
-    ///the effect, so it's not just plain component wise multiplication.
+    /// Multiply `self` with `other`. This uses the alpha component to regulate
+    /// the effect, so it's not just plain component wise multiplication.
     fn multiply(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -187,7 +187,7 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Make a color which is at least as light as `self` or `other`.
+    /// Make a color which is at least as light as `self` or `other`.
     fn screen(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -203,8 +203,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Multiply `self` or `other` if other is dark, or screen them if `other`
-    ///is light. This results in an S curve.
+    /// Multiply `self` or `other` if other is dark, or screen them if `other`
+    /// is light. This results in an S curve.
     fn overlay(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -229,7 +229,7 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Return the darkest parts of `self` and `other`.
+    /// Return the darkest parts of `self` and `other`.
     fn darken(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -247,7 +247,7 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Return the lightest parts of `self` and `other`.
+    /// Return the lightest parts of `self` and `other`.
     fn lighten(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -265,8 +265,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Lighten `other` to reflect `self`. Results in `other` if `self` is
-    ///black.
+    /// Lighten `other` to reflect `self`. Results in `other` if `self` is
+    /// black.
     fn dodge(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -292,8 +292,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Darken `other` to reflect `self`. Results in `other` if `self` is
-    ///white.
+    /// Darken `other` to reflect `self`. Results in `other` if `self` is
+    /// white.
     fn burn(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -319,9 +319,9 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Multiply `self` or `other` if other is dark, or screen them if `self`
-    ///is light. This is similar to `overlay`, but depends on `self` instead
-    ///of `other`.
+    /// Multiply `self` or `other` if other is dark, or screen them if `self`
+    /// is light. This is similar to `overlay`, but depends on `self` instead
+    /// of `other`.
     fn hard_light(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -346,9 +346,9 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Lighten `other` if `self` is light, or darken `other` as if it's burned
-    ///if `self` is dark. The effect is increased if the components of `self`
-    ///is further from 0.5.
+    /// Lighten `other` if `self` is light, or darken `other` as if it's burned
+    /// if `self` is dark. The effect is increased if the components of `self`
+    /// is further from 0.5.
     fn soft_light(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -390,8 +390,8 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Return the absolute difference between `self` and `other`. It's
-    ///basically `abs(self - other)`, but regulated by the alpha component.
+    /// Return the absolute difference between `self` and `other`. It's
+    /// basically `abs(self - other)`, but regulated by the alpha component.
     fn difference(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -410,9 +410,9 @@ where
         Self::from_premultiplied(result)
     }
 
-    ///Similar to `difference`, but appears to result in a lower contrast.
-    ///`other` is inverted if `self` is white, and preserved if `self` is
-    ///black.
+    /// Similar to `difference`, but appears to result in a lower contrast.
+    /// `other` is inverted if `self` is white, and preserved if `self` is
+    /// black.
     fn exclusion(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();

--- a/palette/src/blend/equations.rs
+++ b/palette/src/blend/equations.rs
@@ -1,32 +1,31 @@
-use float::Float;
+use crate::blend::{BlendFunction, PreAlpha};
+use crate::float::Float;
+use crate::{Blend, ComponentWise};
 
-use blend::{BlendFunction, PreAlpha};
-use {Blend, ComponentWise};
-
-///A pair of blending equations and corresponding parameters.
+/// A pair of blending equations and corresponding parameters.
 ///
-///The `Equations` type is similar to how blending works in OpenGL, where a
-///blend function has can be written as `e(sp * S, dp * D)`. `e` is the
-///equation (like `s + d`), `sp` and `dp` are the source and destination
-///parameters, and `S` and `D` are the source and destination colors.
+/// The `Equations` type is similar to how blending works in OpenGL, where a
+/// blend function has can be written as `e(sp * S, dp * D)`. `e` is the
+/// equation (like `s + d`), `sp` and `dp` are the source and destination
+/// parameters, and `S` and `D` are the source and destination colors.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Equations {
-    ///The equation for the color components.
+    /// The equation for the color components.
     pub color_equation: Equation,
 
-    ///The equation for the alpha component.
+    /// The equation for the alpha component.
     pub alpha_equation: Equation,
 
-    ///The parameters for the color components.
+    /// The parameters for the color components.
     pub color_parameters: Parameters,
 
-    ///The parameters for the alpha component.
+    /// The parameters for the alpha component.
     pub alpha_parameters: Parameters,
 }
 
 impl Equations {
-    ///Create a pair of blending equations, where all the parameters are
-    ///`One`.
+    /// Create a pair of blending equations, where all the parameters are
+    /// `One`.
     pub fn from_equations(color: Equation, alpha: Equation) -> Equations {
         Equations {
             color_equation: color,
@@ -42,19 +41,19 @@ impl Equations {
         }
     }
 
-    ///Create a pair of additive blending equations with the provided
-    ///parameters.
+    /// Create a pair of additive blending equations with the provided
+    /// parameters.
     pub fn from_parameters(source: Parameter, destination: Parameter) -> Equations {
         Equations {
             color_equation: Equation::Add,
             alpha_equation: Equation::Add,
             color_parameters: Parameters {
-                source: source,
-                destination: destination,
+                source,
+                destination,
             },
             alpha_parameters: Parameters {
-                source: source,
-                destination: destination,
+                source,
+                destination,
             },
         }
     }
@@ -111,17 +110,14 @@ where
             Equation::Max => source.alpha.max(destination.alpha),
         };
 
-        PreAlpha {
-            color: color,
-            alpha: alpha,
-        }
+        PreAlpha { color, alpha }
     }
 }
 
-///A blending equation.
+/// A blending equation.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Equation {
-    ///Add the source and destination, according to `sp * S + dp * D`.
+    /// Add the source and destination, according to `sp * S + dp * D`.
     Add,
 
     /// Subtract the destination from the source, according to `sp * S - dp *
@@ -132,58 +128,58 @@ pub enum Equation {
     /// S`.
     ReverseSubtract,
 
-    ///Create a color where each component is the smallest of each of the
-    ///source and destination components. A.k.a. component wise min. The
-    ///parameters are ignored.
+    /// Create a color where each component is the smallest of each of the
+    /// source and destination components. A.k.a. component wise min. The
+    /// parameters are ignored.
     Min,
 
-    ///Create a color where each component is the largest of each of the
-    ///source and destination components. A.k.a. component wise max. The
-    ///parameters are ignored.
+    /// Create a color where each component is the largest of each of the
+    /// source and destination components. A.k.a. component wise max. The
+    /// parameters are ignored.
     Max,
 }
 
-///A pair of source and destination parameters.
+/// A pair of source and destination parameters.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Parameters {
-    ///The source parameter.
+    /// The source parameter.
     pub source: Parameter,
 
-    ///The destination parameter.
+    /// The destination parameter.
     pub destination: Parameter,
 }
 
-///A blending parameter.
+/// A blending parameter.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Parameter {
-    ///A simple 1.
+    /// A simple 1.
     One,
 
-    ///A simple 0.
+    /// A simple 0.
     Zero,
 
-    ///The source color, or alpha.
+    /// The source color, or alpha.
     SourceColor,
 
-    ///One minus the source color, or alpha.
+    /// One minus the source color, or alpha.
     OneMinusSourceColor,
 
-    ///The destination color, or alpha.
+    /// The destination color, or alpha.
     DestinationColor,
 
-    ///One minus the destination color, or alpha.
+    /// One minus the destination color, or alpha.
     OneMinusDestinationColor,
 
-    ///The source alpha.
+    /// The source alpha.
     SourceAlpha,
 
-    ///One minus the source alpha.
+    /// One minus the source alpha.
     OneMinusSourceAlpha,
 
-    ///The destination alpha.
+    /// The destination alpha.
     DestinationAlpha,
 
-    ///One minus the destination alpha.
+    /// One minus the destination alpha.
     OneMinusDestinationAlpha,
 }
 

--- a/palette/src/blend/mod.rs
+++ b/palette/src/blend/mod.rs
@@ -1,44 +1,43 @@
-//!Color blending and blending equations.
+//! Color blending and blending equations.
 //!
-//!Palette offers both OpenGL style blending equations, as well as most of the
-//!SVG composition operators (also common in photo manipulation software). The
-//!composition operators are all implemented in the
-//![`Blend`](trait.Blend.html) trait, and ready to use with any appropriate
-//!color type:
+//! Palette offers both OpenGL style blending equations, as well as most of the
+//! SVG composition operators (also common in photo manipulation software). The
+//! composition operators are all implemented in the
+//! [`Blend`](trait.Blend.html) trait, and ready to use with any appropriate
+//! color type:
 //!
-//!```
-//!use palette::{LinSrgba, Blend};
+//! ```
+//! use palette::{LinSrgba, Blend};
 //!
-//!let a = LinSrgba::new(0.2, 0.5, 0.1, 0.8);
-//!let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
-//!let c = a.overlay(b);
-//!```
+//! let a = LinSrgba::new(0.2, 0.5, 0.1, 0.8);
+//! let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
+//! let c = a.overlay(b);
+//! ```
 //!
-//!Blending equations can be defined using the
-//![`Equations`](struct.Equations.html) type, which is then passed to the
-//!`blend` function, from the `Blend` trait:
+//! Blending equations can be defined using the
+//! [`Equations`](struct.Equations.html) type, which is then passed to the
+//! `blend` function, from the `Blend` trait:
 //!
-//!```
-//!use palette::{LinSrgba, Blend};
-//!use palette::blend::{Equations, Parameter};
+//! ```
+//! use palette::{LinSrgba, Blend};
+//! use palette::blend::{Equations, Parameter};
 //!
-//!let blend_mode = Equations::from_parameters(
+//! let blend_mode = Equations::from_parameters(
 //!    Parameter::SourceAlpha,
 //!    Parameter::OneMinusSourceAlpha
-//!);
+//! );
 //!
-//!let a = LinSrgba::new(0.2, 0.5, 0.1, 0.8);
-//!let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
-//!let c = a.blend(b, blend_mode);
-//!```
+//! let a = LinSrgba::new(0.2, 0.5, 0.1, 0.8);
+//! let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
+//! let c = a.blend(b, blend_mode);
+//! ```
 //!
-//!Note that blending will use [premultiplied alpha](struct.PreAlpha.html),
-//!which may result in loss of some color information in some cases. One such
-//!case is that a completely transparent resultant color will become black.
+//! Note that blending will use [premultiplied alpha](struct.PreAlpha.html),
+//! which may result in loss of some color information in some cases. One such
+//! case is that a completely transparent resultant color will become black.
 
-use float::Float;
-
-use ComponentWise;
+use crate::float::Float;
+use crate::ComponentWise;
 
 pub use self::blend::Blend;
 pub use self::equations::{Equation, Equations, Parameter, Parameters};
@@ -51,12 +50,12 @@ mod pre_alpha;
 #[cfg(test)]
 mod test;
 
-///A trait for custom blend functions.
+/// A trait for custom blend functions.
 pub trait BlendFunction<C: Blend<Color = C> + ComponentWise>
 where
     C::Scalar: Float,
 {
-    ///Apply this blend function to a pair of colors.
+    /// Apply this blend function to a pair of colors.
     fn apply_to(
         self,
         source: PreAlpha<C, C::Scalar>,

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -1,41 +1,42 @@
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use core::ops::{Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
-use float::Float;
 
-use encoding::pixel::RawPixel;
-use {clamp, Alpha, Blend, ComponentWise, Mix, Pixel};
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-///Premultiplied alpha wrapper.
+use crate::encoding::pixel::RawPixel;
+use crate::float::Float;
+use crate::{clamp, Alpha, Blend, ComponentWise, Mix, Pixel};
+
+/// Premultiplied alpha wrapper.
 ///
-///Premultiplied colors are commonly used in composition algorithms to
-///simplify the calculations. It may also be preferred when interpolating
-///between colors, which is one of the reasons why it's offered as a separate
-///type. The other reason is to make it easier to avoid unnecessary
-///computations in composition chains.
+/// Premultiplied colors are commonly used in composition algorithms to
+/// simplify the calculations. It may also be preferred when interpolating
+/// between colors, which is one of the reasons why it's offered as a separate
+/// type. The other reason is to make it easier to avoid unnecessary
+/// computations in composition chains.
 ///
-///```
-///use palette::{Blend, LinSrgb, LinSrgba};
-///use palette::blend::PreAlpha;
+/// ```
+/// use palette::{Blend, LinSrgb, LinSrgba};
+/// use palette::blend::PreAlpha;
 ///
-///let a = PreAlpha::from(LinSrgba::new(0.4, 0.5, 0.5, 0.3));
-///let b = PreAlpha::from(LinSrgba::new(0.3, 0.8, 0.4, 0.4));
-///let c = PreAlpha::from(LinSrgba::new(0.7, 0.1, 0.8, 0.8));
+/// let a = PreAlpha::from(LinSrgba::new(0.4, 0.5, 0.5, 0.3));
+/// let b = PreAlpha::from(LinSrgba::new(0.3, 0.8, 0.4, 0.4));
+/// let c = PreAlpha::from(LinSrgba::new(0.7, 0.1, 0.8, 0.8));
 ///
-///let res = LinSrgb::from_premultiplied(a.screen(b).overlay(c));
-///```
+/// let res = LinSrgb::from_premultiplied(a.screen(b).overlay(c));
+/// ```
 ///
-///Note that converting to and from premultiplied alpha will cause the alpha
-///component to be clamped to [0.0, 1.0].
+/// Note that converting to and from premultiplied alpha will cause the alpha
+/// component to be clamped to [0.0, 1.0].
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct PreAlpha<C, T: Float> {
-    ///The premultiplied color components (`original.color * original.alpha`).
+    /// The premultiplied color components (`original.color * original.alpha`).
     #[cfg_attr(feature = "serializing", serde(flatten))]
     pub color: C,
 
-    ///The transparency component. 0.0 is fully transparent and 1.0 is fully
-    ///opaque.
+    /// The transparency component. 0.0 is fully transparent and 1.0 is fully
+    /// opaque.
     pub alpha: T,
 }
 
@@ -49,7 +50,7 @@ where
 
         PreAlpha {
             color: color.color.component_wise_self(|a| a * alpha),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -70,10 +71,7 @@ where
             }
         });
 
-        Alpha {
-            color: color,
-            alpha: alpha,
-        }
+        Alpha { color, alpha }
     }
 }
 
@@ -378,8 +376,8 @@ impl<C, T: Float> DerefMut for PreAlpha<C, T> {
 #[cfg(feature = "serializing")]
 mod test {
     use super::PreAlpha;
-    use encoding::Srgb;
-    use rgb::Rgb;
+    use crate::encoding::Srgb;
+    use crate::rgb::Rgb;
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/blend/test.rs
+++ b/palette/src/blend/test.rs
@@ -1,7 +1,7 @@
-use blend::PreAlpha;
-use encoding::Linear;
-use rgb::Rgb;
-use {Blend, ComponentWise, LinSrgb, LinSrgba};
+use crate::blend::PreAlpha;
+use crate::encoding::Linear;
+use crate::rgb::Rgb;
+use crate::{Blend, ComponentWise, LinSrgb, LinSrgba};
 
 #[test]
 fn blend_color() {

--- a/palette/src/color_difference.rs
+++ b/palette/src/color_difference.rs
@@ -1,12 +1,12 @@
-use component::FloatComponent;
-use from_f64;
+use crate::component::FloatComponent;
+use crate::from_f64;
 
-///A trait for calculating the color difference between two colors.
+/// A trait for calculating the color difference between two colors.
 pub trait ColorDifference {
-    ///The type of the calculated color difference
+    /// The type of the calculated color difference
     type Scalar: FloatComponent;
 
-    ///Return the difference or distance between two colors
+    /// Return the difference or distance between two colors
     fn get_color_difference(&self, other: &Self) -> Self::Scalar;
 }
 

--- a/palette/src/component.rs
+++ b/palette/src/component.rs
@@ -1,7 +1,7 @@
 use num_traits::Zero;
 
-use float::Float;
-use {clamp, FromF64};
+use crate::float::Float;
+use crate::{clamp, FromF64};
 
 /// Common trait for color components.
 pub trait Component: Copy + Zero + PartialOrd {
@@ -44,7 +44,8 @@ macro_rules! impl_uint_components {
 
 impl_uint_components!(u8, u16, u32, u64, u128);
 
-/// Converts from a color component type, while performing the appropriate scaling, rounding and clamping.
+/// Converts from a color component type, while performing the appropriate
+/// scaling, rounding and clamping.
 ///
 /// ```
 /// use palette::FromComponent;
@@ -54,7 +55,8 @@ impl_uint_components!(u8, u16, u32, u64, u128);
 /// assert_eq!(u8_component, 255);
 /// ```
 pub trait FromComponent<T: Component> {
-    /// Converts `other` into `Self`, while performing the appropriate scaling, rounding and clamping.
+    /// Converts `other` into `Self`, while performing the appropriate scaling,
+    /// rounding and clamping.
     fn from_component(other: T) -> Self;
 }
 
@@ -65,7 +67,8 @@ impl<T: Component, U: IntoComponent<T> + Component> FromComponent<U> for T {
     }
 }
 
-/// Converts into a color component type, while performing the appropriate scaling, rounding and clamping.
+/// Converts into a color component type, while performing the appropriate
+/// scaling, rounding and clamping.
 ///
 /// ```
 /// use palette::IntoComponent;
@@ -75,7 +78,8 @@ impl<T: Component, U: IntoComponent<T> + Component> FromComponent<U> for T {
 /// assert_eq!(u8_component, 255);
 /// ```
 pub trait IntoComponent<T: Component> {
-    /// Converts `self` into `T`, while performing the appropriate scaling, rounding and clamping.
+    /// Converts `self` into `T`, while performing the appropriate scaling,
+    /// rounding and clamping.
     fn into_component(self) -> T;
 }
 

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -1,58 +1,65 @@
 use core::fmt::{self, Display, Formatter};
-use encoding::Linear;
-use luma::Luma;
-use rgb::{Rgb, RgbSpace};
-use white_point::{WhitePoint, D65};
-use {FloatComponent, Hsl, Hsv, Hwb, Lab, Lch, Limited, Xyz, Yxy};
+
+use crate::encoding::Linear;
+use crate::luma::Luma;
+use crate::rgb::{Rgb, RgbSpace};
+use crate::white_point::{WhitePoint, D65};
+use crate::{FloatComponent, Hsl, Hsv, Hwb, Lab, Lch, Limited, Xyz, Yxy};
 
 /// FromColor provides conversion from the colors.
 ///
-/// It requires from_xyz, when implemented manually, and derives conversion to other colors as a
-/// default from this. These defaults must be overridden when direct conversion exists between
-/// colors. For example, Luma has direct conversion to LinRgb. So from_rgb conversion for Luma and
-/// from_luma for LinRgb is implemented directly. The from for the same color must override
-/// the default. For example, from_rgb for LinRgb will convert via Xyz which needs to be overridden
-/// with self to avoid the unnecessary conversion.
+/// It requires from_xyz, when implemented manually, and derives conversion to
+/// other colors as a default from this. These defaults must be overridden when
+/// direct conversion exists between colors. For example, Luma has direct
+/// conversion to LinRgb. So from_rgb conversion for Luma and from_luma for
+/// LinRgb is implemented directly. The from for the same color must override
+/// the default. For example, from_rgb for LinRgb will convert via Xyz which
+/// needs to be overridden with self to avoid the unnecessary conversion.
 ///
 /// # Deriving
 ///
-/// `FromColor` can be derived in a mostly automatic way. The strength of deriving it is that it
-/// will also derive `From` implementations for all of the `palette` color types. The minimum
-/// requirement is to implement `From<Xyz>`, but it can also be customized to make use of generics
+/// `FromColor` can be derived in a mostly automatic way. The strength of
+/// deriving it is that it will also derive `From` implementations for all of
+/// the `palette` color types. The minimum requirement is to implement
+/// `From<Xyz>`, but it can also be customized to make use of generics
 /// and have other manual implementations.
 ///
 /// ## Item Attributes
 ///
-///  * `#[palette_manual_from(Luma, Rgb = "from_rgb_internal")]`: Specifies the color types that
-/// the the custom color type already has `From` implementations for. Adding `= "function_name"`
-/// tells it to use that function instead of a `From` implementation. The default, when omitted,
-/// is to require `From<Xyz>` to be implemented.
+///  * `#[palette_manual_from(Luma, Rgb = "from_rgb_internal")]`: Specifies the
+///    color types that
+/// the the custom color type already has `From` implementations for. Adding `=
+/// "function_name"` tells it to use that function instead of a `From`
+/// implementation. The default, when omitted, is to require `From<Xyz>` to be
+/// implemented.
 ///
-///  * `#[palette_white_point = "some::white_point::Type"]`: Sets the white point type that should
-/// be used when deriving. The default is `D65`, but it may be any other type, including
-/// type parameters.
+///  * `#[palette_white_point = "some::white_point::Type"]`: Sets the white
+///    point type that should
+/// be used when deriving. The default is `D65`, but it may be any other type,
+/// including type parameters.
 ///
-///  * `#[palette_component = "some::component::Type"]`: Sets the color component type that should
-/// be used when deriving. The default is `f32`, but it may be any other type, including
-/// type parameters.
+///  * `#[palette_component = "some::component::Type"]`: Sets the color
+///    component type that should
+/// be used when deriving. The default is `f32`, but it may be any other type,
+/// including type parameters.
 ///
-///  * `#[palette_rgb_space = "some::rgb_space::Type"]`: Sets the RGB space type that should
-/// be used when deriving. The default is to either use `Srgb` or a best effort to convert between
-/// spaces, so sometimes it has to be set to a specific type. This does also accept type parameters.
+///  * `#[palette_rgb_space = "some::rgb_space::Type"]`: Sets the RGB space type
+///    that should
+/// be used when deriving. The default is to either use `Srgb` or a best effort
+/// to convert between spaces, so sometimes it has to be set to a specific type.
+/// This does also accept type parameters.
 ///
 /// ## Field Attributes
 ///
-///  * `#[palette_alpha]`: Specifies that the field is the color's transparency value.
+///  * `#[palette_alpha]`: Specifies that the field is the color's transparency
+///    value.
 ///
 /// ## Examples
 ///
 /// Minimum requirements implementation:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate palette;
-///
-/// use palette::{Srgb, Xyz};
+/// use palette::{FromColor, Srgb, Xyz};
 ///
 /// /// A custom version of Xyz that stores integer values from 0 to 100.
 /// #[derive(PartialEq, Debug, FromColor)]
@@ -75,30 +82,27 @@ use {FloatComponent, Hsl, Hsv, Hwb, Lab, Lch, Limited, Xyz, Yxy};
 ///     }
 /// }
 ///
-/// fn main() {
-///     // Start with an sRGB color and convert it from u8 to f32,
-///     // which is the default component type.
-///     let rgb = Srgb::new(196u8, 238, 155).into_format();
+/// // Start with an sRGB color and convert it from u8 to f32,
+/// // which is the default component type.
+/// let rgb = Srgb::new(196u8, 238, 155).into_format();
 ///
-///     // Convert the rgb color to our own format.
-///     let xyz = Xyz100::from(rgb);
+/// // Convert the rgb color to our own format.
+/// let xyz = Xyz100::from(rgb);
 ///
-///     assert_eq!(
-///         xyz,
-///         Xyz100 {
-///             x: 59,
-///             y: 75,
-///             z: 42,
-///         }
-///     );
-/// }
+/// assert_eq!(
+///     xyz,
+///     Xyz100 {
+///         x: 59,
+///         y: 75,
+///         z: 42,
+///     }
+/// );
 /// ```
 ///
 /// With generic components:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{FloatComponent, FromColor, Hsv, Pixel, Srgb};
 /// use palette::rgb::{Rgb, RgbSpace};
@@ -138,17 +142,15 @@ use {FloatComponent, Hsl, Hsv, Hwb, Lab, Lch, Limited, Xyz, Yxy};
 ///     }
 /// }
 ///
-/// fn main() {
-///     let mut buffer = vec![0.0f64, 0.0, 0.0, 0.0, 0.0, 0.0];
-///     {
-///         let bgr_buffer = Bgr::from_raw_slice_mut(&mut buffer);
-///         bgr_buffer[1] = Hsv::new(90.0, 1.0, 0.5).into();
-///     }
-///
-///     assert_relative_eq!(buffer[3], 0.0);
-///     assert_relative_eq!(buffer[4], 0.7353569830524495);
-///     assert_relative_eq!(buffer[5], 0.5370987304831942);
+/// let mut buffer = vec![0.0f64, 0.0, 0.0, 0.0, 0.0, 0.0];
+/// {
+///     let bgr_buffer = Bgr::from_raw_slice_mut(&mut buffer);
+///     bgr_buffer[1] = Hsv::new(90.0, 1.0, 0.5).into();
 /// }
+///
+/// assert_relative_eq!(buffer[3], 0.0);
+/// assert_relative_eq!(buffer[4], 0.7353569830524495);
+/// assert_relative_eq!(buffer[5], 0.5370987304831942);
 /// ```
 ///
 /// With alpha component:
@@ -189,65 +191,63 @@ use {FloatComponent, Hsl, Hsv, Hwb, Lab, Lch, Limited, Xyz, Yxy};
 ///     }
 /// }
 ///
-/// fn main() {
-///     let color = LinSrgba::new(0.5, 0.0, 1.0, 0.3);
-///     let css_color = CssRgb::from(color);
+/// let color = LinSrgba::new(0.5, 0.0, 1.0, 0.3);
+/// let css_color = CssRgb::from(color);
 ///
-///     assert_eq!(
-///         css_color,
-///         CssRgb {
-///             red: 188,
-///             green: 0,
-///             blue: 255,
-///             alpha: 0.3,
-///         }
-///     );
-/// }
+/// assert_eq!(
+///     css_color,
+///     CssRgb {
+///         red: 188,
+///         green: 0,
+///         blue: 255,
+///         alpha: 0.3,
+///     }
+/// );
 /// ```
 pub trait FromColor<Wp = D65, T = f32>: Sized
 where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///Convert from XYZ color space
-    fn from_xyz(Xyz<Wp, T>) -> Self;
+    /// Convert from XYZ color space
+    fn from_xyz(inp: Xyz<Wp, T>) -> Self;
 
-    ///Convert from Yxy color space
+    /// Convert from Yxy color space
     fn from_yxy(inp: Yxy<Wp, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
-    ///Convert from L\*a\*b\* color space
+    /// Convert from L\*a\*b\* color space
     fn from_lab(inp: Lab<Wp, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
-    ///Convert from L\*C\*h° color space
+    /// Convert from L\*C\*h° color space
     fn from_lch(inp: Lch<Wp, T>) -> Self {
         Self::from_lab(inp.into_lab())
     }
 
-    ///Convert from RGB color space
+    /// Convert from RGB color space
     fn from_rgb<S: RgbSpace<WhitePoint = Wp>>(inp: Rgb<Linear<S>, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
 
-    ///Convert from HSL color space
+    /// Convert from HSL color space
     fn from_hsl<S: RgbSpace<WhitePoint = Wp>>(inp: Hsl<S, T>) -> Self {
         Self::from_rgb(Rgb::<Linear<S>, T>::from_hsl(inp))
     }
 
-    ///Convert from HSV color space
+    /// Convert from HSV color space
     fn from_hsv<S: RgbSpace<WhitePoint = Wp>>(inp: Hsv<S, T>) -> Self {
         Self::from_rgb(Rgb::<Linear<S>, T>::from_hsv(inp))
     }
 
-    ///Convert from HWB color space
+    /// Convert from HWB color space
     fn from_hwb<S: RgbSpace<WhitePoint = Wp>>(inp: Hwb<S, T>) -> Self {
         Self::from_hsv(Hsv::<S, T>::from_hwb(inp))
     }
 
-    ///Convert from Luma
+    /// Convert from Luma
     fn from_luma(inp: Luma<Linear<Wp>, T>) -> Self {
         Self::from_xyz(inp.into_xyz())
     }
@@ -255,49 +255,54 @@ where
 
 /// IntoColor provides conversion to the colors.
 ///
-/// It requires into_xyz, when implemented manually, and derives conversion to other colors as a
-/// default from this. These defaults must be overridden when direct conversion exists between
-/// colors.
+/// It requires into_xyz, when implemented manually, and derives conversion to
+/// other colors as a default from this. These defaults must be overridden when
+/// direct conversion exists between colors.
 ///
 /// # Deriving
 ///
-/// `IntoColor` can be derived in a mostly automatic way. The strength of deriving it is that it
-/// will also derive `Into` implementations for all of the `palette` color types. The minimum
-/// requirement is to implement `Into<Xyz>`, but it can also be customized to make use of generics
+/// `IntoColor` can be derived in a mostly automatic way. The strength of
+/// deriving it is that it will also derive `Into` implementations for all of
+/// the `palette` color types. The minimum requirement is to implement
+/// `Into<Xyz>`, but it can also be customized to make use of generics
 /// and have other manual implementations.
 ///
 /// ## Item Attributes
 ///
-///  * `#[palette_manual_into(Luma, Rgb = "into_rgb_internal")]`: Specifies the color types that
-/// the the custom color type already has `Into` implementations for. Adding `= "function_name"`
-/// tells it to use that function instead of an `Into` implementation. The default, when omitted,
-/// is to require `Into<Xyz>` to be implemented.
+///  * `#[palette_manual_into(Luma, Rgb = "into_rgb_internal")]`: Specifies the
+///    color types that
+/// the the custom color type already has `Into` implementations for. Adding `=
+/// "function_name"` tells it to use that function instead of an `Into`
+/// implementation. The default, when omitted, is to require `Into<Xyz>` to be
+/// implemented.
 ///
-///  * `#[palette_white_point = "some::white_point::Type"]`: Sets the white point type that should
-/// be used when deriving. The default is `D65`, but it may be any other type, including
-/// type parameters.
+///  * `#[palette_white_point = "some::white_point::Type"]`: Sets the white
+///    point type that should
+/// be used when deriving. The default is `D65`, but it may be any other type,
+/// including type parameters.
 ///
-///  * `#[palette_component = "some::component::Type"]`: Sets the color component type that should
-/// be used when deriving. The default is `f32`, but it may be any other type, including
-/// type parameters.
+///  * `#[palette_component = "some::component::Type"]`: Sets the color
+///    component type that should
+/// be used when deriving. The default is `f32`, but it may be any other type,
+/// including type parameters.
 ///
-///  * `#[palette_rgb_space = "some::rgb_space::Type"]`: Sets the RGB space type that should
-/// be used when deriving. The default is to either use `Srgb` or a best effort to convert between
-/// spaces, so sometimes it has to be set to a specific type. This does also accept type parameters.
+///  * `#[palette_rgb_space = "some::rgb_space::Type"]`: Sets the RGB space type
+///    that should
+/// be used when deriving. The default is to either use `Srgb` or a best effort
+/// to convert between spaces, so sometimes it has to be set to a specific type.
+/// This does also accept type parameters.
 ///
 /// ## Field Attributes
 ///
-///  * `#[palette_alpha]`: Specifies that the field is the color's transparency value.
+///  * `#[palette_alpha]`: Specifies that the field is the color's transparency
+///    value.
 ///
 /// ## Examples
 ///
 /// Minimum requirements implementation:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate palette;
-///
-/// use palette::{Srgb, Xyz};
+/// use palette::{IntoColor, Srgb, Xyz};
 ///
 /// /// A custom version of Xyz that stores integer values from 0 to 100.
 /// #[derive(PartialEq, Debug, IntoColor)]
@@ -319,26 +324,23 @@ where
 ///     }
 /// }
 ///
-/// fn main() {
-///     // Start with an Xyz100 color.
-///     let xyz = Xyz100 {
-///         x: 59,
-///         y: 75,
-///         z: 42,
-///     };
+/// // Start with an Xyz100 color.
+/// let xyz = Xyz100 {
+///     x: 59,
+///     y: 75,
+///     z: 42,
+/// };
 ///
-///     // Convert the color to sRGB.
-///     let rgb: Srgb = xyz.into();
+/// // Convert the color to sRGB.
+/// let rgb: Srgb = xyz.into();
 ///
-///     assert_eq!(rgb.into_format(), Srgb::new(196u8, 238, 154));
-/// }
+/// assert_eq!(rgb.into_format(), Srgb::new(196u8, 238, 154));
 /// ```
 ///
 /// With generic components:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{FloatComponent, Hsv, IntoColor, Pixel, Srgb};
 /// use palette::rgb::{Rgb, RgbSpace};
@@ -373,26 +375,23 @@ where
 ///     }
 /// }
 ///
-/// fn main() {
-///     let buffer = vec![
-///         0.0f64,
-///         0.0,
-///         0.0,
-///         0.0,
-///         0.7353569830524495,
-///         0.5370987304831942,
-///     ];
-///     let hsv: Hsv64 = Bgr::from_raw_slice(&buffer)[1].into();
+/// let buffer = vec![
+///     0.0f64,
+///     0.0,
+///     0.0,
+///     0.0,
+///     0.7353569830524495,
+///     0.5370987304831942,
+/// ];
+/// let hsv: Hsv64 = Bgr::from_raw_slice(&buffer)[1].into();
 ///
-///     assert_relative_eq!(hsv, Hsv::new(90.0, 1.0, 0.5));
-/// }
+/// assert_relative_eq!(hsv, Hsv::new(90.0, 1.0, 0.5));
 /// ```
 ///
 /// With alpha component:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{IntoColor, LinSrgba, Srgb};
 /// use palette::rgb::{Rgb, RgbSpace};
@@ -423,84 +422,83 @@ where
 ///     }
 /// }
 ///
-/// fn main() {
-///     let css_color = CssRgb {
-///         red: 187,
-///         green: 0,
-///         blue: 255,
-///         alpha: 0.3,
-///     };
-///     let color: LinSrgba = css_color.into();
+/// let css_color = CssRgb {
+///     red: 187,
+///     green: 0,
+///     blue: 255,
+///     alpha: 0.3,
+/// };
+/// let color: LinSrgba = css_color.into();
 ///
-///     assert_relative_eq!(color, LinSrgba::new(0.496933, 0.0, 1.0, 0.3));
-/// }
+/// assert_relative_eq!(color, LinSrgba::new(0.496933, 0.0, 1.0, 0.3));
 /// ```
 pub trait IntoColor<Wp = D65, T = f32>: Sized
 where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///Convert into XYZ space
+    /// Convert into XYZ space
     fn into_xyz(self) -> Xyz<Wp, T>;
 
-    ///Convert into Yxy color space
+    /// Convert into Yxy color space
     fn into_yxy(self) -> Yxy<Wp, T> {
         Yxy::from_xyz(self.into_xyz())
     }
 
-    ///Convert into L\*a\*b\* color space
+    /// Convert into L\*a\*b\* color space
     fn into_lab(self) -> Lab<Wp, T> {
         Lab::from_xyz(self.into_xyz())
     }
 
-    ///Convert into L\*C\*h° color space
+    /// Convert into L\*C\*h° color space
     fn into_lch(self) -> Lch<Wp, T> {
         Lch::from_lab(self.into_lab())
     }
 
-    ///Convert into RGB color space.
+    /// Convert into RGB color space.
     fn into_rgb<S: RgbSpace<WhitePoint = Wp>>(self) -> Rgb<Linear<S>, T> {
         Rgb::from_xyz(self.into_xyz())
     }
 
-    ///Convert into HSL color space
+    /// Convert into HSL color space
     fn into_hsl<S: RgbSpace<WhitePoint = Wp>>(self) -> Hsl<S, T> {
         let rgb: Rgb<Linear<S>, T> = self.into_rgb();
         Hsl::from_rgb(rgb)
     }
 
-    ///Convert into HSV color space
+    /// Convert into HSV color space
     fn into_hsv<S: RgbSpace<WhitePoint = Wp>>(self) -> Hsv<S, T> {
         let rgb: Rgb<Linear<S>, T> = self.into_rgb();
         Hsv::from_rgb(rgb)
     }
 
-    ///Convert into HWB color space
+    /// Convert into HWB color space
     fn into_hwb<S: RgbSpace<WhitePoint = Wp>>(self) -> Hwb<S, T> {
         let hsv: Hsv<S, T> = self.into_hsv();
         Hwb::from_hsv(hsv)
     }
 
-    ///Convert into Luma
+    /// Convert into Luma
     fn into_luma(self) -> Luma<Linear<Wp>, T> {
         Luma::from_xyz(self.into_xyz())
     }
 }
 
-///The error type for a color conversion that converted a color into a color with invalid values.
+/// The error type for a color conversion that converted a color into a color
+/// with invalid values.
 #[derive(Debug)]
 pub struct OutOfBounds<T> {
     color: T,
 }
 
 impl<T> OutOfBounds<T> {
-    ///Create a new error wrapping a color
+    /// Create a new error wrapping a color
     #[inline]
     fn new(color: T) -> Self {
         OutOfBounds { color }
     }
 
-    ///Consume this error and return the wrapped color
+    /// Consume this error and return the wrapped color
     #[inline]
     pub fn color(self) -> T {
         self.color
@@ -520,98 +518,100 @@ impl<T> Display for OutOfBounds<T> {
     }
 }
 
-///A trait for converting a color into another.
+/// A trait for converting a color into another.
 pub trait ConvertInto<T>: Into<T> {
-    ///Convert into T with values clamped to the color defined bounds
+    /// Convert into T with values clamped to the color defined bounds
     ///
-    ///```
-    ///use palette::ConvertInto;
-    ///use palette::Limited;
-    ///use palette::{Srgb, Lch};
+    /// ```
+    /// use palette::ConvertInto;
+    /// use palette::Limited;
+    /// use palette::{Srgb, Lch};
     ///
     ///
-    ///let rgb: Srgb = Lch::new(50.0, 100.0, -175.0).convert_into();
-    ///assert!(rgb.is_valid());
-    ///```
+    /// let rgb: Srgb = Lch::new(50.0, 100.0, -175.0).convert_into();
+    /// assert!(rgb.is_valid());
+    /// ```
     fn convert_into(self) -> T;
 
-    ///Convert into T. The resulting color might be invalid in its color space
+    /// Convert into T. The resulting color might be invalid in its color space
     ///
-    ///```
-    ///use palette::ConvertInto;
-    ///use palette::Limited;
-    ///use palette::{Srgb, Lch};
+    /// ```
+    /// use palette::ConvertInto;
+    /// use palette::Limited;
+    /// use palette::{Srgb, Lch};
     ///
-    ///let rgb: Srgb = Lch::new(50.0, 100.0, -175.0).convert_unclamped_into();
-    ///assert!(!rgb.is_valid());
-    ///```
+    /// let rgb: Srgb = Lch::new(50.0, 100.0, -175.0).convert_unclamped_into();
+    /// assert!(!rgb.is_valid());
+    /// ```
     fn convert_unclamped_into(self) -> T;
 
-    ///Convert into T, returning ok if the color is inside of its defined range,
-    ///otherwise an `OutOfBounds` error is returned which contains the unclamped color.
+    /// Convert into T, returning ok if the color is inside of its defined
+    /// range, otherwise an `OutOfBounds` error is returned which contains
+    /// the unclamped color.
     ///
-    ///```
-    ///use palette::ConvertInto;
-    ///use palette::{Srgb, Hsl};
+    /// ```
+    /// use palette::ConvertInto;
+    /// use palette::{Srgb, Hsl};
     ///
-    ///let rgb: Srgb = match Hsl::new(150.0, 1.0, 1.1).try_convert_into() {
+    /// let rgb: Srgb = match Hsl::new(150.0, 1.0, 1.1).try_convert_into() {
     ///    Ok(color) => color,
     ///    Err(err) => {
     ///        println!("Color is out of bounds");
     ///        err.color()
     ///    },
-    ///};
-    ///```
+    /// };
+    /// ```
     fn try_convert_into(self) -> Result<T, OutOfBounds<T>>;
 }
 
-///A trait for converting one color from another.
+/// A trait for converting one color from another.
 ///
-///`convert_unclamped` currently wraps the underlying `From` implementation.
+/// `convert_unclamped` currently wraps the underlying `From` implementation.
 pub trait ConvertFrom<T>: From<T> {
-    ///Convert from T with values clamped to the color defined bounds
+    /// Convert from T with values clamped to the color defined bounds
     ///
-    ///```
-    ///use palette::ConvertFrom;
-    ///use palette::Limited;
-    ///use palette::{Srgb, Lch};
+    /// ```
+    /// use palette::ConvertFrom;
+    /// use palette::Limited;
+    /// use palette::{Srgb, Lch};
     ///
     ///
-    ///let rgb = Srgb::convert_from(Lch::new(50.0, 100.0, -175.0));
-    ///assert!(rgb.is_valid());
-    ///```
+    /// let rgb = Srgb::convert_from(Lch::new(50.0, 100.0, -175.0));
+    /// assert!(rgb.is_valid());
+    /// ```
     fn convert_from(_: T) -> Self;
 
-    ///Convert from T. The resulting color might be invalid in its color space
+    /// Convert from T. The resulting color might be invalid in its color space
     ///
-    ///```
-    ///use palette::ConvertFrom;
-    ///use palette::Limited;
-    ///use palette::{Srgb, Lch};
+    /// ```
+    /// use palette::ConvertFrom;
+    /// use palette::Limited;
+    /// use palette::{Srgb, Lch};
     ///
-    ///let rgb = Srgb::convert_unclamped_from(Lch::new(50.0, 100.0, -175.0));
-    ///assert!(!rgb.is_valid());
-    ///```
+    /// let rgb = Srgb::convert_unclamped_from(Lch::new(50.0, 100.0, -175.0));
+    /// assert!(!rgb.is_valid());
+    /// ```
     #[inline]
     fn convert_unclamped_from(val: T) -> Self {
         Self::from(val)
     }
 
-    ///Convert from T, returning ok if the color is inside of its defined range,
-    ///otherwise an `OutOfBounds` error is returned which contains the unclamped color.
+    /// Convert from T, returning ok if the color is inside of its defined
+    /// range, otherwise an `OutOfBounds` error is returned which contains
+    /// the unclamped color.
     ///
-    ///```
-    ///use palette::ConvertFrom;
-    ///use palette::{Srgb, Hsl};
+    /// ```
+    /// use palette::ConvertFrom;
+    /// use palette::{Srgb, Hsl};
     ///
-    ///let rgb = match Srgb::try_convert_from(Hsl::new(150.0, 1.0, 1.1)) {
+    /// let rgb = match Srgb::try_convert_from(Hsl::new(150.0, 1.0, 1.1)) {
     ///    Ok(color) => color,
     ///    Err(err) => {
     ///        println!("Color is out of bounds");
     ///        err.color()
     ///    },
-    ///};
-    ///```
+    /// };
+    /// ```
     fn try_convert_from(_: T) -> Result<Self, OutOfBounds<Self>>;
 }
 
@@ -753,12 +753,14 @@ impl_into_color_rgb!(Hwb, from_hwb);
 
 #[cfg(test)]
 mod tests {
+    use crate::encoding;
+    use crate::encoding::linear::Linear;
+    use crate::luma::Luma;
+    use crate::rgb::{Rgb, RgbSpace};
+    use crate::white_point;
+    use crate::FloatComponent;
+    use crate::{Hsl, Hsv, Hwb, Lab, Lch, Xyz, Yxy};
     use core::marker::PhantomData;
-    use encoding::linear::Linear;
-    use luma::Luma;
-    use rgb::{Rgb, RgbSpace};
-    use FloatComponent;
-    use {Hsl, Hsv, Hwb, Lab, Lch, Xyz, Yxy};
 
     #[derive(Copy, Clone, FromColor, IntoColor)]
     #[palette_manual_from(Xyz, Luma = "from_luma_internal")]
@@ -794,30 +796,30 @@ mod tests {
     #[derive(Copy, Clone, FromColor, IntoColor)]
     #[palette_manual_from(Lch, Luma = "from_luma_internal")]
     #[palette_manual_into(Lch, Luma = "into_luma_internal")]
-    #[palette_white_point = "::white_point::E"]
+    #[palette_white_point = "crate::white_point::E"]
     #[palette_component = "T"]
-    #[palette_rgb_space = "(::encoding::Srgb, ::white_point::E)"]
+    #[palette_rgb_space = "(crate::encoding::Srgb, crate::white_point::E)"]
     #[palette_internal]
     struct WithoutXyz<T: FloatComponent>(PhantomData<T>);
 
     impl<T: FloatComponent> WithoutXyz<T> {
-        fn from_luma_internal(_color: Luma<Linear<::white_point::E>, T>) -> Self {
+        fn from_luma_internal(_color: Luma<Linear<white_point::E>, T>) -> Self {
             WithoutXyz(PhantomData)
         }
 
-        fn into_luma_internal(self) -> Luma<Linear<::white_point::E>, T> {
+        fn into_luma_internal(self) -> Luma<Linear<white_point::E>, T> {
             Luma::new(T::one())
         }
     }
 
-    impl<T: FloatComponent> From<Lch<::white_point::E, T>> for WithoutXyz<T> {
-        fn from(_color: Lch<::white_point::E, T>) -> Self {
+    impl<T: FloatComponent> From<Lch<white_point::E, T>> for WithoutXyz<T> {
+        fn from(_color: Lch<white_point::E, T>) -> Self {
             WithoutXyz(PhantomData)
         }
     }
 
-    impl<T: FloatComponent> Into<Lch<::white_point::E, T>> for WithoutXyz<T> {
-        fn into(self) -> Lch<::white_point::E, T> {
+    impl<T: FloatComponent> Into<Lch<white_point::E, T>> for WithoutXyz<T> {
+        fn into(self) -> Lch<white_point::E, T> {
             Lch::with_wp(T::one(), T::zero(), T::zero())
         }
     }
@@ -825,63 +827,63 @@ mod tests {
     #[test]
     fn from_with_xyz() {
         let xyz: Xyz<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(xyz);
+        WithXyz::<encoding::Srgb>::from(xyz);
 
         let yxy: Yxy<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(yxy);
+        WithXyz::<encoding::Srgb>::from(yxy);
 
         let lab: Lab<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(lab);
+        WithXyz::<encoding::Srgb>::from(lab);
 
         let lch: Lch<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(lch);
+        WithXyz::<encoding::Srgb>::from(lch);
 
-        let rgb: Rgb<::encoding::Srgb, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(rgb);
+        let rgb: Rgb<encoding::Srgb, f64> = Default::default();
+        WithXyz::<encoding::Srgb>::from(rgb);
 
         let hsl: Hsl<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(hsl);
+        WithXyz::<encoding::Srgb>::from(hsl);
 
         let hsv: Hsv<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(hsv);
+        WithXyz::<encoding::Srgb>::from(hsv);
 
         let hwb: Hwb<_, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(hwb);
+        WithXyz::<encoding::Srgb>::from(hwb);
 
-        let luma: Luma<::encoding::Srgb, f64> = Default::default();
-        WithXyz::<::encoding::Srgb>::from(luma);
+        let luma: Luma<encoding::Srgb, f64> = Default::default();
+        WithXyz::<encoding::Srgb>::from(luma);
     }
 
     #[test]
     fn into_with_xyz() {
-        let color = WithXyz::<::encoding::Srgb>(PhantomData);
+        let color = WithXyz::<encoding::Srgb>(PhantomData);
 
         let _xyz: Xyz<_, f64> = color.into();
         let _yxy: Yxy<_, f64> = color.into();
         let _lab: Lab<_, f64> = color.into();
         let _lch: Lch<_, f64> = color.into();
-        let _rgb: Rgb<::encoding::Srgb, f64> = color.into();
+        let _rgb: Rgb<encoding::Srgb, f64> = color.into();
         let _hsl: Hsl<_, f64> = color.into();
         let _hsv: Hsv<_, f64> = color.into();
         let _hwb: Hwb<_, f64> = color.into();
-        let _luma: Luma<::encoding::Srgb, f64> = color.into();
+        let _luma: Luma<encoding::Srgb, f64> = color.into();
     }
 
     #[test]
     fn from_without_xyz() {
-        let xyz: Xyz<::white_point::E, f64> = Default::default();
+        let xyz: Xyz<white_point::E, f64> = Default::default();
         WithoutXyz::<f64>::from(xyz);
 
-        let yxy: Yxy<::white_point::E, f64> = Default::default();
+        let yxy: Yxy<white_point::E, f64> = Default::default();
         WithoutXyz::<f64>::from(yxy);
 
-        let lab: Lab<::white_point::E, f64> = Default::default();
+        let lab: Lab<white_point::E, f64> = Default::default();
         WithoutXyz::<f64>::from(lab);
 
-        let lch: Lch<::white_point::E, f64> = Default::default();
+        let lch: Lch<white_point::E, f64> = Default::default();
         WithoutXyz::<f64>::from(lch);
 
-        let rgb: Rgb<(_, ::encoding::Srgb), f64> = Default::default();
+        let rgb: Rgb<(_, encoding::Srgb), f64> = Default::default();
         WithoutXyz::<f64>::from(rgb);
 
         let hsl: Hsl<_, f64> = Default::default();
@@ -893,7 +895,7 @@ mod tests {
         let hwb: Hwb<_, f64> = Default::default();
         WithoutXyz::<f64>::from(hwb);
 
-        let luma: Luma<Linear<::white_point::E>, f64> = Default::default();
+        let luma: Luma<Linear<white_point::E>, f64> = Default::default();
         WithoutXyz::<f64>::from(luma);
     }
 
@@ -901,14 +903,14 @@ mod tests {
     fn into_without_xyz() {
         let color = WithoutXyz::<f64>(PhantomData);
 
-        let _xyz: Xyz<::white_point::E, f64> = color.into();
-        let _yxy: Yxy<::white_point::E, f64> = color.into();
-        let _lab: Lab<::white_point::E, f64> = color.into();
-        let _lch: Lch<::white_point::E, f64> = color.into();
-        let _rgb: Rgb<(_, ::encoding::Srgb), f64> = color.into();
+        let _xyz: Xyz<white_point::E, f64> = color.into();
+        let _yxy: Yxy<white_point::E, f64> = color.into();
+        let _lab: Lab<white_point::E, f64> = color.into();
+        let _lch: Lch<white_point::E, f64> = color.into();
+        let _rgb: Rgb<(_, encoding::Srgb), f64> = color.into();
         let _hsl: Hsl<_, f64> = color.into();
         let _hsv: Hsv<_, f64> = color.into();
         let _hwb: Hwb<_, f64> = color.into();
-        let _luma: Luma<Linear<::white_point::E>, f64> = color.into();
+        let _luma: Luma<Linear<white_point::E>, f64> = color.into();
     }
 }

--- a/palette/src/encoding/gamma.rs
+++ b/palette/src/encoding/gamma.rs
@@ -2,13 +2,12 @@
 
 use core::marker::PhantomData;
 
-use float::Float;
-
-use encoding::TransferFn;
-use luma::LumaStandard;
-use rgb::{RgbSpace, RgbStandard};
-use white_point::WhitePoint;
-use {from_f64, FromF64};
+use crate::encoding::TransferFn;
+use crate::float::Float;
+use crate::luma::LumaStandard;
+use crate::rgb::{RgbSpace, RgbStandard};
+use crate::white_point::WhitePoint;
+use crate::{from_f64, FromF64};
 
 /// Gamma encoding.
 ///
@@ -16,10 +15,11 @@ use {from_f64, FromF64};
 /// values to either match a non-linear display, like CRT, or to prevent
 /// banding among the darker colors. `GammaRgb` represents a gamma corrected
 /// RGB color, where the intensities are encoded using the following power-law
-/// expression: _V<sup> γ</sup>_ (where _V_ is the intensity value an _γ_ is the encoding
-/// gamma).
+/// expression: _V<sup> γ</sup>_ (where _V_ is the intensity value an _γ_ is the
+/// encoding gamma).
 ///
-/// The gamma value is stored as a simple type that represents an `f32` constant.
+/// The gamma value is stored as a simple type that represents an `f32`
+/// constant.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Gamma<S, N: Number = F2p2>(PhantomData<(S, N)>);
 
@@ -35,7 +35,8 @@ impl<Wp: WhitePoint, N: Number> LumaStandard for Gamma<Wp, N> {
 
 /// The transfer function for gamma encoded colors.
 ///
-/// The gamma value is stored as a simple type that represents an `f32` constant.
+/// The gamma value is stored as a simple type that represents an `f32`
+/// constant.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct GammaFn<N: Number = F2p2>(PhantomData<N>);
 

--- a/palette/src/encoding/linear.rs
+++ b/palette/src/encoding/linear.rs
@@ -2,11 +2,11 @@
 
 use core::marker::PhantomData;
 
-use encoding::TransferFn;
-use float::Float;
-use luma::LumaStandard;
-use rgb::{RgbSpace, RgbStandard};
-use white_point::WhitePoint;
+use crate::encoding::TransferFn;
+use crate::float::Float;
+use crate::luma::LumaStandard;
+use crate::rgb::{RgbSpace, RgbStandard};
+use crate::white_point::WhitePoint;
 
 /// A generic standard with linear components.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -22,7 +22,7 @@ impl<Wp: WhitePoint> LumaStandard for Linear<Wp> {
     type TransferFn = LinearFn;
 }
 
-///Linear color component encoding.
+/// Linear color component encoding.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LinearFn;
 

--- a/palette/src/encoding/mod.rs
+++ b/palette/src/encoding/mod.rs
@@ -1,7 +1,7 @@
 //! Various encoding traits, types and standards.
 
-use float::Float;
-use FromF64;
+use crate::float::Float;
+use crate::FromF64;
 
 pub use self::gamma::{F2p2, Gamma};
 pub use self::linear::Linear;

--- a/palette/src/encoding/pixel/mod.rs
+++ b/palette/src/encoding/pixel/mod.rs
@@ -1,33 +1,39 @@
-//!Pixel encodings and pixel format conversion.
+//! Pixel encodings and pixel format conversion.
 
 pub use self::raw::*;
 mod raw;
 
-/// Represents colors that can be serialized and deserialized from raw color components.
+/// Represents colors that can be serialized and deserialized from raw color
+/// components.
 ///
-/// This uses bit by bit conversion, so make sure that anything that implements it can be
-/// represented as a contiguous sequence of a single type `T`. This is most safely done using
-/// `#[derive(Pixel)]`.
+/// This uses bit by bit conversion, so make sure that anything that implements
+/// it can be represented as a contiguous sequence of a single type `T`. This is
+/// most safely done using `#[derive(Pixel)]`.
 ///
 /// # Deriving
 ///
-/// `Pixel` can be automatically derived. The only requirements are that the type is a `struct`,
-/// that it has a `#[repr(C)]` attribute, and that all of its fields have the same types. It stays
-/// on the conservative side and will show an error if any of those requirements are not fulfilled.
-/// If some fields have different types, but the same memory layout, or are zero-sized, they can be
-/// marked with attributes to show that their types are safe to use.
+/// `Pixel` can be automatically derived. The only requirements are that the
+/// type is a `struct`, that it has a `#[repr(C)]` attribute, and that all of
+/// its fields have the same types. It stays on the conservative side and will
+/// show an error if any of those requirements are not fulfilled. If some fields
+/// have different types, but the same memory layout, or are zero-sized, they
+/// can be marked with attributes to show that their types are safe to use.
 ///
 /// ## Field Attributes
 ///
-/// * `#[palette_unsafe_same_layout_as = "SomeType"]`: Mark the field as having the same memory
+/// * `#[palette_unsafe_same_layout_as = "SomeType"]`: Mark the field as having
+///   the same memory
 /// layout as `SomeType`.
 ///
-///   **Unsafety:** corrupt data and undefined behavior may occur if this is not true!
+///   **Unsafety:** corrupt data and undefined behavior may occur if this is not
+/// true!
 ///
-/// * `#[palette_unsafe_zero_sized]`: Mark the field as being zero-sized, and thus not taking up
+/// * `#[palette_unsafe_zero_sized]`: Mark the field as being zero-sized, and
+///   thus not taking up
 /// any memory space. This means that it can be ignored.
 ///
-///   **Unsafety:** corrupt data and undefined behavior may occur if this is not true!
+///   **Unsafety:** corrupt data and undefined behavior may occur if this is not
+/// true!
 ///
 /// ## Examples
 ///
@@ -45,20 +51,18 @@ mod raw;
 ///     key: f32,
 /// }
 ///
-/// fn main() {
-///     let buffer = [0.1, 0.2, 0.3, 0.4];
-///     let color = MyCmyk::from_raw(&buffer);
+/// let buffer = [0.1, 0.2, 0.3, 0.4];
+/// let color = MyCmyk::from_raw(&buffer);
 ///
-///     assert_eq!(
-///         color,
-///         &MyCmyk {
-///             cyan: 0.1,
-///             magenta: 0.2,
-///             yellow: 0.3,
-///             key: 0.4,
-///         }
-///     );
-/// }
+/// assert_eq!(
+///     color,
+///     &MyCmyk {
+///         cyan: 0.1,
+///         magenta: 0.2,
+///         yellow: 0.3,
+///         key: 0.4,
+///     }
+/// );
 /// ```
 ///
 /// Heterogenous field types:
@@ -83,20 +87,18 @@ mod raw;
 ///     chroma: f32,
 /// }
 ///
-/// fn main() {
-///     let buffer = [172.0, 100.0, 0.3];
-///     let color = MyCoolColor::<Srgb>::from_raw(&buffer);
+/// let buffer = [172.0, 100.0, 0.3];
+/// let color = MyCoolColor::<Srgb>::from_raw(&buffer);
 ///
-///     assert_eq!(
-///         color,
-///         &MyCoolColor {
-///             hue: 172.0.into(),
-///             lumen: 100.0,
-///             chroma: 0.3,
-///             standard: PhantomData,
-///         }
-///     );
-/// }
+/// assert_eq!(
+///     color,
+///     &MyCoolColor {
+///         hue: 172.0.into(),
+///         lumen: 100.0,
+///         chroma: 0.3,
+///         standard: PhantomData,
+///     }
+/// );
 /// ```
 pub unsafe trait Pixel<T>: Sized {
     /// The number of color channels.
@@ -168,7 +170,8 @@ pub unsafe trait Pixel<T>: Sized {
         unsafe { ::core::slice::from_raw_parts(slice.as_ptr() as *const Self, new_length) }
     }
 
-    /// Cast a mutable slice of raw color components to a mutable slice of colors.
+    /// Cast a mutable slice of raw color components to a mutable slice of
+    /// colors.
     ///
     /// ```rust
     /// use palette::{Pixel, Srgb};
@@ -210,7 +213,8 @@ pub unsafe trait Pixel<T>: Sized {
         unsafe { ::core::slice::from_raw_parts(slice.as_ptr() as *const T, new_length) }
     }
 
-    /// Cast a mutable slice of colors to a mutable slice of raw color components.
+    /// Cast a mutable slice of colors to a mutable slice of raw color
+    /// components.
     ///
     /// ```rust
     /// use palette::{Pixel, Srgb};

--- a/palette/src/encoding/pixel/raw.rs
+++ b/palette/src/encoding/pixel/raw.rs
@@ -1,7 +1,7 @@
 /// A contiguous sequence of pixel channels with a known length.
 ///
-/// It's used when converting to and from raw pixel data and should only be implemented for types
-/// with either a suitable in-memory representation.
+/// It's used when converting to and from raw pixel data and should only be
+/// implemented for types with either a suitable in-memory representation.
 pub unsafe trait RawPixelSized<T>: Sized {
     /// The guaranteed number of channels in the sequence.
     const CHANNELS: usize;
@@ -25,8 +25,8 @@ unsafe impl<T> RawPixelSized<T> for [T; 4] {
 
 /// A contiguous sequence of pixel channels.
 ///
-/// It's used when converting to and from raw pixel data and should only be implemented for types
-/// with a suitable in-memory representation.
+/// It's used when converting to and from raw pixel data and should only be
+/// implemented for types with a suitable in-memory representation.
 pub unsafe trait RawPixel<T> {
     /// The length of the sequence.
     fn channels(&self) -> usize;

--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -1,14 +1,14 @@
 //! The sRGB standard.
 
-use encoding::TransferFn;
-use float::Float;
-use luma::LumaStandard;
-use rgb::{Primaries, RgbSpace, RgbStandard};
-use white_point::{WhitePoint, D65};
-use {from_f64, FromF64};
-use {FloatComponent, Yxy};
+use crate::encoding::TransferFn;
+use crate::float::Float;
+use crate::luma::LumaStandard;
+use crate::rgb::{Primaries, RgbSpace, RgbStandard};
+use crate::white_point::{WhitePoint, D65};
+use crate::{from_f64, FromF64};
+use crate::{FloatComponent, Yxy};
 
-///The sRGB color space.
+/// The sRGB color space.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Srgb;
 

--- a/palette/src/equality.rs
+++ b/palette/src/equality.rs
@@ -1,9 +1,8 @@
-use float::Float;
-
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-use white_point::WhitePoint;
-use {from_f64, FloatComponent, FromF64, Lab, LabHue, Lch, RgbHue, Xyz, Yxy};
+use crate::float::Float;
+use crate::white_point::WhitePoint;
+use crate::{from_f64, FloatComponent, FromF64, Lab, LabHue, Lch, RgbHue, Xyz, Yxy};
 
 macro_rules! impl_eq {
     (  $self_ty: ident , [$($element: ident),+]) => {

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -1,34 +1,32 @@
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
-use float::Float;
-
 use core::any::TypeId;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
-use encoding::pixel::RawPixel;
-use encoding::{Linear, Srgb};
-use rgb::{Rgb, RgbSpace};
-use {clamp, contrast_ratio, from_f64};
-use {Alpha, Hsv, RgbHue, Xyz};
-use {
-    Component, FloatComponent, FromColor, FromF64, GetHue, Hue, IntoColor, Limited, Mix, Pixel,
-    RelativeContrast, Saturate, Shade,
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
+
+use crate::encoding::pixel::RawPixel;
+use crate::encoding::{Linear, Srgb};
+use crate::float::Float;
+use crate::rgb::{Rgb, RgbSpace};
+use crate::{
+    clamp, contrast_ratio, from_f64, Alpha, Component, FloatComponent, FromColor, FromF64, GetHue,
+    Hsv, Hue, IntoColor, Limited, Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
 };
 
 /// Linear HSL with an alpha component. See the [`Hsla` implementation in
 /// `Alpha`](struct.Alpha.html#Hsla).
 pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 
-///Linear HSL color space.
+/// Linear HSL color space.
 ///
-///The HSL color space can be seen as a cylindrical version of
-///[RGB](rgb/struct.LinRgb.html), where the `hue` is the angle around the color
-///cylinder, the `saturation` is the distance from the center, and the
-///`lightness` is the height from the bottom. Its composition makes it
-///especially good for operations like changing green to red, making a color
-///more gray, or making it darker.
+/// The HSL color space can be seen as a cylindrical version of
+/// [RGB](rgb/struct.LinRgb.html), where the `hue` is the angle around the color
+/// cylinder, the `saturation` is the distance from the center, and the
+/// `lightness` is the height from the bottom. Its composition makes it
+/// especially good for operations like changing green to red, making a color
+/// more gray, or making it darker.
 ///
-///See [HSV](struct.Hsv.html) for a very similar color space, with brightness
+/// See [HSV](struct.Hsv.html) for a very similar color space, with brightness
 /// instead of lightness.
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -43,21 +41,21 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    ///The hue of the color, in degrees. Decides if it's red, blue, purple,
-    ///etc.
+    /// The hue of the color, in degrees. Decides if it's red, blue, purple,
+    /// etc.
     #[palette_unsafe_same_layout_as = "T"]
     pub hue: RgbHue<T>,
 
-    ///The colorfulness of the color. 0.0 gives gray scale colors and 1.0 will
-    ///give absolutely clear colors.
+    /// The colorfulness of the color. 0.0 gives gray scale colors and 1.0 will
+    /// give absolutely clear colors.
     pub saturation: T,
 
-    ///Decides how light the color will look. 0.0 will be black, 0.5 will give
-    ///a clear color, and 1.0 will give white.
+    /// Decides how light the color will look. 0.0 will be black, 0.5 will give
+    /// a clear color, and 1.0 will give white.
     pub lightness: T,
 
-    ///The white point and RGB primaries this color is adapted to. The default
-    ///is the sRGB standard.
+    /// The white point and RGB primaries this color is adapted to. The default
+    /// is the sRGB standard.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub space: PhantomData<S>,
@@ -84,12 +82,12 @@ impl<T> Hsl<Srgb, T>
 where
     T: FloatComponent,
 {
-    ///HSL for linear sRGB.
+    /// HSL for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, saturation: T, lightness: T) -> Hsl<Srgb, T> {
         Hsl {
             hue: hue.into(),
-            saturation: saturation,
-            lightness: lightness,
+            saturation,
+            lightness,
             space: PhantomData,
         }
     }
@@ -100,12 +98,12 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    ///Linear HSL.
+    /// Linear HSL.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, saturation: T, lightness: T) -> Hsl<S, T> {
         Hsl {
             hue: hue.into(),
-            saturation: saturation,
-            lightness: lightness,
+            saturation,
+            lightness,
             space: PhantomData,
         }
     }
@@ -187,11 +185,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///HSL and transparency for linear sRGB.
+    /// HSL and transparency for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, saturation: T, lightness: T, alpha: A) -> Self {
         Alpha {
             color: Hsl::new(hue, saturation, lightness),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -203,11 +201,11 @@ where
     A: Component,
     S: RgbSpace,
 {
-    ///Linear HSL and transparency.
+    /// Linear HSL and transparency.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, saturation: T, lightness: T, alpha: A) -> Self {
         Alpha {
             color: Hsl::with_wp(hue, saturation, lightness),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -264,7 +262,7 @@ where
 
         Hsl {
             hue: hsv.hue,
-            saturation: saturation,
+            saturation,
             lightness: x / from_f64(2.0),
             space: PhantomData,
         }
@@ -304,7 +302,7 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::one() &&
         self.lightness >= T::zero() && self.lightness <= T::one()
@@ -593,7 +591,7 @@ where
         T::default_max_relative()
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn relative_eq(
         &self,
         other: &Self,
@@ -616,7 +614,7 @@ where
         T::default_max_ulps()
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
         self.hue.ulps_eq(&other.hue, epsilon, max_ulps) &&
             self.saturation.ulps_eq(&other.saturation, epsilon, max_ulps) &&
@@ -642,8 +640,8 @@ where
 #[cfg(test)]
 mod test {
     use super::Hsl;
-    use encoding::Srgb;
-    use {Hsv, LinSrgb};
+    use crate::encoding::Srgb;
+    use crate::{Hsv, LinSrgb};
 
     #[test]
     fn red() {

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -1,32 +1,32 @@
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
-use float::Float;
-
 use core::any::TypeId;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
-use encoding::pixel::RawPixel;
-use encoding::{Linear, Srgb};
-use rgb::{Rgb, RgbSpace};
-use {clamp, contrast_ratio, from_f64};
-use {Alpha, Hsl, Hwb, RgbHue, Xyz};
-use {
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
+
+use crate::encoding::pixel::RawPixel;
+use crate::encoding::{Linear, Srgb};
+use crate::float::Float;
+use crate::rgb::{Rgb, RgbSpace};
+use crate::{clamp, contrast_ratio, from_f64};
+use crate::{Alpha, Hsl, Hwb, Xyz};
+use crate::{
     Component, FloatComponent, FromColor, FromF64, GetHue, Hue, IntoColor, Limited, Mix, Pixel,
-    RelativeContrast, Saturate, Shade,
+    RelativeContrast, RgbHue, Saturate, Shade,
 };
 
 /// Linear HSV with an alpha component. See the [`Hsva` implementation in
 /// `Alpha`](struct.Alpha.html#Hsva).
 pub type Hsva<S = Srgb, T = f32> = Alpha<Hsv<S, T>, T>;
 
-///Linear HSV color space.
+/// Linear HSV color space.
 ///
-///HSV is a cylindrical version of [RGB](rgb/struct.LinRgb.html) and it's very
-///similar to [HSL](struct.Hsl.html). The difference is that the `value`
-///component in HSV determines the _brightness_ of the color, and not the
-///_lightness_. The difference is that, for example, red (100% R, 0% G, 0% B)
-///and white (100% R, 100% G, 100% B) has the same brightness (or value), but
-///not the same lightness.
+/// HSV is a cylindrical version of [RGB](rgb/struct.LinRgb.html) and it's very
+/// similar to [HSL](struct.Hsl.html). The difference is that the `value`
+/// component in HSV determines the _brightness_ of the color, and not the
+/// _lightness_. The difference is that, for example, red (100% R, 0% G, 0% B)
+/// and white (100% R, 100% G, 100% B) has the same brightness (or value), but
+/// not the same lightness.
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette_internal]
@@ -40,22 +40,22 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    ///The hue of the color, in degrees. Decides if it's red, blue, purple,
-    ///etc.
+    /// The hue of the color, in degrees. Decides if it's red, blue, purple,
+    /// etc.
     #[palette_unsafe_same_layout_as = "T"]
     pub hue: RgbHue<T>,
 
-    ///The colorfulness of the color. 0.0 gives gray scale colors and 1.0 will
-    ///give absolutely clear colors.
+    /// The colorfulness of the color. 0.0 gives gray scale colors and 1.0 will
+    /// give absolutely clear colors.
     pub saturation: T,
 
-    ///Decides how bright the color will look. 0.0 will be black, and 1.0 will
-    ///give a bright an clear color that goes towards white when `saturation`
-    ///goes towards 0.0.
+    /// Decides how bright the color will look. 0.0 will be black, and 1.0 will
+    /// give a bright an clear color that goes towards white when `saturation`
+    /// goes towards 0.0.
     pub value: T,
 
-    ///The white point and RGB primaries this color is adapted to. The default
-    ///is the sRGB standard.
+    /// The white point and RGB primaries this color is adapted to. The default
+    /// is the sRGB standard.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub space: PhantomData<S>,
@@ -82,12 +82,12 @@ impl<T> Hsv<Srgb, T>
 where
     T: FloatComponent,
 {
-    ///HSV for linear sRGB.
+    /// HSV for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, saturation: T, value: T) -> Hsv<Srgb, T> {
         Hsv {
             hue: hue.into(),
-            saturation: saturation,
-            value: value,
+            saturation,
+            value,
             space: PhantomData,
         }
     }
@@ -98,12 +98,12 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    ///Linear HSV.
+    /// Linear HSV.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, saturation: T, value: T) -> Hsv<S, T> {
         Hsv {
             hue: hue.into(),
-            saturation: saturation,
-            value: value,
+            saturation,
+            value,
             space: PhantomData,
         }
     }
@@ -180,11 +180,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///HSV and transparency for linear sRGB.
+    /// HSV and transparency for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, saturation: T, value: T, alpha: A) -> Self {
         Alpha {
             color: Hsv::new(hue, saturation, value),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -196,11 +196,11 @@ where
     A: Component,
     S: RgbSpace,
 {
-    ///Linear HSV and transparency.
+    /// Linear HSV and transparency.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, saturation: T, value: T, alpha: A) -> Self {
         Alpha {
             color: Hsv::with_wp(hue, saturation, value),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -317,7 +317,7 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::one() &&
         self.value >= T::zero() && self.value <= T::one()
@@ -606,7 +606,7 @@ where
         T::default_max_relative()
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn relative_eq(
         &self,
         other: &Self,
@@ -629,7 +629,7 @@ where
         T::default_max_ulps()
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
         self.hue.ulps_eq(&other.hue, epsilon, max_ulps) &&
             self.saturation.ulps_eq(&other.saturation, epsilon, max_ulps) &&
@@ -655,8 +655,8 @@ where
 #[cfg(test)]
 mod test {
     use super::Hsv;
-    use encoding::Srgb;
-    use {Hsl, LinSrgb};
+    use crate::encoding::Srgb;
+    use crate::{Hsl, LinSrgb};
 
     #[test]
     fn red() {

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -1,8 +1,8 @@
-use float::Float;
-
 use core::cmp::PartialEq;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
-use {from_f64, FromF64};
+
+use crate::float::Float;
+use crate::{from_f64, FromF64};
 
 macro_rules! make_hues {
     ($($(#[$doc:meta])+ struct $name:ident;)+) => ($(
@@ -273,7 +273,7 @@ fn normalize_angle_positive<T: Float + FromF64>(deg: T) -> T {
 #[cfg(test)]
 mod test {
     use super::{normalize_angle, normalize_angle_positive};
-    use RgbHue;
+    use crate::RgbHue;
 
     #[test]
     fn normalize_angle_0_360() {

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -1,32 +1,30 @@
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
-use float::Float;
-
 use core::any::TypeId;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
-use encoding::pixel::RawPixel;
-use encoding::Srgb;
-use rgb::RgbSpace;
-use {clamp, contrast_ratio};
-use {Alpha, Hsv, RgbHue, Xyz};
-use {
-    Component, FloatComponent, FromColor, FromF64, GetHue, Hue, IntoColor, Limited, Mix, Pixel,
-    RelativeContrast, Shade,
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
+
+use crate::encoding::pixel::RawPixel;
+use crate::encoding::Srgb;
+use crate::float::Float;
+use crate::rgb::RgbSpace;
+use crate::{
+    clamp, contrast_ratio, Alpha, Component, FloatComponent, FromColor, FromF64, GetHue, Hsv, Hue,
+    IntoColor, Limited, Mix, Pixel, RelativeContrast, RgbHue, Shade, Xyz,
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
 /// `Alpha`](struct.Alpha.html#Hwba).
 pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 
-///Linear HWB color space.
+/// Linear HWB color space.
 ///
-///HWB is a cylindrical version of [RGB](rgb/struct.LinRgb.html) and it's very
-///closely related to [HSV](struct.Hsv.html).  It describes colors with a
+/// HWB is a cylindrical version of [RGB](rgb/struct.LinRgb.html) and it's very
+/// closely related to [HSV](struct.Hsv.html).  It describes colors with a
 /// starting hue, then a degree of whiteness and blackness to mix into that
 /// base hue.
 ///
-///It is very intuitive for humans to use and many color-pickers are based on
+/// It is very intuitive for humans to use and many color-pickers are based on
 /// the HWB color system
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -41,26 +39,26 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    ///The hue of the color, in degrees. Decides if it's red, blue, purple,
-    ///etc. Same as the hue for HSL and HSV.
+    /// The hue of the color, in degrees. Decides if it's red, blue, purple,
+    /// etc. Same as the hue for HSL and HSV.
     #[palette_unsafe_same_layout_as = "T"]
     pub hue: RgbHue<T>,
 
-    ///The whiteness of the color. It specifies the amount white to mix into
+    /// The whiteness of the color. It specifies the amount white to mix into
     /// the hue. It varies from 0 to 1, with 1 being always full white and 0
-    ///always being the color shade (a mixture of a pure hue with black)
+    /// always being the color shade (a mixture of a pure hue with black)
     /// chosen with the other two controls.
     pub whiteness: T,
 
-    ///The blackness of the color. It specifies the amount black to mix into
+    /// The blackness of the color. It specifies the amount black to mix into
     /// the hue. It varies from 0 to 1, with 1 being always full black and
     /// 0 always being the color tint (a mixture of a pure hue with white)
     /// chosen with the other two
     //controls.
     pub blackness: T,
 
-    ///The white point and RGB primaries this color is adapted to. The default
-    ///is the sRGB standard.
+    /// The white point and RGB primaries this color is adapted to. The default
+    /// is the sRGB standard.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub space: PhantomData<S>,
@@ -87,12 +85,12 @@ impl<T> Hwb<Srgb, T>
 where
     T: FloatComponent,
 {
-    ///HWB for linear sRGB.
+    /// HWB for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, whiteness: T, blackness: T) -> Hwb<Srgb, T> {
         Hwb {
             hue: hue.into(),
-            whiteness: whiteness,
-            blackness: blackness,
+            whiteness,
+            blackness,
             space: PhantomData,
         }
     }
@@ -103,12 +101,12 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    ///Linear HWB.
+    /// Linear HWB.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, whiteness: T, blackness: T) -> Hwb<S, T> {
         Hwb {
             hue: hue.into(),
-            whiteness: whiteness,
-            blackness: blackness,
+            whiteness,
+            blackness,
             space: PhantomData,
         }
     }
@@ -148,11 +146,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///HWB and transparency for linear sRGB.
+    /// HWB and transparency for linear sRGB.
     pub fn new<H: Into<RgbHue<T>>>(hue: H, whiteness: T, blackness: T, alpha: A) -> Self {
         Alpha {
             color: Hwb::new(hue, whiteness, blackness),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -164,11 +162,11 @@ where
     A: Component,
     S: RgbSpace,
 {
-    ///Linear HWB and transparency.
+    /// Linear HWB and transparency.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, whiteness: T, blackness: T, alpha: A) -> Self {
         Alpha {
             color: Hwb::with_wp(hue, whiteness, blackness),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -247,7 +245,7 @@ where
     T: FloatComponent,
     S: RgbSpace,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         self.blackness >= T::zero() && self.blackness <= T::one() &&
         self.whiteness >= T::zero() && self.whiteness <= T::one() &&
@@ -603,8 +601,8 @@ where
 #[cfg(test)]
 mod test {
     use super::Hwb;
-    use encoding::Srgb;
-    use {Limited, LinSrgb};
+    use crate::encoding::Srgb;
+    use crate::{Limited, LinSrgb};
 
     #[test]
     fn red() {

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -1,32 +1,31 @@
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use encoding::pixel::RawPixel;
-use white_point::{WhitePoint, D65};
-use {clamp, contrast_ratio, from_f64};
-use {Alpha, LabHue, Lch, Xyz};
-use {
+use crate::color_difference::ColorDifference;
+use crate::color_difference::{get_ciede_difference, LabColorDiff};
+use crate::encoding::pixel::RawPixel;
+use crate::white_point::{WhitePoint, D65};
+use crate::{clamp, contrast_ratio, from_f64};
+use crate::{Alpha, LabHue, Lch, Xyz};
+use crate::{
     Component, ComponentWise, FloatComponent, GetHue, IntoColor, Limited, Mix, Pixel,
     RelativeContrast, Shade,
 };
-
-use color_difference::ColorDifference;
-use color_difference::{get_ciede_difference, LabColorDiff};
 
 /// CIE L\*a\*b\* (CIELAB) with an alpha component. See the [`Laba`
 /// implementation in `Alpha`](struct.Alpha.html#Laba).
 pub type Laba<Wp, T = f32> = Alpha<Lab<Wp, T>, T>;
 
-///The CIE L\*a\*b\* (CIELAB) color space.
+/// The CIE L\*a\*b\* (CIELAB) color space.
 ///
-///CIE L\*a\*b\* is a device independent color space which includes all
-///perceivable colors. It's sometimes used to convert between other color
-///spaces, because of its ability to represent all of their colors, and
-///sometimes in color manipulation, because of its perceptual uniformity. This
-///means that the perceptual difference between two colors is equal to their
-///numerical difference.
+/// CIE L\*a\*b\* is a device independent color space which includes all
+/// perceivable colors. It's sometimes used to convert between other color
+/// spaces, because of its ability to represent all of their colors, and
+/// sometimes in color manipulation, because of its perceptual uniformity. This
+/// means that the perceptual difference between two colors is equal to their
+/// numerical difference.
 ///
-///The parameters of L\*a\*b\* are quite different, compared to many other
+/// The parameters of L\*a\*b\* are quite different, compared to many other
 /// color spaces, so manipulating them manually may be unintuitive.
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -40,18 +39,18 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///L\* is the lightness of the color. 0.0 gives absolute black and 100
-    ///give the brightest white.
+    /// L\* is the lightness of the color. 0.0 gives absolute black and 100
+    /// give the brightest white.
     pub l: T,
 
-    ///a\* goes from red at -128 to green at 127.
+    /// a\* goes from red at -128 to green at 127.
     pub a: T,
 
-    ///b\* goes from yellow at -128 to blue at 127.
+    /// b\* goes from yellow at -128 to blue at 127.
     pub b: T,
 
-    ///The white point associated with the color's illuminant and observer.
-    ///D65 for 2 degree observer is used by default.
+    /// The white point associated with the color's illuminant and observer.
+    /// D65 for 2 degree observer is used by default.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub white_point: PhantomData<Wp>,
@@ -78,12 +77,12 @@ impl<T> Lab<D65, T>
 where
     T: FloatComponent,
 {
-    ///CIE L\*a\*b\* with white point D65.
+    /// CIE L\*a\*b\* with white point D65.
     pub fn new(l: T, a: T, b: T) -> Lab<D65, T> {
         Lab {
-            l: l,
-            a: a,
-            b: b,
+            l,
+            a,
+            b,
             white_point: PhantomData,
         }
     }
@@ -94,12 +93,12 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///CIE L\*a\*b\*.
+    /// CIE L\*a\*b\*.
     pub fn with_wp(l: T, a: T, b: T) -> Lab<Wp, T> {
         Lab {
-            l: l,
-            a: a,
-            b: b,
+            l,
+            a,
+            b,
             white_point: PhantomData,
         }
     }
@@ -121,11 +120,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///CIE L\*a\*b\* and transparency and white point D65.
+    /// CIE L\*a\*b\* and transparency and white point D65.
     pub fn new(l: T, a: T, b: T, alpha: A) -> Self {
         Alpha {
             color: Lab::new(l, a, b),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -137,11 +136,11 @@ where
     A: Component,
     Wp: WhitePoint,
 {
-    ///CIE L\*a\*b\* and transparency.
+    /// CIE L\*a\*b\* and transparency.
     pub fn with_wp(l: T, a: T, b: T, alpha: A) -> Self {
         Alpha {
             color: Lab::with_wp(l, a, b),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -237,7 +236,7 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         self.l >= T::zero() && self.l <= from_f64(100.0) &&
         self.a >= from_f64(-128.0) && self.a <= from_f64(127.0) &&
@@ -645,8 +644,8 @@ where
 #[cfg(test)]
 mod test {
     use super::Lab;
-    use white_point::D65;
-    use LinSrgb;
+    use crate::white_point::D65;
+    use crate::LinSrgb;
 
     #[test]
     fn red() {

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -1,27 +1,27 @@
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
-use color_difference::ColorDifference;
-use color_difference::{get_ciede_difference, LabColorDiff};
-use encoding::pixel::RawPixel;
-use white_point::{WhitePoint, D65};
-use {clamp, contrast_ratio, from_f64};
-use {Alpha, Lab, LabHue, Xyz};
-use {
-    Component, FloatComponent, FromColor, GetHue, Hue, IntoColor, Limited, Mix, Pixel,
-    RelativeContrast, Saturate, Shade,
+use crate::color_difference::ColorDifference;
+use crate::color_difference::{get_ciede_difference, LabColorDiff};
+use crate::encoding::pixel::RawPixel;
+use crate::white_point::{WhitePoint, D65};
+use crate::{clamp, contrast_ratio, from_f64};
+use crate::{Alpha, Hue, Lab, LabHue, Xyz};
+use crate::{
+    Component, FloatComponent, FromColor, GetHue, IntoColor, Limited, Mix, Pixel, RelativeContrast,
+    Saturate, Shade,
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
 /// `Alpha`](struct.Alpha.html#Lcha).
 pub type Lcha<Wp, T = f32> = Alpha<Lch<Wp, T>, T>;
 
-///CIE L\*C\*h°, a polar version of [CIE L\*a\*b\*](struct.Lab.html).
+/// CIE L\*C\*h°, a polar version of [CIE L\*a\*b\*](struct.Lab.html).
 ///
-///L\*C\*h° shares its range and perceptual uniformity with L\*a\*b\*, but
+/// L\*C\*h° shares its range and perceptual uniformity with L\*a\*b\*, but
 /// it's a cylindrical color space, like [HSL](struct.Hsl.html) and
-///[HSV](struct.Hsv.html). This gives it the same ability to directly change
-///the hue and colorfulness of a color, while preserving other visual aspects.
+/// [HSV](struct.Hsv.html). This gives it the same ability to directly change
+/// the hue and colorfulness of a color, while preserving other visual aspects.
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette_internal]
@@ -34,23 +34,23 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///L\* is the lightness of the color. 0.0 gives absolute black and 100.0
-    ///gives the brightest white.
+    /// L\* is the lightness of the color. 0.0 gives absolute black and 100.0
+    /// gives the brightest white.
     pub l: T,
 
-    ///C\* is the colorfulness of the color. It's similar to saturation. 0.0
-    ///gives gray scale colors, and numbers around 128-181 gives fully
-    ///saturated colors. The upper limit of 128 should
-    ///include the whole L\*a\*b\* space and some more.
+    /// C\* is the colorfulness of the color. It's similar to saturation. 0.0
+    /// gives gray scale colors, and numbers around 128-181 gives fully
+    /// saturated colors. The upper limit of 128 should
+    /// include the whole L\*a\*b\* space and some more.
     pub chroma: T,
 
-    ///The hue of the color, in degrees. Decides if it's red, blue, purple,
-    ///etc.
+    /// The hue of the color, in degrees. Decides if it's red, blue, purple,
+    /// etc.
     #[palette_unsafe_same_layout_as = "T"]
     pub hue: LabHue<T>,
 
-    ///The white point associated with the color's illuminant and observer.
-    ///D65 for 2 degree observer is used by default.
+    /// The white point associated with the color's illuminant and observer.
+    /// D65 for 2 degree observer is used by default.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub white_point: PhantomData<Wp>,
@@ -77,11 +77,11 @@ impl<T> Lch<D65, T>
 where
     T: FloatComponent,
 {
-    ///CIE L\*C\*h° with white point D65.
+    /// CIE L\*C\*h° with white point D65.
     pub fn new<H: Into<LabHue<T>>>(l: T, chroma: T, hue: H) -> Lch<D65, T> {
         Lch {
-            l: l,
-            chroma: chroma,
+            l,
+            chroma,
             hue: hue.into(),
             white_point: PhantomData,
         }
@@ -93,11 +93,11 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///CIE L\*C\*h°.
+    /// CIE L\*C\*h°.
     pub fn with_wp<H: Into<LabHue<T>>>(l: T, chroma: T, hue: H) -> Lch<Wp, T> {
         Lch {
-            l: l,
-            chroma: chroma,
+            l,
+            chroma,
             hue: hue.into(),
             white_point: PhantomData,
         }
@@ -120,11 +120,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///CIE L\*C\*h° and transparency with white point D65.
+    /// CIE L\*C\*h° and transparency with white point D65.
     pub fn new<H: Into<LabHue<T>>>(l: T, chroma: T, hue: H, alpha: A) -> Self {
         Alpha {
             color: Lch::new(l, chroma, hue),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -136,11 +136,11 @@ where
     A: Component,
     Wp: WhitePoint,
 {
-    ///CIE L\*C\*h° and transparency.
+    /// CIE L\*C\*h° and transparency.
     pub fn with_wp<H: Into<LabHue<T>>>(l: T, chroma: T, hue: H, alpha: A) -> Self {
         Alpha {
             color: Lch::with_wp(l, chroma, hue),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -535,8 +535,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use white_point::D65;
-    use Lch;
+    use crate::white_point::D65;
+    use crate::Lch;
 
     #[test]
     fn ranges() {

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -133,7 +133,6 @@
 //! When the desired processing is done, it's time to encode the colors back
 //! into some image format. The same rules applies as for the decoding, but the
 //! process reversed.
-//!
 
 // Keep the standard library when running tests, too
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
@@ -149,8 +148,6 @@ extern crate approx;
 
 #[macro_use]
 extern crate palette_derive;
-
-extern crate num_traits;
 
 #[cfg(feature = "phf")]
 extern crate phf;
@@ -208,7 +205,7 @@ macro_rules! assert_ranges {
     ) => (
         {
             use core::iter::repeat;
-            use Limited;
+            use crate::Limited;
 
             {
                 print!("checking below limits ... ");
@@ -387,71 +384,65 @@ fn clamp<T: PartialOrd>(v: T, min: T, max: T) -> T {
     }
 }
 
-///A trait for clamping and checking if colors are within their ranges.
+/// A trait for clamping and checking if colors are within their ranges.
 pub trait Limited {
-    ///Check if the color's components are within the expected ranges.
+    /// Check if the color's components are within the expected ranges.
     fn is_valid(&self) -> bool;
 
-    ///Return a new color where the components has been clamped to the nearest
-    ///valid values.
+    /// Return a new color where the components has been clamped to the nearest
+    /// valid values.
     fn clamp(&self) -> Self;
 
-    ///Clamp the color's components to the nearest valid values.
+    /// Clamp the color's components to the nearest valid values.
     fn clamp_self(&mut self);
 }
 
 /// A trait for linear color interpolation.
 ///
 /// ```
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{LinSrgb, Mix};
 ///
-/// fn main() {
-///     let a = LinSrgb::new(0.0, 0.5, 1.0);
-///     let b = LinSrgb::new(1.0, 0.5, 0.0);
+/// let a = LinSrgb::new(0.0, 0.5, 1.0);
+/// let b = LinSrgb::new(1.0, 0.5, 0.0);
 ///
-///     assert_relative_eq!(a.mix(&b, 0.0), a);
-///     assert_relative_eq!(a.mix(&b, 0.5), LinSrgb::new(0.5, 0.5, 0.5));
-///     assert_relative_eq!(a.mix(&b, 1.0), b);
-/// }
+/// assert_relative_eq!(a.mix(&b, 0.0), a);
+/// assert_relative_eq!(a.mix(&b, 0.5), LinSrgb::new(0.5, 0.5, 0.5));
+/// assert_relative_eq!(a.mix(&b, 1.0), b);
 /// ```
 pub trait Mix {
-    ///The type of the mixing factor.
+    /// The type of the mixing factor.
     type Scalar: Float;
 
-    ///Mix the color with an other color, by `factor`.
+    /// Mix the color with an other color, by `factor`.
     ///
-    ///`factor` sould be between `0.0` and `1.0`, where `0.0` will result in
-    ///the same color as `self` and `1.0` will result in the same color as
-    ///`other`.
+    /// `factor` sould be between `0.0` and `1.0`, where `0.0` will result in
+    /// the same color as `self` and `1.0` will result in the same color as
+    /// `other`.
     fn mix(&self, other: &Self, factor: Self::Scalar) -> Self;
 }
 
 /// The `Shade` trait allows a color to be lightened or darkened.
 ///
 /// ```
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{LinSrgb, Shade};
 ///
-/// fn main() {
-///     let a = LinSrgb::new(0.4, 0.4, 0.4);
-///     let b = LinSrgb::new(0.6, 0.6, 0.6);
+/// let a = LinSrgb::new(0.4, 0.4, 0.4);
+/// let b = LinSrgb::new(0.6, 0.6, 0.6);
 ///
-///     assert_relative_eq!(a.lighten(0.1), b.darken(0.1));
-/// }
+/// assert_relative_eq!(a.lighten(0.1), b.darken(0.1));
 /// ```
 pub trait Shade: Sized {
-    ///The type of the lighten/darken amount.
+    /// The type of the lighten/darken amount.
     type Scalar: Float;
 
-    ///Lighten the color by `amount`.
+    /// Lighten the color by `amount`.
     fn lighten(&self, amount: Self::Scalar) -> Self;
 
-    ///Darken the color by `amount`.
+    /// Darken the color by `amount`.
     fn darken(&self, amount: Self::Scalar) -> Self {
         self.lighten(-amount)
     }
@@ -460,45 +451,42 @@ pub trait Shade: Sized {
 /// A trait for colors where a hue may be calculated.
 ///
 /// ```
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{GetHue, LinSrgb};
 ///
-/// fn main() {
-///     let red = LinSrgb::new(1.0f32, 0.0, 0.0);
-///     let green = LinSrgb::new(0.0f32, 1.0, 0.0);
-///     let blue = LinSrgb::new(0.0f32, 0.0, 1.0);
-///     let gray = LinSrgb::new(0.5f32, 0.5, 0.5);
+/// let red = LinSrgb::new(1.0f32, 0.0, 0.0);
+/// let green = LinSrgb::new(0.0f32, 1.0, 0.0);
+/// let blue = LinSrgb::new(0.0f32, 0.0, 1.0);
+/// let gray = LinSrgb::new(0.5f32, 0.5, 0.5);
 ///
-///     assert_relative_eq!(red.get_hue().unwrap(), 0.0.into());
-///     assert_relative_eq!(green.get_hue().unwrap(), 120.0.into());
-///     assert_relative_eq!(blue.get_hue().unwrap(), 240.0.into());
-///     assert_eq!(gray.get_hue(), None);
-/// }
+/// assert_relative_eq!(red.get_hue().unwrap(), 0.0.into());
+/// assert_relative_eq!(green.get_hue().unwrap(), 120.0.into());
+/// assert_relative_eq!(blue.get_hue().unwrap(), 240.0.into());
+/// assert_eq!(gray.get_hue(), None);
 /// ```
 pub trait GetHue {
-    ///The kind of hue unit this color space uses.
+    /// The kind of hue unit this color space uses.
     ///
-    ///The hue is most commonly calculated as an angle around a color circle
-    ///and may not always be uniform between color spaces. It's therefore not
-    ///recommended to take one type of hue and apply it to a color space that
-    ///expects an other.
+    /// The hue is most commonly calculated as an angle around a color circle
+    /// and may not always be uniform between color spaces. It's therefore not
+    /// recommended to take one type of hue and apply it to a color space that
+    /// expects an other.
     type Hue;
 
-    ///Calculate a hue if possible.
+    /// Calculate a hue if possible.
     ///
-    ///Colors in the gray scale has no well defined hue and should preferably
-    ///return `None`.
+    /// Colors in the gray scale has no well defined hue and should preferably
+    /// return `None`.
     fn get_hue(&self) -> Option<Self::Hue>;
 }
 
-///A trait for colors where the hue can be manipulated without conversion.
+/// A trait for colors where the hue can be manipulated without conversion.
 pub trait Hue: GetHue {
-    ///Return a new copy of `self`, but with a specific hue.
+    /// Return a new copy of `self`, but with a specific hue.
     fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Self;
 
-    ///Return a new copy of `self`, but with the hue shifted by `amount`.
+    /// Return a new copy of `self`, but with the hue shifted by `amount`.
     fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Self;
 }
 
@@ -506,44 +494,41 @@ pub trait Hue: GetHue {
 /// without conversion.
 ///
 /// ```
-/// #[macro_use]
-/// extern crate approx;
+/// use approx::assert_relative_eq;
 ///
 /// use palette::{Hsv, Saturate};
 ///
-/// fn main() {
-///     let a = Hsv::new(0.0, 0.25, 1.0);
-///     let b = Hsv::new(0.0, 1.0, 1.0);
+/// let a = Hsv::new(0.0, 0.25, 1.0);
+/// let b = Hsv::new(0.0, 1.0, 1.0);
 ///
-///     assert_relative_eq!(a.saturate(1.0), b.desaturate(0.5));
-/// }
+/// assert_relative_eq!(a.saturate(1.0), b.desaturate(0.5));
 /// ```
 pub trait Saturate: Sized {
-    ///The type of the (de)saturation factor.
+    /// The type of the (de)saturation factor.
     type Scalar: Float;
 
-    ///Increase the saturation by `factor`.
+    /// Increase the saturation by `factor`.
     fn saturate(&self, factor: Self::Scalar) -> Self;
 
-    ///Decrease the saturation by `factor`.
+    /// Decrease the saturation by `factor`.
     fn desaturate(&self, factor: Self::Scalar) -> Self {
         self.saturate(-factor)
     }
 }
 
-///Perform a unary or binary operation on each component of a color.
+/// Perform a unary or binary operation on each component of a color.
 pub trait ComponentWise {
-    ///The scalar type for color components.
+    /// The scalar type for color components.
     type Scalar;
 
-    ///Perform a binary operation on this and an other color.
+    /// Perform a binary operation on this and an other color.
     fn component_wise<F: FnMut(Self::Scalar, Self::Scalar) -> Self::Scalar>(
         &self,
         other: &Self,
         f: F,
     ) -> Self;
 
-    ///Perform a unary operation on this color.
+    /// Perform a unary operation on this color.
     fn component_wise_self<F: FnMut(Self::Scalar) -> Self::Scalar>(&self, f: F) -> Self;
 }
 

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -4,15 +4,15 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-use blend::PreAlpha;
-use encoding::linear::LinearFn;
-use encoding::pixel::RawPixel;
-use encoding::{Linear, Srgb, TransferFn};
-use luma::LumaStandard;
-use white_point::WhitePoint;
-use {clamp, contrast_ratio};
-use {Alpha, Xyz, Yxy};
-use {
+use crate::blend::PreAlpha;
+use crate::encoding::linear::LinearFn;
+use crate::encoding::pixel::RawPixel;
+use crate::encoding::{Linear, Srgb, TransferFn};
+use crate::luma::LumaStandard;
+use crate::white_point::WhitePoint;
+use crate::{clamp, contrast_ratio};
+use crate::{Alpha, Xyz, Yxy};
+use crate::{
     Blend, Component, ComponentWise, FloatComponent, FromColor, FromComponent, IntoColor, Limited,
     Mix, Pixel, RelativeContrast, Shade,
 };
@@ -21,13 +21,13 @@ use {
 /// in `Alpha`](struct.Alpha.html#Lumaa).
 pub type Lumaa<S = Srgb, T = f32> = Alpha<Luma<S, T>, T>;
 
-///Luminance.
+/// Luminance.
 ///
-///Luma is a purely gray scale color space, which is included more for
-///completeness than anything else, and represents how bright a color is
-///perceived to be. It's basically the `Y` component of [CIE
-///XYZ](struct.Xyz.html). The lack of any form of hue representation limits
-///the set of operations that can be performed on it.
+/// Luma is a purely gray scale color space, which is included more for
+/// completeness than anything else, and represents how bright a color is
+/// perceived to be. It's basically the `Y` component of [CIE
+/// XYZ](struct.Xyz.html). The lack of any form of hue representation limits
+/// the set of operations that can be performed on it.
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette_internal]
@@ -40,7 +40,7 @@ where
     T: Component,
     S: LumaStandard,
 {
-    ///The lightness of the color. 0.0 is black and 1.0 is white.
+    /// The lightness of the color. 0.0 is black and 1.0 is white.
     pub luma: T,
 
     /// The kind of RGB standard. sRGB is the default.
@@ -74,7 +74,7 @@ where
     /// Create a luminance color.
     pub fn new(luma: T) -> Luma<S, T> {
         Luma {
-            luma: luma,
+            luma,
             standard: PhantomData,
         }
     }
@@ -153,7 +153,7 @@ where
     pub fn new(luma: T, alpha: A) -> Self {
         Alpha {
             color: Luma::new(luma),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -742,8 +742,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use encoding::Srgb;
-    use Luma;
+    use crate::encoding::Srgb;
+    use crate::Luma;
 
     #[test]
     fn ranges() {

--- a/palette/src/luma/mod.rs
+++ b/palette/src/luma/mod.rs
@@ -2,8 +2,8 @@
 
 mod luma;
 
-use encoding::{Gamma, Linear, Srgb, TransferFn};
-use white_point::{WhitePoint, D65};
+use crate::encoding::{Gamma, Linear, Srgb, TransferFn};
+use crate::white_point::{WhitePoint, D65};
 
 pub use self::luma::{Luma, Lumaa};
 

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -23,8 +23,8 @@ macro_rules! raw_pixel_conversion_tests {
     };
 
     (@float_array_test $float: ty, $name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
-        use ::Pixel;
-        use ::Alpha;
+        use crate::Pixel;
+        use crate::Alpha;
 
         let mut counter: $float = 0.0;
         $(
@@ -50,8 +50,8 @@ macro_rules! raw_pixel_conversion_tests {
     };
 
     (@float_slice_test $float: ty, $name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
-        use ::Pixel;
-        use ::Alpha;
+        use crate::Pixel;
+        use crate::Alpha;
 
         let mut counter: $float = 0.0;
         $(
@@ -113,13 +113,13 @@ macro_rules! raw_pixel_conversion_fail_tests {
     };
 
     (@float_array_test $float: ty, $name: ident <$($ty_param: ident),+>) => {
-        use ::Pixel;
+        use crate::Pixel;
         let raw: [$float; 1] = [0.1];
         let _: $name<$($ty_param,)+ $float> = *$name::from_raw(&raw);
     };
 
     (@float_slice_test $float: ty, $name: ident <$($ty_param: ident),+>) => {
-        use ::Pixel;
+        use crate::Pixel;
         let raw: &[$float] = &[0.1];
         let _: $name<$($ty_param,)+ $float> = *$name::from_raw(raw);
     };

--- a/palette/src/matrix.rs
+++ b/palette/src/matrix.rs
@@ -1,20 +1,19 @@
-//!This module provides simple matrix operations on 3x3 matrix to aid in chromatic adaptation and
-//!conversion calculations.
-
-use float::Float;
+//! This module provides simple matrix operations on 3x3 matrix to aid in
+//! chromatic adaptation and conversion calculations.
 
 use core::marker::PhantomData;
 
-use convert::IntoColor;
-use encoding::Linear;
-use rgb::{Primaries, Rgb, RgbSpace};
-use white_point::WhitePoint;
-use {FloatComponent, Xyz};
+use crate::convert::IntoColor;
+use crate::encoding::Linear;
+use crate::float::Float;
+use crate::rgb::{Primaries, Rgb, RgbSpace};
+use crate::white_point::WhitePoint;
+use crate::{FloatComponent, Xyz};
 
-///A 9 element array representing a 3x3 matrix
+/// A 9 element array representing a 3x3 matrix
 pub type Mat3<T> = [T; 9];
 
-///Multiply the 3x3 matrix with the XYZ color
+/// Multiply the 3x3 matrix with the XYZ color
 pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Xyz<Swp, T>,
@@ -26,7 +25,7 @@ pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: FloatComponent>(
         white_point: PhantomData,
     }
 }
-///Multiply the 3x3 matrix with the XYZ color into RGB color
+/// Multiply the 3x3 matrix with the XYZ color into RGB color
 pub fn multiply_xyz_to_rgb<S: RgbSpace, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Xyz<S::WhitePoint, T>,
@@ -38,7 +37,7 @@ pub fn multiply_xyz_to_rgb<S: RgbSpace, T: FloatComponent>(
         standard: PhantomData,
     }
 }
-///Multiply the 3x3 matrix with the  RGB into XYZ color
+/// Multiply the 3x3 matrix with the  RGB into XYZ color
 pub fn multiply_rgb_to_xyz<S: RgbSpace, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Rgb<Linear<S>, T>,
@@ -51,7 +50,7 @@ pub fn multiply_rgb_to_xyz<S: RgbSpace, T: FloatComponent>(
     }
 }
 
-///Multiply a 3x3 matrix with another 3x3 matrix
+/// Multiply a 3x3 matrix with another 3x3 matrix
 pub fn multiply_3x3<T: Float>(c: &Mat3<T>, f: &Mat3<T>) -> Mat3<T> {
     let mut out = [T::zero(); 9];
     out[0] = c[0] * f[0] + c[1] * f[3] + c[2] * f[6];
@@ -69,7 +68,7 @@ pub fn multiply_3x3<T: Float>(c: &Mat3<T>, f: &Mat3<T>) -> Mat3<T> {
     out
 }
 
-///Invert a 3x3 matrix and panic if matrix is not invertable.
+/// Invert a 3x3 matrix and panic if matrix is not invertable.
 pub fn matrix_inverse<T: Float>(a: &Mat3<T>) -> Mat3<T> {
     let d0 = a[4] * a[8] - a[5] * a[7];
     let d1 = a[3] * a[8] - a[5] * a[6];
@@ -98,7 +97,7 @@ pub fn matrix_inverse<T: Float>(a: &Mat3<T>) -> Mat3<T> {
     ]
 }
 
-///Geneartes to Srgb to Xyz transformation matrix for the given white point
+/// Geneartes to Srgb to Xyz transformation matrix for the given white point
 pub fn rgb_to_xyz_matrix<S: RgbSpace, T: FloatComponent>() -> Mat3<T> {
     let r: Xyz<S::WhitePoint, T> = S::Primaries::red().into_xyz();
     let g: Xyz<S::WhitePoint, T> = S::Primaries::green().into_xyz();
@@ -123,7 +122,7 @@ pub fn rgb_to_xyz_matrix<S: RgbSpace, T: FloatComponent>() -> Mat3<T> {
     transform_matrix
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 fn mat3_from_primaries<T: FloatComponent, Wp: WhitePoint>(r: Xyz<Wp, T>, g: Xyz<Wp, T>, b: Xyz<Wp, T>) -> Mat3<T> {
     [
         r.x, g.x, b.x,
@@ -135,11 +134,11 @@ fn mat3_from_primaries<T: FloatComponent, Wp: WhitePoint>(r: Xyz<Wp, T>, g: Xyz<
 #[cfg(test)]
 mod test {
     use super::{matrix_inverse, multiply_3x3, multiply_xyz, rgb_to_xyz_matrix};
-    use chromatic_adaptation::AdaptInto;
-    use encoding::{Linear, Srgb};
-    use rgb::Rgb;
-    use white_point::D50;
-    use Xyz;
+    use crate::chromatic_adaptation::AdaptInto;
+    use crate::encoding::{Linear, Srgb};
+    use crate::rgb::Rgb;
+    use crate::white_point::D50;
+    use crate::Xyz;
 
     #[test]
     fn matrix_multiply_3x3() {
@@ -191,7 +190,7 @@ mod test {
         matrix_inverse(&input);
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn d65_rgb_conversion_matrix() {
         let expected = [

--- a/palette/src/named.rs
+++ b/palette/src/named.rs
@@ -1,31 +1,31 @@
-//!A collection of named color constants. Can be toggled with the `"named"` and `"named_from_str"`
-//!Cargo features.
+//! A collection of named color constants. Can be toggled with the `"named"` and
+//! `"named_from_str"` Cargo features.
 //!
-//!They are taken from the [SVG keyword
-//!colors](https://www.w3.org/TR/SVG/types.html#ColorKeywords) (same as in
-//!CSS3) and they can be used as if they were pixel values:
+//! They are taken from the [SVG keyword
+//! colors](https://www.w3.org/TR/SVG/types.html#ColorKeywords) (same as in
+//! CSS3) and they can be used as if they were pixel values:
 //!
-//!```
-//!use palette::Srgb;
-//!use palette::named;
+//! ```
+//! use palette::Srgb;
+//! use palette::named;
 //!
-//!//From constant
-//!let from_const = Srgb::<f32>::from_format(named::OLIVE).into_linear();
+//! //From constant
+//! let from_const = Srgb::<f32>::from_format(named::OLIVE).into_linear();
 #![cfg_attr(feature = "named_from_str", doc = "")]
 #![cfg_attr(feature = "named_from_str", doc = "//From name string")]
 #![cfg_attr(feature = "named_from_str", doc = "let olive = named::from_str(\"olive\").expect(\"unknown color\");")]
 #![cfg_attr(feature = "named_from_str", doc = "let from_str = Srgb::<f32>::from_format(olive).into_linear();")]
 #![cfg_attr(feature = "named_from_str", doc = "")]
 #![cfg_attr(feature = "named_from_str", doc = "assert_eq!(from_const, from_str);")]
-//!```
+//! ```
 
 include!(concat!(env!("OUT_DIR"), "/named.rs"));
 
-///Get a SVG/CSS3 color by name. Can be toggled with the `"named_from_str"`
-///Cargo feature.
+/// Get a SVG/CSS3 color by name. Can be toggled with the `"named_from_str"`
+/// Cargo feature.
 ///
-///The names are the same as the constants, but lower case.
+/// The names are the same as the constants, but lower case.
 #[cfg(feature = "named_from_str")]
-pub fn from_str(name: &str) -> Option<::Srgb<u8>> {
+pub fn from_str(name: &str) -> Option<crate::Srgb<u8>> {
     COLORS.get(name).cloned()
 }

--- a/palette/src/relative_contrast.rs
+++ b/palette/src/relative_contrast.rs
@@ -1,6 +1,7 @@
-use component::Component;
 use core::ops::{Add, Div};
-use {from_f64, FromF64};
+
+use crate::component::Component;
+use crate::{from_f64, FromF64};
 
 /// A trait for calculating relative contrast between two colors.
 ///
@@ -19,19 +20,14 @@ use {from_f64, FromF64};
 /// the contrast ratio of two colors in RGB format.
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate approx;
-///
 /// use std::str::FromStr;
 /// use palette::{Srgb, RelativeContrast};
 ///
-/// fn main() {
-///     // the rustdoc "DARK" theme background and text colors
-///     let my_background_rgb: Srgb<f32> = Srgb::from_str("#353535").unwrap().into_format();
-///     let my_foreground_rgb = Srgb::from_str("#ddd").unwrap().into_format();
+/// // the rustdoc "DARK" theme background and text colors
+/// let my_background_rgb: Srgb<f32> = Srgb::from_str("#353535").unwrap().into_format();
+/// let my_foreground_rgb = Srgb::from_str("#ddd").unwrap().into_format();
 ///
-///     assert!(my_background_rgb.has_enhanced_contrast_text(&my_foreground_rgb));
-/// }
+/// assert!(my_background_rgb.has_enhanced_contrast_text(&my_foreground_rgb));
 /// ```
 ///
 /// The possible range of contrast ratios is from 1:1 to 21:1. There is a
@@ -103,8 +99,9 @@ where
 #[cfg(test)]
 mod test {
     use core::str::FromStr;
-    use RelativeContrast;
-    use Srgb;
+
+    use crate::RelativeContrast;
+    use crate::Srgb;
 
     #[test]
     fn relative_contrast() {

--- a/palette/src/rgb/mod.rs
+++ b/palette/src/rgb/mod.rs
@@ -1,38 +1,37 @@
-//!RGB types, spaces and standards.
+//! RGB types, spaces and standards.
 
 use core::any::Any;
 
-use white_point::WhitePoint;
-use {Component, FloatComponent, FromComponent, Yxy};
-
-use encoding::{Linear, TransferFn};
+use crate::encoding::{self, Gamma, Linear, TransferFn};
+use crate::white_point::WhitePoint;
+use crate::{Component, FloatComponent, FromComponent, Yxy};
 
 pub use self::rgb::{Rgb, Rgba};
 
 //mod linear;
 mod rgb;
 
-///Nonlinear sRGB.
-pub type Srgb<T = f32> = Rgb<::encoding::Srgb, T>;
-///Nonlinear sRGB with an alpha component.
-pub type Srgba<T = f32> = Rgba<::encoding::Srgb, T>;
+/// Nonlinear sRGB.
+pub type Srgb<T = f32> = Rgb<encoding::Srgb, T>;
+/// Nonlinear sRGB with an alpha component.
+pub type Srgba<T = f32> = Rgba<encoding::Srgb, T>;
 
-///Linear sRGB.
-pub type LinSrgb<T = f32> = Rgb<Linear<::encoding::Srgb>, T>;
-///Linear sRGB with an alpha component.
-pub type LinSrgba<T = f32> = Rgba<Linear<::encoding::Srgb>, T>;
+/// Linear sRGB.
+pub type LinSrgb<T = f32> = Rgb<Linear<encoding::Srgb>, T>;
+/// Linear sRGB with an alpha component.
+pub type LinSrgba<T = f32> = Rgba<Linear<encoding::Srgb>, T>;
 
 /// Gamma 2.2 encoded sRGB.
-pub type GammaSrgb<T = f32> = Rgb<::encoding::Gamma<::encoding::Srgb>, T>;
+pub type GammaSrgb<T = f32> = Rgb<Gamma<encoding::Srgb>, T>;
 /// Gamma 2.2 encoded sRGB with an alpha component.
-pub type GammaSrgba<T = f32> = Rgba<::encoding::Gamma<::encoding::Srgb>, T>;
+pub type GammaSrgba<T = f32> = Rgba<Gamma<encoding::Srgb>, T>;
 
-///An RGB space and a transfer function.
+/// An RGB space and a transfer function.
 pub trait RgbStandard {
-    ///The RGB color space.
+    /// The RGB color space.
     type Space: RgbSpace;
 
-    ///The transfer function for the color components.
+    /// The transfer function for the color components.
     type TransferFn: TransferFn;
 }
 
@@ -46,12 +45,12 @@ impl<P: Primaries, W: WhitePoint, T: TransferFn> RgbStandard for (P, W, T) {
     type TransferFn = T;
 }
 
-///A set of primaries and a white point.
+/// A set of primaries and a white point.
 pub trait RgbSpace {
-    ///The primaries of the RGB color space.
+    /// The primaries of the RGB color space.
     type Primaries: Primaries;
 
-    ///The white point of the RGB color space.
+    /// The white point of the RGB color space.
     type WhitePoint: WhitePoint;
 }
 
@@ -60,13 +59,13 @@ impl<P: Primaries, W: WhitePoint> RgbSpace for (P, W) {
     type WhitePoint = W;
 }
 
-///Represents the red, green and blue primaries of an RGB space.
+/// Represents the red, green and blue primaries of an RGB space.
 pub trait Primaries: Any {
-    ///Primary red.
+    /// Primary red.
     fn red<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T>;
-    ///Primary green.
+    /// Primary green.
     fn green<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T>;
-    ///Primary blue.
+    /// Primary blue.
     fn blue<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T>;
 }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -7,22 +7,22 @@ use core::str::FromStr;
 
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-use alpha::Alpha;
-use blend::PreAlpha;
-use convert::{FromColor, IntoColor};
-use encoding::linear::LinearFn;
-use encoding::pixel::RawPixel;
-use encoding::{Linear, Srgb};
-use luma::LumaStandard;
-use matrix::{matrix_inverse, multiply_xyz_to_rgb, rgb_to_xyz_matrix};
-use rgb::{RgbSpace, RgbStandard, TransferFn};
-use white_point::WhitePoint;
-use {clamp, contrast_ratio, from_f64};
-use {
+use crate::alpha::Alpha;
+use crate::blend::PreAlpha;
+use crate::convert::{FromColor, IntoColor};
+use crate::encoding::linear::LinearFn;
+use crate::encoding::pixel::RawPixel;
+use crate::encoding::{Linear, Srgb};
+use crate::luma::LumaStandard;
+use crate::matrix::{matrix_inverse, multiply_xyz_to_rgb, rgb_to_xyz_matrix};
+use crate::rgb::{RgbSpace, RgbStandard, TransferFn};
+use crate::white_point::WhitePoint;
+use crate::{clamp, contrast_ratio, from_f64};
+use crate::{
     Blend, Component, ComponentWise, FloatComponent, FromComponent, GetHue, Limited, Mix, Pixel,
     RelativeContrast, Shade,
 };
-use {Hsl, Hsv, Hwb, Lab, Lch, Luma, RgbHue, Xyz, Yxy};
+use crate::{Hsl, Hsv, Hwb, Lab, Lch, Luma, RgbHue, Xyz, Yxy};
 
 /// Generic RGB with an alpha component. See the [`Rgba` implementation in
 /// `Alpha`](../struct.Alpha.html#Rgba).
@@ -78,9 +78,9 @@ impl<S: RgbStandard, T: Component> Rgb<S, T> {
     /// Create an RGB color.
     pub fn new(red: T, green: T, blue: T) -> Rgb<S, T> {
         Rgb {
-            red: red,
-            green: green,
-            blue: blue,
+            red,
+            green,
+            blue,
             standard: PhantomData,
         }
     }
@@ -188,7 +188,7 @@ impl<S: RgbStandard, T: Component, A: Component> Alpha<Rgb<S, T>, A> {
     pub fn new(red: T, green: T, blue: T, alpha: A) -> Self {
         Alpha {
             color: Rgb::new(red, green, blue),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -276,7 +276,7 @@ where
     S: RgbStandard,
     T: Component,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         self.red >= T::zero() && self.red <= T::max_intensity() &&
         self.green >= T::zero() && self.green <= T::max_intensity() &&
@@ -862,7 +862,7 @@ where
         T::default_max_relative()
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn relative_eq(
         &self,
         other: &Self,
@@ -885,7 +885,7 @@ where
         T::default_max_ulps()
     }
 
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
         self.red.ulps_eq(&other.red, epsilon, max_ulps) &&
             self.green.ulps_eq(&other.green, epsilon, max_ulps) &&
@@ -1059,8 +1059,8 @@ where
 #[cfg(test)]
 mod test {
     use super::Rgb;
+    use crate::encoding::Srgb;
     use core::str::FromStr;
-    use encoding::Srgb;
 
     #[test]
     fn ranges() {

--- a/palette/src/white_point.rs
+++ b/palette/src/white_point.rs
@@ -1,31 +1,34 @@
 //! Defines the tristimulus values of the CIE Illuminants.
 //!
-//! White point is the reference white or target white as seen by a standard observer under a
-//! standard illuminant. For example, photographs taken indoors may be lit by incandescent lights,
-//! which are relatively orange compared to daylight. Defining "white" as daylight will give
-//! unacceptable results when attempting to color-correct a photograph taken with incandescent
-//! lighting.
+//! White point is the reference white or target white as seen by a standard
+//! observer under a standard illuminant. For example, photographs taken indoors
+//! may be lit by incandescent lights, which are relatively orange compared to
+//! daylight. Defining "white" as daylight will give unacceptable results when
+//! attempting to color-correct a photograph taken with incandescent lighting.
 
-use {from_f64, FloatComponent, Xyz};
+use crate::{from_f64, FloatComponent, Xyz};
 
-///WhitePoint defines the Xyz color co-ordinates for a given white point.
+/// WhitePoint defines the Xyz color co-ordinates for a given white point.
 ///
-///A white point (often referred to as reference white or target white in technical documents)
-///is a set of tristimulus values or chromaticity coordinates that serve to define the color
-///"white" in image capture, encoding, or reproduction.
+/// A white point (often referred to as reference white or target white in
+/// technical documents) is a set of tristimulus values or chromaticity
+/// coordinates that serve to define the color "white" in image capture,
+/// encoding, or reproduction.
 ///
-///Custom white points can be easily defined on an empty struct with the tristimulus values
-///and can be used in place of the ones defined in this library.
+/// Custom white points can be easily defined on an empty struct with the
+/// tristimulus values and can be used in place of the ones defined in this
+/// library.
 pub trait WhitePoint {
-    ///Get the Xyz chromacity co-ordinates for the white point.
+    /// Get the Xyz chromacity co-ordinates for the white point.
     fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T>;
 }
 
 /// CIE standard illuminant A
 ///
-/// CIE standard illuminant A is intended to represent typical, domestic, tungsten-filament
-/// lighting. Its relative spectral power distribution is that of a Planckian radiator at a
-/// temperature of approximately 2856 K. Uses the CIE 1932 2° Standard Observer
+/// CIE standard illuminant A is intended to represent typical, domestic,
+/// tungsten-filament lighting. Its relative spectral power distribution is that
+/// of a Planckian radiator at a temperature of approximately 2856 K. Uses the
+/// CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct A;
 impl WhitePoint for A {
@@ -35,8 +38,8 @@ impl WhitePoint for A {
 }
 /// CIE standard illuminant B
 ///
-/// CIE standard illuminant B represents noon sunlight, with a correlated color temperature (CCT)
-/// of 4874 K Uses the CIE 1932 2° Standard Observer
+/// CIE standard illuminant B represents noon sunlight, with a correlated color
+/// temperature (CCT) of 4874 K Uses the CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct B;
 impl WhitePoint for B {
@@ -44,10 +47,10 @@ impl WhitePoint for B {
         Xyz::with_wp(from_f64(0.99072), T::one(), from_f64(0.85223))
     }
 }
-///CIE standard illuminant C
+/// CIE standard illuminant C
 ///
-///CIE standard illuminant C represents the average day light with a CCT of 6774 K
-///Uses the CIE 1932 2° Standard Observer
+/// CIE standard illuminant C represents the average day light with a CCT of
+/// 6774 K Uses the CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct C;
 impl WhitePoint for C {
@@ -55,10 +58,10 @@ impl WhitePoint for C {
         Xyz::with_wp(from_f64(0.98074), T::one(), from_f64(1.18232))
     }
 }
-///CIE D series standard illuminant - D50
+/// CIE D series standard illuminant - D50
 ///
-///D50 White Point is the natural daylight with a color temperature of around 5000K
-///for 2° Standard Observer.
+/// D50 White Point is the natural daylight with a color temperature of around
+/// 5000K for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50;
 impl WhitePoint for D50 {
@@ -66,10 +69,10 @@ impl WhitePoint for D50 {
         Xyz::with_wp(from_f64(0.96422), T::one(), from_f64(0.82521))
     }
 }
-///CIE D series standard illuminant - D55
+/// CIE D series standard illuminant - D55
 ///
-///D55 White Point is the natural daylight with a color temperature of around 5500K
-///for 2° Standard Observer.
+/// D55 White Point is the natural daylight with a color temperature of around
+/// 5500K for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55;
 impl WhitePoint for D55 {
@@ -77,10 +80,10 @@ impl WhitePoint for D55 {
         Xyz::with_wp(from_f64(0.95682), T::one(), from_f64(0.92149))
     }
 }
-///CIE D series standard illuminant - D65
+/// CIE D series standard illuminant - D65
 ///
-///D65 White Point is the natural daylight with a color temperature of 6500K
-///for 2° Standard Observer.
+/// D65 White Point is the natural daylight with a color temperature of 6500K
+/// for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65;
 impl WhitePoint for D65 {
@@ -88,10 +91,10 @@ impl WhitePoint for D65 {
         Xyz::with_wp(from_f64(0.95047), T::one(), from_f64(1.08883))
     }
 }
-///CIE D series standard illuminant - D75
+/// CIE D series standard illuminant - D75
 ///
-///D75 White Point is the natural daylight with a color temperature of around 7500K
-///for 2° Standard Observer.
+/// D75 White Point is the natural daylight with a color temperature of around
+/// 7500K for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75;
 impl WhitePoint for D75 {
@@ -99,10 +102,10 @@ impl WhitePoint for D75 {
         Xyz::with_wp(from_f64(0.94972), T::one(), from_f64(1.22638))
     }
 }
-///CIE standard illuminant E
+/// CIE standard illuminant E
 ///
-///CIE standard illuminant E represents the equal energy radiator
-///Uses the CIE 1932 2° Standard Observer
+/// CIE standard illuminant E represents the equal energy radiator
+/// Uses the CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct E;
 impl WhitePoint for E {
@@ -110,9 +113,9 @@ impl WhitePoint for E {
         Xyz::with_wp(T::one(), T::one(), T::one())
     }
 }
-///CIE fluorescent illuminant series - F2
+/// CIE fluorescent illuminant series - F2
 ///
-///F2 represents a semi-broadband fluorescent lamp for 2° Standard Observer.
+/// F2 represents a semi-broadband fluorescent lamp for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F2;
 impl WhitePoint for F2 {
@@ -120,9 +123,9 @@ impl WhitePoint for F2 {
         Xyz::with_wp(from_f64(0.99186), T::one(), from_f64(0.67393))
     }
 }
-///CIE fluorescent illuminant series - F7
+/// CIE fluorescent illuminant series - F7
 ///
-///F7 represents a broadband fluorescent lamp for 2° Standard Observer.
+/// F7 represents a broadband fluorescent lamp for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F7;
 impl WhitePoint for F7 {
@@ -130,9 +133,9 @@ impl WhitePoint for F7 {
         Xyz::with_wp(from_f64(0.95041), T::one(), from_f64(1.08747))
     }
 }
-///CIE fluorescent illuminant series - F11
+/// CIE fluorescent illuminant series - F11
 ///
-///F11 represents a narrowband fluorescent lamp for 2° Standard Observer.
+/// F11 represents a narrowband fluorescent lamp for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F11;
 impl WhitePoint for F11 {
@@ -140,10 +143,10 @@ impl WhitePoint for F11 {
         Xyz::with_wp(from_f64(1.00962), T::one(), from_f64(0.64350))
     }
 }
-///CIE D series standard illuminant - D50
+/// CIE D series standard illuminant - D50
 ///
-///D50 White Point is the natural daylight with a color temperature of around 5000K
-///for 10° Standard Observer.
+/// D50 White Point is the natural daylight with a color temperature of around
+/// 5000K for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50Degree10;
 impl WhitePoint for D50Degree10 {
@@ -151,10 +154,10 @@ impl WhitePoint for D50Degree10 {
         Xyz::with_wp(from_f64(0.9672), T::one(), from_f64(0.8143))
     }
 }
-///CIE D series standard illuminant - D55
+/// CIE D series standard illuminant - D55
 ///
-///D55 White Point is the natural daylight with a color temperature of around 5500K
-///for 10° Standard Observer.
+/// D55 White Point is the natural daylight with a color temperature of around
+/// 5500K for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55Degree10;
 impl WhitePoint for D55Degree10 {
@@ -162,10 +165,10 @@ impl WhitePoint for D55Degree10 {
         Xyz::with_wp(from_f64(0.958), T::one(), from_f64(0.9093))
     }
 }
-///CIE D series standard illuminant - D65
+/// CIE D series standard illuminant - D65
 ///
-///D65 White Point is the natural daylight with a color temperature of 6500K
-///for 10° Standard Observer.
+/// D65 White Point is the natural daylight with a color temperature of 6500K
+/// for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65Degree10;
 impl WhitePoint for D65Degree10 {
@@ -173,10 +176,10 @@ impl WhitePoint for D65Degree10 {
         Xyz::with_wp(from_f64(0.9481), T::one(), from_f64(1.073))
     }
 }
-///CIE D series standard illuminant - D75
+/// CIE D series standard illuminant - D75
 ///
-///D75 White Point is the natural daylight with a color temperature of around 7500K
-///for 10° Standard Observer.
+/// D75 White Point is the natural daylight with a color temperature of around
+/// 7500K for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75Degree10;
 impl WhitePoint for D75Degree10 {

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -1,27 +1,29 @@
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use encoding::pixel::RawPixel;
-use luma::LumaStandard;
-use matrix::{multiply_rgb_to_xyz, rgb_to_xyz_matrix};
-use rgb::{Rgb, RgbSpace, RgbStandard};
-use white_point::{WhitePoint, D65};
-use {clamp, contrast_ratio, from_f64};
-use {Alpha, Lab, Luma, Yxy};
-use {Component, ComponentWise, FloatComponent, Limited, Mix, Pixel, RelativeContrast, Shade};
+use crate::encoding::pixel::RawPixel;
+use crate::luma::LumaStandard;
+use crate::matrix::{multiply_rgb_to_xyz, rgb_to_xyz_matrix};
+use crate::rgb::{Rgb, RgbSpace, RgbStandard};
+use crate::white_point::{WhitePoint, D65};
+use crate::{clamp, contrast_ratio, from_f64};
+use crate::{Alpha, Lab, Luma, Yxy};
+use crate::{
+    Component, ComponentWise, FloatComponent, Limited, Mix, Pixel, RelativeContrast, Shade,
+};
 
 /// CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in
 /// `Alpha`](struct.Alpha.html#Xyza).
 pub type Xyza<Wp = D65, T = f32> = Alpha<Xyz<Wp, T>, T>;
 
-///The CIE 1931 XYZ color space.
+/// The CIE 1931 XYZ color space.
 ///
-///XYZ links the perceived colors to their wavelengths and simply makes it
-///possible to describe the way we see colors as numbers. It's often used when
-///converting from one color space to an other, and requires a standard
-///illuminant and a standard observer to be defined.
+/// XYZ links the perceived colors to their wavelengths and simply makes it
+/// possible to describe the way we see colors as numbers. It's often used when
+/// converting from one color space to an other, and requires a standard
+/// illuminant and a standard observer to be defined.
 ///
-///Conversions and operations on this color space depend on the defined white
+/// Conversions and operations on this color space depend on the defined white
 /// point
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -35,21 +37,21 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///X is the scale of what can be seen as a response curve for the cone
-    ///cells in the human eye. Its range depends
-    ///on the white point and goes from 0.0 to 0.95047 for the default D65.
+    /// X is the scale of what can be seen as a response curve for the cone
+    /// cells in the human eye. Its range depends
+    /// on the white point and goes from 0.0 to 0.95047 for the default D65.
     pub x: T,
 
-    ///Y is the luminance of the color, where 0.0 is black and 1.0 is white.
+    /// Y is the luminance of the color, where 0.0 is black and 1.0 is white.
     pub y: T,
 
-    ///Z is the scale of what can be seen as the blue stimulation. Its range
+    /// Z is the scale of what can be seen as the blue stimulation. Its range
     /// depends on the white point and goes from 0.0 to 1.08883 for the
     /// defautl D65.
     pub z: T,
 
-    ///The white point associated with the color's illuminant and observer.
-    ///D65 for 2 degree observer is used by default.
+    /// The white point associated with the color's illuminant and observer.
+    /// D65 for 2 degree observer is used by default.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub white_point: PhantomData<Wp>,
@@ -76,12 +78,12 @@ impl<T> Xyz<D65, T>
 where
     T: FloatComponent,
 {
-    ///CIE XYZ with whtie point D65.
+    /// CIE XYZ with whtie point D65.
     pub fn new(x: T, y: T, z: T) -> Xyz<D65, T> {
         Xyz {
-            x: x,
-            y: y,
-            z: z,
+            x,
+            y,
+            z,
             white_point: PhantomData,
         }
     }
@@ -92,12 +94,12 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///CIE XYZ.
+    /// CIE XYZ.
     pub fn with_wp(x: T, y: T, z: T) -> Xyz<Wp, T> {
         Xyz {
-            x: x,
-            y: y,
-            z: z,
+            x,
+            y,
+            z,
             white_point: PhantomData,
         }
     }
@@ -119,11 +121,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///CIE Yxy and transparency with white point D65.
+    /// CIE Yxy and transparency with white point D65.
     pub fn new(x: T, y: T, luma: T, alpha: A) -> Self {
         Alpha {
             color: Xyz::new(x, y, luma),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -135,11 +137,11 @@ where
     A: Component,
     Wp: WhitePoint,
 {
-    ///CIE XYZ and transparency.
+    /// CIE XYZ and transparency.
     pub fn with_wp(x: T, y: T, z: T, alpha: A) -> Self {
         Alpha {
             color: Xyz::with_wp(x, y, z),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -252,7 +254,7 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         let xyz_ref: Self = Wp::get_xyz();
         self.x >= T::zero() && self.x <= xyz_ref.x &&
@@ -615,9 +617,9 @@ where
 #[cfg(test)]
 mod test {
     use super::Xyz;
-    use white_point::D65;
-    use LinLuma;
-    use LinSrgb;
+    use crate::white_point::D65;
+    use crate::LinLuma;
+    use crate::LinSrgb;
     const X_N: f64 = 0.95047;
     const Y_N: f64 = 1.0;
     const Z_N: f64 = 1.08883;

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -1,12 +1,12 @@
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-use encoding::pixel::RawPixel;
-use luma::LumaStandard;
-use white_point::{WhitePoint, D65};
-use {clamp, contrast_ratio};
-use {Alpha, Luma, Xyz};
-use {
+use crate::encoding::pixel::RawPixel;
+use crate::luma::LumaStandard;
+use crate::white_point::{WhitePoint, D65};
+use crate::{clamp, contrast_ratio};
+use crate::{Alpha, Luma, Xyz};
+use crate::{
     Component, ComponentWise, FloatComponent, IntoColor, Limited, Mix, Pixel, RelativeContrast,
     Shade,
 };
@@ -15,13 +15,13 @@ use {
 /// in `Alpha`](struct.Alpha.html#Yxya).
 pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 
-///The CIE 1931 Yxy (xyY)  color space.
+/// The CIE 1931 Yxy (xyY)  color space.
 ///
-///Yxy is a luminance-chromaticity color space derived from the CIE XYZ
-///color space. It is widely used to define colors. The chromacity diagrams
-///for the color spaces are a plot of this color space's x and y coordiantes.
+/// Yxy is a luminance-chromaticity color space derived from the CIE XYZ
+/// color space. It is widely used to define colors. The chromacity diagrams
+/// for the color spaces are a plot of this color space's x and y coordiantes.
 ///
-///Conversions and operations on this color space depend on the white point.
+/// Conversions and operations on this color space depend on the white point.
 #[derive(Debug, PartialEq, FromColor, Pixel)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette_internal]
@@ -34,21 +34,21 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///x chromacity co-ordinate derived from XYZ color space as X/(X+Y+Z).
-    ///Typical range is between 0 and 1
+    /// x chromacity co-ordinate derived from XYZ color space as X/(X+Y+Z).
+    /// Typical range is between 0 and 1
     pub x: T,
 
-    ///y chromacity co-ordinate derived from XYZ color space as Y/(X+Y+Z).
-    ///Typical range is between 0 and 1
+    /// y chromacity co-ordinate derived from XYZ color space as Y/(X+Y+Z).
+    /// Typical range is between 0 and 1
     pub y: T,
 
-    ///luma (Y) was a measure of the brightness or luminance of a color.
-    ///It is the same as the Y from the XYZ color space. Its range is from
+    /// luma (Y) was a measure of the brightness or luminance of a color.
+    /// It is the same as the Y from the XYZ color space. Its range is from
     ///0 to 1, where 0 is black and 1 is white.
     pub luma: T,
 
-    ///The white point associated with the color's illuminant and observer.
-    ///D65 for 2 degree observer is used by default.
+    /// The white point associated with the color's illuminant and observer.
+    /// D65 for 2 degree observer is used by default.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette_unsafe_zero_sized]
     pub white_point: PhantomData<Wp>,
@@ -75,12 +75,12 @@ impl<T> Yxy<D65, T>
 where
     T: FloatComponent,
 {
-    ///CIE Yxy with white point D65.
+    /// CIE Yxy with white point D65.
     pub fn new(x: T, y: T, luma: T) -> Yxy<D65, T> {
         Yxy {
-            x: x,
-            y: y,
-            luma: luma,
+            x,
+            y,
+            luma,
             white_point: PhantomData,
         }
     }
@@ -91,12 +91,12 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    ///CIE Yxy.
+    /// CIE Yxy.
     pub fn with_wp(x: T, y: T, luma: T) -> Yxy<Wp, T> {
         Yxy {
-            x: x,
-            y: y,
-            luma: luma,
+            x,
+            y,
+            luma,
             white_point: PhantomData,
         }
     }
@@ -118,11 +118,11 @@ where
     T: FloatComponent,
     A: Component,
 {
-    ///CIE Yxy and transparency with white point D65.
+    /// CIE Yxy and transparency with white point D65.
     pub fn new(x: T, y: T, luma: T, alpha: A) -> Self {
         Alpha {
             color: Yxy::new(x, y, luma),
-            alpha: alpha,
+            alpha,
         }
     }
 }
@@ -133,11 +133,11 @@ where
     A: Component,
     Wp: WhitePoint,
 {
-    ///CIE Yxy and transparency.
+    /// CIE Yxy and transparency.
     pub fn with_wp(x: T, y: T, luma: T, alpha: A) -> Self {
         Alpha {
             color: Yxy::with_wp(x, y, luma),
-            alpha: alpha,
+            alpha,
         }
     }
 
@@ -216,7 +216,7 @@ where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     fn is_valid(&self) -> bool {
         self.x >= T::zero() && self.x <= T::one() &&
         self.y >= T::zero() && self.y <= T::one() &&
@@ -584,9 +584,9 @@ where
 #[cfg(test)]
 mod test {
     use super::Yxy;
-    use white_point::D65;
-    use LinLuma;
-    use LinSrgb;
+    use crate::white_point::D65;
+    use crate::LinLuma;
+    use crate::LinSrgb;
 
     #[test]
     fn luma() {

--- a/palette/tests/color_checker.rs
+++ b/palette/tests/color_checker.rs
@@ -1,12 +1,1 @@
-#[macro_use]
-extern crate approx;
-#[macro_use]
-extern crate lazy_static;
-extern crate num_traits;
-#[macro_use]
-extern crate serde_derive;
-extern crate csv;
-extern crate palette;
-extern crate serde;
-
 mod color_checker_data;

--- a/palette/tests/color_checker_data/babel.rs
+++ b/palette/tests/color_checker_data/babel.rs
@@ -6,6 +6,9 @@ The Rgb colors in this data appear to be adapted to the D50 white_point from the
 
 */
 
+use approx::assert_relative_eq;
+use lazy_static::lazy_static;
+
 use palette::white_point::D50;
 use palette::{IntoColor, Lab, Xyz, Yxy};
 

--- a/palette/tests/color_checker_data/color_checker.rs
+++ b/palette/tests/color_checker_data/color_checker.rs
@@ -6,6 +6,9 @@ The Rgb colors in this data appear to be adapted to the reference white point fo
 
 */
 
+use approx::assert_relative_eq;
+use lazy_static::lazy_static;
+
 use palette::white_point::D50;
 use palette::{IntoColor, Lab, Xyz, Yxy};
 

--- a/palette/tests/color_checker_data/load_data.rs
+++ b/palette/tests/color_checker_data/load_data.rs
@@ -1,4 +1,5 @@
 use csv;
+use serde_derive::Deserialize;
 
 use super::babel::BabelData;
 use super::color_checker::ColorCheckerData;

--- a/palette/tests/color_convert.rs
+++ b/palette/tests/color_convert.rs
@@ -1,11 +1,1 @@
-#[macro_use]
-extern crate approx;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate serde_derive;
-extern crate csv;
-extern crate palette;
-extern crate serde;
-
 mod convert;

--- a/palette/tests/convert/data_cie_15_2004.rs
+++ b/palette/tests/convert/data_cie_15_2004.rs
@@ -6,7 +6,10 @@ https://law.resource.org/pub/us/cfr/ibr/003/cie.15.2004.pdf
 Tests XYZ and YXY conversion
 */
 
+use approx::assert_relative_eq;
 use csv;
+use serde_derive::Deserialize;
+
 use palette::white_point::D65;
 use palette::{IntoColor, Xyz, Yxy};
 

--- a/palette/tests/convert/data_ciede_2000.rs
+++ b/palette/tests/convert/data_ciede_2000.rs
@@ -9,12 +9,13 @@ Note: Test uses `f64` because `f32` failed Travis CI builds on Linux for Lch on
         MacOS and Windows passed the tests so be wary when using f32 on Linux.
 */
 
-extern crate approx;
-
 use csv;
+
+use approx::assert_relative_eq;
+use serde_derive::Deserialize;
+
 use palette::white_point::D65;
-use palette::ColorDifference;
-use palette::{Lab, Lch};
+use palette::{ColorDifference, Lab, Lch};
 
 #[derive(Deserialize, PartialEq)]
 struct Cie2000Raw {

--- a/palette/tests/convert/data_color_mine.rs
+++ b/palette/tests/convert/data_color_mine.rs
@@ -2,6 +2,11 @@
 List of color from www.colormine.org
 */
 use csv;
+
+use approx::assert_relative_eq;
+use lazy_static::lazy_static;
+use serde_derive::Deserialize;
+
 use palette::white_point::D65;
 use palette::{Hsl, Hsv, Hwb, IntoColor, Lab, Lch, LinSrgb, Srgb, Xyz, Yxy};
 

--- a/palette/tests/convert/lab_lch.rs
+++ b/palette/tests/convert/lab_lch.rs
@@ -1,3 +1,5 @@
+use approx::assert_relative_eq;
+
 use palette::{IntoColor, Lab, Lch};
 
 #[test]

--- a/palette/tests/pointer_convert.rs
+++ b/palette/tests/pointer_convert.rs
@@ -1,12 +1,1 @@
-#[macro_use]
-extern crate approx;
-#[macro_use]
-extern crate lazy_static;
-extern crate num_traits;
-#[macro_use]
-extern crate serde_derive;
-extern crate csv;
-extern crate palette;
-extern crate serde;
-
 mod pointer_dataset;

--- a/palette/tests/pointer_dataset/pointer_data.rs
+++ b/palette/tests/pointer_dataset/pointer_data.rs
@@ -11,8 +11,12 @@ u', v'		0.2008907213	0.4608888395
 Note: The xyz and yxy conversions do not use the updated conversion formula. So they are not used.
 */
 
+use approx::assert_relative_eq;
 use csv;
+use lazy_static::lazy_static;
 use num_traits::{NumCast, ToPrimitive};
+use serde_derive::Deserialize;
+
 use palette::float::Float;
 use palette::white_point::WhitePoint;
 use palette::{FloatComponent, IntoColor, Lab, Lch, Xyz};
@@ -25,7 +29,7 @@ impl WhitePoint for PointerWP {
     }
 }
 
-///A convenience function to convert a constant number to Float Type
+/// A convenience function to convert a constant number to Float Type
 fn flt<T: Float, P: ToPrimitive>(prim: P) -> T {
     NumCast::from(prim).unwrap()
 }

--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Ogeon/palette"
 readme = "README.md"
 keywords = ["palette", "derive", "macros"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/palette_derive/src/convert/from_color.rs
+++ b/palette_derive/src/convert/from_color.rs
@@ -1,13 +1,14 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use syn::{parse_macro_input, DeriveInput, Generics, Ident, Type};
+use quote::quote;
 
-use meta::{self, DataMetaParser, IdentOrIndex, KeyValuePair, MetaParser};
-use util;
+use crate::meta::{self, DataMetaParser, IdentOrIndex, KeyValuePair, MetaParser};
+use crate::util;
 
 use super::shared::{self, ConvertDirection};
 
-use COLOR_TYPES;
+use crate::COLOR_TYPES;
 
 pub fn derive(tokens: TokenStream) -> TokenStream {
     let DeriveInput {

--- a/palette_derive/src/convert/into_color.rs
+++ b/palette_derive/src/convert/into_color.rs
@@ -1,10 +1,11 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use syn::{parse_macro_input, DeriveInput, Generics, Ident, Type};
+use quote::quote;
 
-use meta::{self, DataMetaParser, IdentOrIndex, KeyValuePair, MetaParser};
-use util;
-use COLOR_TYPES;
+use crate::meta::{self, DataMetaParser, IdentOrIndex, KeyValuePair, MetaParser};
+use crate::util;
+use crate::COLOR_TYPES;
 
 use super::shared::{self, ConvertDirection};
 

--- a/palette_derive/src/convert/shared.rs
+++ b/palette_derive/src/convert/shared.rs
@@ -2,9 +2,10 @@ use std::fmt;
 
 use proc_macro2::{Span, TokenStream};
 use syn::{parse_quote, GenericParam, Generics, Ident, Path, Turbofish, Type, TypePath};
+use quote::quote;
 
-use meta::KeyValuePair;
-use util;
+use crate::meta::KeyValuePair;
+use crate::util;
 
 pub fn find_in_generics(
     component: Option<&Type>,

--- a/palette_derive/src/encoding/pixel.rs
+++ b/palette_derive/src/encoding/pixel.rs
@@ -2,11 +2,11 @@ use std::collections::{HashMap, HashSet};
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::{parse_macro_input, Data, DeriveInput, Fields, Ident, Type};
 
-use meta::{self, DataMetaParser, IdentOrIndex, MetaParser};
-use util;
+use crate::meta::{self, DataMetaParser, IdentOrIndex, MetaParser};
+use crate::util;
 
 pub fn derive(tokens: TokenStream) -> TokenStream {
     let DeriveInput {

--- a/palette_derive/src/lib.rs
+++ b/palette_derive/src/lib.rs
@@ -4,10 +4,6 @@
 #![recursion_limit = "128"]
 
 extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-extern crate syn;
 
 use proc_macro::TokenStream;
 

--- a/palette_derive/src/util.rs
+++ b/palette_derive/src/util.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use syn::{parse_quote, Ident, Type};
+use quote::quote;
 
 pub fn bundle_impl(
     trait_name: &str,
@@ -16,7 +17,7 @@ pub fn bundle_impl(
         quote! {
             #[allow(non_snake_case, unused_attributes, unused_qualifications, unused_imports)]
             mod #const_name {
-                use float::Float as _FloatTrait;
+                use crate::float::Float as _FloatTrait;
                 use super::*;
                 #block
             }
@@ -40,7 +41,7 @@ pub fn path(path: &[&str], internal: bool) -> TokenStream {
         .map(|&ident| Ident::new(ident, Span::call_site()));
 
     if internal {
-        quote! {::#(#path)::*}
+        quote! {crate::#(#path)::*}
     } else {
         quote! {self::_palette::#(#path)::*}
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-wrap_comments = true
-comment_width = 80


### PR DESCRIPTION
Update `palette` to 2018 edition
Update `palette_derive` and `no_std_test` to 2018 edition
Apply selected cargo clippy lints
- `#[cfg_attr(rustfmt, rustfmt_skip)]` to `#[rustfmt::skip]`
- remove redundant names in struct assignment for variables with same name: `value: value,` becomes `value,`

Remove `extern crate` when applicable
Replace `#[macro_use]` with `use {crate}::{macro}`
Remove needless `fn main()` in doctests
Fix spacing and wrapping in comments
Change 4 expects to unwrap_or_else in build/named.rs
Remove rustfmt.toml until rustfmt 2.0 stabilizes wrapping comments