### PR TITLE
Update cargo manifest keywords, categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Ogeon/palette.svg?branch=master)](https://travis-ci.org/Ogeon/palette)
 [![Crates.io](https://img.shields.io/crates/v/palette.svg)](https://crates.io/crates/palette/)
+[![Docs.rs](https://docs.rs/palette/badge.svg)](https://docs.rs/palette)
 
 A Rust library that makes linear color calculations and conversion easy and accessible for anyone. It provides both precision tools that lets you work in exactly the color space you want to, as well as a general color type that abstracts away some of the technical details.
 

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -7,9 +7,10 @@ description = "Makes linear color calculations and conversion easy and accessibl
 documentation = "https://docs.rs/palette/0.5.0/palette/"
 repository = "https://github.com/Ogeon/palette"
 readme = "README.md"
-keywords = ["color", "colour", "space", "linear"]
+keywords = ["color", "conversion", "linear", "pixel", "rgb"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+categories = ["graphics", "multimedia::images", "no-std"]
 
 build = "build/main.rs"
 
@@ -39,13 +40,19 @@ features = ["serde_derive"]
 optional = true
 
 [dev-dependencies]
-image = "0.22"
-clap = "2"
 csv = "1"
+lazy_static = "1"
 serde = "1"
 serde_derive = "1"
-lazy_static = "1"
 serde_json = "1"
+
+[dev-dependencies.clap]
+version = "2"
+default-features = false
+
+[dev-dependencies.image]
+version = "0.22"
+default-features = false
 
 [build-dependencies.phf_codegen]
 version = "0.8"

--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -20,6 +20,5 @@ quote = "^1.0"
 proc-macro2 = "^1.0"
 
 [features]
-
 #internal
 strict = []


### PR DESCRIPTION
Change `cargo.toml` keywords: `keywords = ["color", "conversion", "linear", "pixel", "rgb"]`
Add cateogries to `cargo.toml`: `categories = ["graphics", "multimedia::images", "no-std"]`
Reduce dev-dependencies features for crates used in `palette` examples, results in reduction from 131 to 82 crates built for `cargo test --features strict`
Add docs.rs badge to README.md

This addresses some parts of #167.