### PR TITLE
Add functions to get min/max component values for all color types, alpha

### DIFF
--- a/palette/src/alpha.rs
+++ b/palette/src/alpha.rs
@@ -24,6 +24,18 @@ pub struct Alpha<C, T> {
     pub alpha: T,
 }
 
+impl<C, T: Component> Alpha<C, T> {
+    /// Return the `alpha` value minimum.
+    pub fn min_alpha() -> T {
+        T::zero()
+    }
+
+    /// Return the `alpha` value maximum.
+    pub fn max_alpha() -> T {
+        T::max_intensity()
+    }
+}
+
 impl<C, T> Deref for Alpha<C, T> {
     type Target = C;
 
@@ -522,6 +534,12 @@ mod test {
             format!("{:03X}", Rgba::<Srgb, u64>::new(1, 2, 3, 4)),
             "001002003004"
         );
+    }
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Rgba::<Srgb>::min_alpha(), 0.0);
+        assert_relative_eq!(Rgba::<Srgb>::max_alpha(), 1.0);
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -177,6 +177,26 @@ where
             space: PhantomData,
         }
     }
+
+    /// Return the `saturation` value minimum.
+    pub fn min_saturation() -> T {
+        T::zero()
+    }
+
+    /// Return the `saturation` value maximum.
+    pub fn max_saturation() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `lightness` value minimum.
+    pub fn min_lightness() -> T {
+        T::zero()
+    }
+
+    /// Return the `lightness` value maximum.
+    pub fn max_lightness() -> T {
+        T::max_intensity()
+    }
 }
 
 ///<span id="Hsla"></span>[`Hsla`](type.Hsla.html) implementations.
@@ -710,6 +730,14 @@ mod test {
 
     raw_pixel_conversion_tests!(Hsl<Srgb>: hue, saturation, lightness);
     raw_pixel_conversion_fail_tests!(Hsl<Srgb>: hue, saturation, lightness);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Hsl::<Srgb>::min_saturation(), 0.0);
+        assert_relative_eq!(Hsl::<Srgb>::min_lightness(), 0.0);
+        assert_relative_eq!(Hsl::<Srgb>::max_saturation(), 1.0);
+        assert_relative_eq!(Hsl::<Srgb>::max_lightness(), 1.0);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -172,6 +172,26 @@ where
             space: PhantomData,
         }
     }
+
+    /// Return the `saturation` value minimum.
+    pub fn min_saturation() -> T {
+        T::zero()
+    }
+
+    /// Return the `saturation` value maximum.
+    pub fn max_saturation() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `value` value minimum.
+    pub fn min_value() -> T {
+        T::zero()
+    }
+
+    /// Return the `value` value maximum.
+    pub fn max_value() -> T {
+        T::max_intensity()
+    }
 }
 
 ///<span id="Hsva"></span>[`Hsva`](type.Hsva.html) implementations.
@@ -725,6 +745,14 @@ mod test {
 
     raw_pixel_conversion_tests!(Hsv<Srgb>: hue, saturation, value);
     raw_pixel_conversion_fail_tests!(Hsv<Srgb>: hue, saturation, value);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Hsv::<Srgb>::min_saturation(), 0.0,);
+        assert_relative_eq!(Hsv::<Srgb>::min_value(), 0.0,);
+        assert_relative_eq!(Hsv::<Srgb>::max_saturation(), 1.0,);
+        assert_relative_eq!(Hsv::<Srgb>::max_value(), 1.0,);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -138,6 +138,26 @@ where
             space: PhantomData,
         }
     }
+
+    /// Return the `whiteness` value minimum.
+    pub fn min_whiteness() -> T {
+        T::zero()
+    }
+
+    /// Return the `whiteness` value maximum.
+    pub fn max_whiteness() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `blackness` value minimum.
+    pub fn min_blackness() -> T {
+        T::zero()
+    }
+
+    /// Return the `blackness` value maximum.
+    pub fn max_blackness() -> T {
+        T::max_intensity()
+    }
 }
 
 ///<span id="Hwba"></span>[`Hwba`](type.Hwba.html) implementations.
@@ -675,6 +695,14 @@ mod test {
 
     raw_pixel_conversion_tests!(Hwb<Srgb>: hue, whiteness, blackness);
     raw_pixel_conversion_fail_tests!(Hwb<Srgb>: hue, whiteness, blackness);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Hwb::<Srgb>::min_whiteness(), 0.0,);
+        assert_relative_eq!(Hwb::<Srgb>::min_blackness(), 0.0,);
+        assert_relative_eq!(Hwb::<Srgb>::max_whiteness(), 1.0,);
+        assert_relative_eq!(Hwb::<Srgb>::max_blackness(), 1.0,);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -112,6 +112,36 @@ where
     pub fn from_components((l, a, b): (T, T, T)) -> Self {
         Self::with_wp(l, a, b)
     }
+
+    /// Return the `l` value minimum.
+    pub fn min_l() -> T {
+        T::zero()
+    }
+
+    /// Return the `l` value maximum.
+    pub fn max_l() -> T {
+        from_f64(100.0)
+    }
+
+    /// Return the `a` value minimum.
+    pub fn min_a() -> T {
+        from_f64(-128.0)
+    }
+
+    /// Return the `a` value maximum.
+    pub fn max_a() -> T {
+        from_f64(127.0)
+    }
+
+    /// Return the `b` value minimum.
+    pub fn min_b() -> T {
+        from_f64(-128.0)
+    }
+
+    /// Return the `b` value maximum.
+    pub fn max_b() -> T {
+        from_f64(127.0)
+    }
 }
 
 ///<span id="Laba"></span>[`Laba`](type.Laba.html) implementations.
@@ -684,6 +714,16 @@ mod test {
 
     raw_pixel_conversion_tests!(Lab<D65>: l, a, b);
     raw_pixel_conversion_fail_tests!(Lab<D65>: l, a, b);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Lab::<D65, f32>::min_l(), 0.0);
+        assert_relative_eq!(Lab::<D65, f32>::min_a(), -128.0);
+        assert_relative_eq!(Lab::<D65, f32>::min_b(), -128.0);
+        assert_relative_eq!(Lab::<D65, f32>::max_l(), 100.0);
+        assert_relative_eq!(Lab::<D65, f32>::max_a(), 127.0);
+        assert_relative_eq!(Lab::<D65, f32>::max_b(), 127.0);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -112,6 +112,35 @@ where
     pub fn from_components<H: Into<LabHue<T>>>((l, chroma, hue): (T, T, H)) -> Self {
         Self::with_wp(l, chroma, hue)
     }
+
+    /// Return the `l` value minimum.
+    pub fn min_l() -> T {
+        T::zero()
+    }
+
+    /// Return the `l` value maximum.
+    pub fn max_l() -> T {
+        from_f64(100.0)
+    }
+
+    /// Return the `chroma` value minimum.
+    pub fn min_chroma() -> T {
+        T::zero()
+    }
+
+    /// Return the `chroma` value maximum. This value does not cover the entire
+    /// color space, but covers enough to be practical for downsampling to
+    /// smaller color spaces like sRGB.
+    pub fn max_chroma() -> T {
+        from_f64(128.0)
+    }
+
+    /// Return the `chroma` extended maximum value. This value covers the entire
+    /// color space and is included for completeness, but the additional range
+    /// should be unnecessary for most use cases.
+    pub fn max_extended_chroma() -> T {
+        from_f64(crate::float::Float::sqrt(128.0f64 * 128.0 + 128.0 * 128.0))
+    }
 }
 
 ///<span id="Lcha"></span>[`Lcha`](type.Lcha.html) implementations.
@@ -556,6 +585,15 @@ mod test {
 
     raw_pixel_conversion_tests!(Lch<D65>: l, chroma, hue);
     raw_pixel_conversion_fail_tests!(Lch<D65>: l, chroma, hue);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Lch::<D65, f32>::min_l(), 0.0);
+        assert_relative_eq!(Lch::<D65, f32>::max_l(), 100.0);
+        assert_relative_eq!(Lch::<D65, f32>::min_chroma(), 0.0);
+        assert_relative_eq!(Lch::<D65, f32>::max_chroma(), 128.0);
+        assert_relative_eq!(Lch::<D65, f32>::max_extended_chroma(), 181.01933598375618);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -108,6 +108,16 @@ where
     pub fn from_components((luma,): (T,)) -> Self {
         Self::new(luma)
     }
+
+    /// Return the `luma` value minimum.
+    pub fn min_luma() -> T {
+        T::zero()
+    }
+
+    /// Return the `luma` value maximum.
+    pub fn max_luma() -> T {
+        T::max_intensity()
+    }
 }
 
 impl<S, T> Luma<S, T>
@@ -805,6 +815,12 @@ mod test {
         assert_eq!(format!("{:03X}", Luma::<Srgb, u16>::new(1)), "001");
         assert_eq!(format!("{:03X}", Luma::<Srgb, u32>::new(1)), "001");
         assert_eq!(format!("{:03X}", Luma::<Srgb, u64>::new(1)), "001");
+    }
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Luma::<Srgb, f32>::min_luma(), 0.0);
+        assert_relative_eq!(Luma::<Srgb, f32>::max_luma(), 1.0);
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -116,6 +116,36 @@ impl<S: RgbStandard, T: Component> Rgb<S, T> {
     pub fn from_components((red, green, blue): (T, T, T)) -> Self {
         Self::new(red, green, blue)
     }
+
+    /// Return the `red` value minimum.
+    pub fn min_red() -> T {
+        T::zero()
+    }
+
+    /// Return the `red` value maximum.
+    pub fn max_red() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `green` value minimum.
+    pub fn min_green() -> T {
+        T::zero()
+    }
+
+    /// Return the `green` value maximum.
+    pub fn max_green() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `blue` value minimum.
+    pub fn min_blue() -> T {
+        T::zero()
+    }
+
+    /// Return the `blue` value maximum.
+    pub fn max_blue() -> T {
+        T::max_intensity()
+    }
 }
 
 /// Convenience functions to convert between a packed `u32` and `Rgb`.
@@ -1314,5 +1344,15 @@ mod test {
         assert_eq!(c.unwrap(), Rgb::<Srgb, u8>::new(240, 52, 230));
         let c = Rgb::<Srgb, u8>::from_str("abc");
         assert_eq!(c.unwrap(), Rgb::<Srgb, u8>::new(170, 187, 204));
+    }
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Rgb::<Srgb, f32>::min_red(), 0.0);
+        assert_relative_eq!(Rgb::<Srgb, f32>::min_green(), 0.0);
+        assert_relative_eq!(Rgb::<Srgb, f32>::min_blue(), 0.0);
+        assert_relative_eq!(Rgb::<Srgb, f32>::max_red(), 1.0);
+        assert_relative_eq!(Rgb::<Srgb, f32>::max_green(), 1.0);
+        assert_relative_eq!(Rgb::<Srgb, f32>::max_blue(), 1.0);
     }
 }

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -113,6 +113,39 @@ where
     pub fn from_components((x, y, z): (T, T, T)) -> Self {
         Self::with_wp(x, y, z)
     }
+
+    /// Return the `x` value minimum.
+    pub fn min_x() -> T {
+        T::zero()
+    }
+
+    /// Return the `x` value maximum.
+    pub fn max_x() -> T {
+        let xyz_ref: Xyz<Wp, _> = Wp::get_xyz();
+        xyz_ref.x
+    }
+
+    /// Return the `y` value minimum.
+    pub fn min_y() -> T {
+        T::zero()
+    }
+
+    /// Return the `y` value maximum.
+    pub fn max_y() -> T {
+        let xyz_ref: Xyz<Wp, _> = Wp::get_xyz();
+        xyz_ref.y
+    }
+
+    /// Return the `z` value minimum.
+    pub fn min_z() -> T {
+        T::zero()
+    }
+
+    /// Return the `z` value maximum.
+    pub fn max_z() -> T {
+        let xyz_ref: Xyz<Wp, _> = Wp::get_xyz();
+        xyz_ref.z
+    }
 }
 
 ///<span id="Xyza"></span>[`Xyza`](type.Xyza.html) implementations.
@@ -618,8 +651,7 @@ where
 mod test {
     use super::Xyz;
     use crate::white_point::D65;
-    use crate::LinLuma;
-    use crate::LinSrgb;
+    use crate::{LinLuma, LinSrgb};
     const X_N: f64 = 0.95047;
     const Y_N: f64 = 1.0;
     const Z_N: f64 = 1.08883;
@@ -668,6 +700,16 @@ mod test {
 
     raw_pixel_conversion_tests!(Xyz<D65>: x, y, z);
     raw_pixel_conversion_fail_tests!(Xyz<D65>: x, y, z);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Xyz::<D65>::min_x(), 0.0);
+        assert_relative_eq!(Xyz::<D65>::min_y(), 0.0);
+        assert_relative_eq!(Xyz::<D65>::min_z(), 0.0);
+        assert_relative_eq!(Xyz::<D65, f64>::max_x(), X_N);
+        assert_relative_eq!(Xyz::<D65, f64>::max_y(), Y_N);
+        assert_relative_eq!(Xyz::<D65, f64>::max_z(), Z_N);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -110,6 +110,36 @@ where
     pub fn from_components((x, y, luma): (T, T, T)) -> Self {
         Self::with_wp(x, y, luma)
     }
+
+    /// Return the `x` value minimum.
+    pub fn min_x() -> T {
+        T::zero()
+    }
+
+    /// Return the `x` value maximum.
+    pub fn max_x() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `y` value minimum.
+    pub fn min_y() -> T {
+        T::zero()
+    }
+
+    /// Return the `y` value maximum.
+    pub fn max_y() -> T {
+        T::max_intensity()
+    }
+
+    /// Return the `luma` value minimum.
+    pub fn min_luma() -> T {
+        T::zero()
+    }
+
+    /// Return the `luma` value maximum.
+    pub fn max_luma() -> T {
+        T::max_intensity()
+    }
 }
 
 ///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
@@ -585,8 +615,7 @@ where
 mod test {
     use super::Yxy;
     use crate::white_point::D65;
-    use crate::LinLuma;
-    use crate::LinSrgb;
+    use crate::{LinLuma, LinSrgb};
 
     #[test]
     fn luma() {
@@ -632,6 +661,16 @@ mod test {
 
     raw_pixel_conversion_tests!(Yxy<D65>: x, y, luma);
     raw_pixel_conversion_fail_tests!(Yxy<D65>: x, y, luma);
+
+    #[test]
+    fn check_min_max_components() {
+        assert_relative_eq!(Yxy::<D65>::min_x(), 0.0);
+        assert_relative_eq!(Yxy::<D65>::min_y(), 0.0);
+        assert_relative_eq!(Yxy::<D65>::min_luma(), 0.0);
+        assert_relative_eq!(Yxy::<D65>::max_x(), 1.0);
+        assert_relative_eq!(Yxy::<D65>::max_y(), 1.0);
+        assert_relative_eq!(Yxy::<D65>::max_luma(), 1.0);
+    }
 
     #[cfg(feature = "serializing")]
     #[test]


### PR DESCRIPTION
Add functions to retrieve the maximum and minimum component values for all color types and alpha.
There are no functions for min/max values of Hue components since they are periodic and range from 0 to 360 degrees, 360 degrees not inclusive.
Lch and HWB are special cases:
- Lch `chroma` is fully saturated starting at 128 but continues to 181, so two max chroma functions are implemented.
- Hwb's whiteness and blackness components both have a max of 1 but they cannot simultaneously be 1. The sum of whiteness and blackness must be less than or equal to 1. 