### PR TITLE
Add feature "random" for random color generation using `rand` crate

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -18,6 +18,7 @@ build = "build/main.rs"
 default = ["named_from_str", "std"]
 named_from_str = ["named", "phf", "phf_codegen", "std"]
 named = []
+random = ["rand"]
 serializing = ["serde", "std"]
 
 #ignore in feature test
@@ -31,6 +32,11 @@ approx = {version = "0.3", default-features = false}
 
 [dependencies.phf]
 version = "0.8"
+optional = true
+
+[dependencies.rand]
+version = "0.7"
+default-features = false
 optional = true
 
 [dependencies.serde]

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -3,6 +3,12 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
+#[cfg(feature = "random")]
+use rand::distributions::uniform::{SampleBorrow, SampleUniform, Uniform, UniformSampler};
+#[cfg(feature = "random")]
+use rand::distributions::{Distribution, Standard};
+#[cfg(feature = "random")]
+use rand::Rng;
 
 use crate::encoding::pixel::RawPixel;
 use crate::encoding::{Linear, Srgb};
@@ -654,6 +660,98 @@ where
         let luma2 = other.into_luma();
 
         contrast_ratio(luma1.luma, luma2.luma)
+    }
+}
+
+#[cfg(feature = "random")]
+impl<S, T> Distribution<Hsl<S, T>> for Standard
+where
+    T: FloatComponent,
+    S: RgbSpace,
+    Standard: Distribution<T>,
+{
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Hsl<S, T> {
+        crate::random_sampling::sample_hsl(rng.gen::<RgbHue<T>>(), rng.gen(), rng.gen())
+    }
+}
+
+#[cfg(feature = "random")]
+pub struct UniformHsl<S, T>
+where
+    T: FloatComponent + SampleUniform,
+    S: RgbSpace + SampleUniform,
+{
+    hue: crate::hues::UniformRgbHue<T>,
+    u1: Uniform<T>,
+    u2: Uniform<T>,
+    space: PhantomData<S>,
+}
+
+#[cfg(feature = "random")]
+impl<S, T> SampleUniform for Hsl<S, T>
+where
+    T: FloatComponent + SampleUniform,
+    S: RgbSpace + SampleUniform,
+{
+    type Sampler = UniformHsl<S, T>;
+}
+
+#[cfg(feature = "random")]
+impl<S, T> UniformSampler for UniformHsl<S, T>
+where
+    T: FloatComponent + SampleUniform,
+    S: RgbSpace + SampleUniform,
+{
+    type X = Hsl<S, T>;
+
+    fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        use crate::random_sampling::invert_hsl_sample;
+
+        let low = *low_b.borrow();
+        let high = *high_b.borrow();
+
+        let (r1_min, r2_min) = invert_hsl_sample(low);
+        let (r1_max, r2_max) = invert_hsl_sample(high);
+
+        UniformHsl {
+            hue: crate::hues::UniformRgbHue::new(low.hue, high.hue),
+            u1: Uniform::new::<_, T>(r1_min, r1_max),
+            u2: Uniform::new::<_, T>(r2_min, r2_max),
+            space: PhantomData,
+        }
+    }
+
+    fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        use crate::random_sampling::invert_hsl_sample;
+
+        let low = *low_b.borrow();
+        let high = *high_b.borrow();
+
+        let (r1_min, r2_min) = invert_hsl_sample(low);
+        let (r1_max, r2_max) = invert_hsl_sample(high);
+
+        UniformHsl {
+            hue: crate::hues::UniformRgbHue::new_inclusive(low.hue, high.hue),
+            u1: Uniform::new_inclusive::<_, T>(r1_min, r1_max),
+            u2: Uniform::new_inclusive::<_, T>(r2_min, r2_max),
+            space: PhantomData,
+        }
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Hsl<S, T> {
+        crate::random_sampling::sample_hsl(
+            self.hue.sample(rng),
+            self.u1.sample(rng),
+            self.u2.sample(rng),
+        )
     }
 }
 

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -372,6 +372,9 @@ pub mod gradient;
 #[cfg(feature = "named")]
 pub mod named;
 
+#[cfg(feature = "random")]
+mod random_sampling;
+
 mod alpha;
 mod hsl;
 mod hsv;

--- a/palette/src/random_sampling/cone.rs
+++ b/palette/src/random_sampling/cone.rs
@@ -1,0 +1,133 @@
+use core::marker::PhantomData;
+
+use crate::float::Float;
+use crate::hues::RgbHue;
+use crate::rgb::RgbSpace;
+use crate::{from_f64, FloatComponent, Hsl, Hsv};
+
+// Based on https://stackoverflow.com/q/4778147 and https://math.stackexchange.com/q/18686,
+// picking A = (0, 0), B = (0, 1), C = (1, 1) gives us:
+//
+// (  sqrt(r1) * r2  ,  sqrt(r1) * (1 - r2) + sqrt(r1) * r2  ) =
+// (  sqrt(r1) * r2  ,  sqrt(r1) - sqrt(r1) * r2 + sqrt(r1) * r2  ) =
+// (  sqrt(r1) * r2  ,  sqrt(r1)  )
+//
+// `sqrt(r1)` gives us the scale of the triangle, `r2` the radius.
+// Substituting, we get `x = scale * radius, y = scale` and thus for cone
+// sampling: `scale = powf(r1, 1.0/3.0)` and `radius = sqrt(r2)`.
+
+pub fn sample_hsv<S, T>(hue: RgbHue<T>, r1: T, r2: T) -> Hsv<S, T>
+where
+    T: FloatComponent,
+    S: RgbSpace,
+{
+    let (value, saturation) = (Float::cbrt(r1), Float::sqrt(r2));
+
+    Hsv {
+        hue,
+        saturation,
+        value,
+        space: PhantomData,
+    }
+}
+
+pub fn sample_hsl<S, T>(hue: RgbHue<T>, r1: T, r2: T) -> Hsl<S, T>
+where
+    T: FloatComponent,
+    S: RgbSpace,
+{
+    let (saturation, lightness) = if r1 <= from_f64::<T>(0.5) {
+        // Scale it up to [0, 1]
+        let r1 = r1 * from_f64::<T>(2.0);
+        let h = Float::cbrt(r1);
+        let r = Float::sqrt(r2);
+        // Scale the lightness back to [0, 0.5]
+        (r, h * from_f64::<T>(0.5))
+    } else {
+        // Scale and shift it to [0, 1).
+        let r1 = (from_f64::<T>(1.0) - r1) * from_f64::<T>(2.0);
+        let h = Float::cbrt(r1);
+        let r = Float::sqrt(r2);
+        // Turn the cone upside-down and scale the lightness back to (0.5, 1.0]
+        (r, (from_f64::<T>(2.0) - h) * from_f64::<T>(0.5))
+    };
+
+    Hsl {
+        hue,
+        saturation,
+        lightness,
+        space: PhantomData,
+    }
+}
+
+pub fn invert_hsl_sample<S, T>(color: Hsl<S, T>) -> (T, T)
+where
+    T: FloatComponent,
+    S: RgbSpace,
+{
+    let r1 = if color.lightness <= from_f64::<T>(0.5) {
+        // ((x * 2)^3) / 2 = x^3 * 4.
+        // lightness is multiplied by 2 to scale it up to [0, 1], becoming h.
+        // h is cubed to make it r1. r1 is divided by 2 to take it back to [0, 0.5].
+        color.lightness * color.lightness * color.lightness * from_f64::<T>(4.0)
+    } else {
+        let x = color.lightness - from_f64::<T>(1.0);
+        x * x * x * from_f64::<T>(4.0) + from_f64::<T>(1.0)
+    };
+
+    // saturation is first multiplied, then divided by h before squaring.
+    // h can be completely eliminated, leaving only the saturation.
+    let r2 = color.saturation * color.saturation;
+
+    (r1, r2)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{invert_hsl_sample, sample_hsl, sample_hsv};
+    use crate::encoding::Srgb;
+    use crate::hues::RgbHue;
+    use crate::{Hsl, Hsv};
+
+    #[cfg(feature = "random")]
+    #[test]
+    fn sample_max_min() {
+        let a = sample_hsv(RgbHue::from(0.0), 0.0, 0.0);
+        let b = sample_hsv(RgbHue::from(360.0), 1.0, 1.0);
+        assert_relative_eq!(Hsv::new(0.0, 0.0, 0.0), a);
+        assert_relative_eq!(Hsv::new(360.0, 1.0, 1.0), b);
+        let a = sample_hsl(RgbHue::from(0.0), 0.0, 0.0);
+        let b = sample_hsl(RgbHue::from(360.0), 1.0, 1.0);
+        assert_relative_eq!(Hsl::new(0.0, 0.0, 0.0), a);
+        assert_relative_eq!(Hsl::new(360.0, 1.0, 1.0), b);
+    }
+
+    #[cfg(feature = "random")]
+    #[test]
+    fn hsl_sampling() {
+        // Sanity check that sampling and inverting from sample are equivalent
+        macro_rules! test_hsl {
+            ( $x:expr, $y:expr ) => {{
+                let a = invert_hsl_sample::<Srgb, _>(sample_hsl(RgbHue::from(0.0), $x, $y));
+                assert_relative_eq!(a.0, $x);
+                assert_relative_eq!(a.1, $y);
+            }};
+        }
+
+        test_hsl!(0.8464721407, 0.8271899200);
+        test_hsl!(0.8797234442, 0.4924621591);
+        test_hsl!(0.9179406120, 0.8771350605);
+        test_hsl!(0.5458023108, 0.1154283005);
+        test_hsl!(0.2691241774, 0.7881780600);
+        test_hsl!(0.2085030453, 0.9975406626);
+        test_hsl!(0.8483632811, 0.4955013942);
+        test_hsl!(0.0857919040, 0.0652214785);
+        test_hsl!(0.7152662838, 0.2788421565);
+        test_hsl!(0.2973598808, 0.5585230243);
+        test_hsl!(0.0936619602, 0.7289450731);
+        test_hsl!(0.4364395449, 0.9362269009);
+        test_hsl!(0.9802381158, 0.9742974964);
+        test_hsl!(0.1666129293, 0.4396910574);
+        test_hsl!(0.6190216210, 0.7175675180);
+    }
+}

--- a/palette/src/random_sampling/mod.rs
+++ b/palette/src/random_sampling/mod.rs
@@ -1,0 +1,3 @@
+mod cone;
+
+pub use self::cone::*;


### PR DESCRIPTION
Implement `Distribution<T> for Standard` from rand for all color types, LabHue, and RgbHue
Implement `SampleUniform ` for all color types, LabHue, and RgbHue
Color sampling is supported for `gen`, `gen_range`, and `Uniform`.

See #174 for design discussion
Color models are sampled based on their geometric space with special consideration for HSV (cone) and HSL (bicone).

Geometry of each color model:
`Hsv` and `Hwb` - Cone. `Hwb` is expressed in terms of `Hsv`.
`Hsl` - Bicone. Sampled as a random selection between two cones.
`Lab`, `Rgb`, `Xyz` and `Yxy` - Cubes and blocks. Each component can be sampled independently.
`Luma` - A line. A single value.
`Alpha` - Samples the contained color and the alpha channel independently.

Closes #174 