### PR TITLE
Add benchmarking with criterion to track changes

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -25,6 +25,9 @@ serializing = ["serde", "std"]
 std = ["approx/std", "num-traits/std"]
 libm = ["num-traits/libm"]
 
+[lib]
+bench = false
+
 [dependencies]
 palette_derive = {version = "0.5.0", path = "../palette_derive"}
 num-traits = {version = "0.2", default-features = false}
@@ -55,6 +58,10 @@ serde_json = "1"
 version = "2"
 default-features = false
 
+[dev-dependencies.criterion]
+version = "0.3"
+default-features = false
+
 [dev-dependencies.image]
 version = "0.22"
 default-features = false
@@ -62,3 +69,18 @@ default-features = false
 [build-dependencies.phf_codegen]
 version = "0.8"
 optional = true
+
+[[bench]]
+path = "benches/cie.rs"
+name = "cie_conversion"
+harness = false
+
+[[bench]]
+path = "benches/rgb.rs"
+name = "rgb_conversion"
+harness = false
+
+[[bench]]
+path = "benches/matrix.rs"
+name = "matrix"
+harness = false

--- a/palette/benches/cie.rs
+++ b/palette/benches/cie.rs
@@ -1,0 +1,88 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use palette::convert::FromColorUnclamped;
+use palette::{Lab, Lch, Xyz, Yxy};
+
+#[path = "../tests/convert/data_color_mine.rs"]
+#[allow(dead_code)]
+mod data_color_mine;
+use data_color_mine::{load_data, ColorMine};
+
+/* Benches the following conversions:
+    - xyz to lab
+    - lch to lab
+    - lab to lch
+    - rgb to xyz
+    - yxy to xyz
+    - lab to xyz
+    - xyz to yxy
+*/
+
+fn cie_conversion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Cie family");
+    let colormine: Vec<ColorMine> = load_data();
+    let lab: Vec<Lab> = colormine
+        .iter()
+        .map(|x| Lab::from_color_unclamped(x.xyz))
+        .collect();
+    let lch: Vec<Lch> = colormine
+        .iter()
+        .map(|x| Lch::from_color_unclamped(x.xyz))
+        .collect();
+
+    group.throughput(Throughput::Elements(colormine.len() as u64));
+
+    group.bench_with_input("xyz to lab", &colormine, |b, colormine| {
+        b.iter(|| {
+            for c in colormine {
+                black_box(Lab::from_color_unclamped(c.xyz));
+            }
+        })
+    });
+    group.bench_with_input("lch to lab", &lch, |b, lch| {
+        b.iter(|| {
+            for c in lch {
+                black_box(Lab::from_color_unclamped(*c));
+            }
+        })
+    });
+    group.bench_with_input("lab to lch", &lab, |b, lab| {
+        b.iter(|| {
+            for c in lab {
+                black_box(Lch::from_color_unclamped(*c));
+            }
+        })
+    });
+    group.bench_with_input("linsrgb to xyz", &colormine, |b, colormine| {
+        b.iter(|| {
+            for c in colormine {
+                black_box(Xyz::from_color_unclamped(c.linear_rgb));
+            }
+        })
+    });
+    group.bench_with_input("yxy to xyz", &colormine, |b, colormine| {
+        b.iter(|| {
+            for c in colormine {
+                black_box(Xyz::from_color_unclamped(c.yxy));
+            }
+        })
+    });
+    group.bench_with_input("lab to xyz", &lab, |b, lab| {
+        b.iter(|| {
+            for c in lab {
+                black_box(Xyz::from_color_unclamped(*c));
+            }
+        })
+    });
+    group.bench_with_input("xyz to yxy", &colormine, |b, colormine| {
+        b.iter(|| {
+            for c in colormine {
+                black_box(Yxy::from_color_unclamped(c.xyz));
+            }
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, cie_conversion);
+criterion_main!(benches);

--- a/palette/benches/matrix.rs
+++ b/palette/benches/matrix.rs
@@ -1,0 +1,44 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use palette::encoding;
+use palette::matrix::{
+    matrix_inverse, multiply_3x3, multiply_rgb_to_xyz, multiply_xyz, multiply_xyz_to_rgb,
+    rgb_to_xyz_matrix,
+};
+use palette::white_point::{WhitePoint, D50, D65};
+use palette::{LinSrgb, Xyz};
+
+fn matrix(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Matrix functions");
+
+    let inp1 = [0.1, 0.2, 0.3, 0.3, 0.2, 0.1, 0.2, 0.1, 0.3];
+    let inp2: Xyz<D65, _> = Xyz::new(0.4, 0.6, 0.8);
+    let inp3 = [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
+    let inp4 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
+    let inverse: [f64; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
+    let color = LinSrgb::new(0.2, 0.8, 0.4);
+    let mat3 = rgb_to_xyz_matrix::<encoding::Srgb, f64>();
+    let wp: Xyz<D65, f64> = D65::get_xyz();
+
+    group.bench_function("multiply_xyz", |b| {
+        b.iter(|| multiply_xyz::<D65, D50, _>(black_box(&inp1), black_box(&inp2)))
+    });
+    group.bench_function("multiply_xyz_to_rgb", |b| {
+        b.iter(|| multiply_xyz_to_rgb::<encoding::Srgb, _>(black_box(&inp1), black_box(&wp)))
+    });
+    group.bench_function("multiply_rgb_to_xyz", |b| {
+        b.iter(|| multiply_rgb_to_xyz(black_box(&mat3), black_box(&color)))
+    });
+    group.bench_function("multiply_3x3", |b| {
+        b.iter(|| multiply_3x3(black_box(&inp3), black_box(&inp4)))
+    });
+    group.bench_with_input("matrix_inverse", &inverse, |b, inverse| {
+        b.iter(|| matrix_inverse(inverse))
+    });
+    group.bench_function("rgb_to_xyz_matrix", |b| {
+        b.iter(|| rgb_to_xyz_matrix::<encoding::Srgb, f64>())
+    });
+}
+
+criterion_group!(benches, matrix);
+criterion_main!(benches);

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -391,11 +391,13 @@ mod component;
 pub mod convert;
 pub mod encoding;
 mod equality;
-mod matrix;
 mod relative_contrast;
 pub mod white_point;
 
 pub mod float;
+
+#[doc(hidden)]
+pub mod matrix;
 
 fn clamp<T: PartialOrd>(v: T, min: T, max: T) -> T {
     if v < min {

--- a/palette/src/matrix.rs
+++ b/palette/src/matrix.rs
@@ -1,4 +1,4 @@
-//! This module provides simple matrix operations on 3x3 matrix to aid in
+//! This module provides simple matrix operations on 3x3 matrices to aid in
 //! chromatic adaptation and conversion calculations.
 
 use core::marker::PhantomData;
@@ -10,10 +10,10 @@ use crate::rgb::{Primaries, Rgb, RgbSpace};
 use crate::white_point::WhitePoint;
 use crate::{FloatComponent, Xyz};
 
-/// A 9 element array representing a 3x3 matrix
+/// A 9 element array representing a 3x3 matrix.
 pub type Mat3<T> = [T; 9];
 
-/// Multiply the 3x3 matrix with the XYZ color
+/// Multiply the 3x3 matrix with an XYZ color.
 pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Xyz<Swp, T>,
@@ -25,7 +25,7 @@ pub fn multiply_xyz<Swp: WhitePoint, Dwp: WhitePoint, T: FloatComponent>(
         white_point: PhantomData,
     }
 }
-/// Multiply the 3x3 matrix with the XYZ color into RGB color
+/// Multiply the 3x3 matrix with an XYZ color to return an RGB color.
 pub fn multiply_xyz_to_rgb<S: RgbSpace, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Xyz<S::WhitePoint, T>,
@@ -37,7 +37,7 @@ pub fn multiply_xyz_to_rgb<S: RgbSpace, T: FloatComponent>(
         standard: PhantomData,
     }
 }
-/// Multiply the 3x3 matrix with the  RGB into XYZ color
+/// Multiply the 3x3 matrix with an RGB color to return an XYZ color.
 pub fn multiply_rgb_to_xyz<S: RgbSpace, T: FloatComponent>(
     c: &Mat3<T>,
     f: &Rgb<Linear<S>, T>,
@@ -50,7 +50,7 @@ pub fn multiply_rgb_to_xyz<S: RgbSpace, T: FloatComponent>(
     }
 }
 
-/// Multiply a 3x3 matrix with another 3x3 matrix
+/// Multiply two 3x3 matrices.
 pub fn multiply_3x3<T: Float>(c: &Mat3<T>, f: &Mat3<T>) -> Mat3<T> {
     let mut out = [T::zero(); 9];
     out[0] = c[0] * f[0] + c[1] * f[3] + c[2] * f[6];
@@ -68,7 +68,7 @@ pub fn multiply_3x3<T: Float>(c: &Mat3<T>, f: &Mat3<T>) -> Mat3<T> {
     out
 }
 
-/// Invert a 3x3 matrix and panic if matrix is not invertable.
+/// Invert a 3x3 matrix and panic if matrix is not invertible.
 pub fn matrix_inverse<T: Float>(a: &Mat3<T>) -> Mat3<T> {
     let d0 = a[4] * a[8] - a[5] * a[7];
     let d1 = a[3] * a[8] - a[5] * a[6];
@@ -97,7 +97,7 @@ pub fn matrix_inverse<T: Float>(a: &Mat3<T>) -> Mat3<T> {
     ]
 }
 
-/// Geneartes to Srgb to Xyz transformation matrix for the given white point
+/// Generates the Srgb to Xyz transformation matrix for a given white point.
 pub fn rgb_to_xyz_matrix<S: RgbSpace, T: FloatComponent>() -> Mat3<T> {
     let r: Xyz<S::WhitePoint, T> = S::Primaries::red().into_color_unclamped();
     let g: Xyz<S::WhitePoint, T> = S::Primaries::green().into_color_unclamped();

--- a/palette/tests/convert/data_color_mine.rs
+++ b/palette/tests/convert/data_color_mine.rs
@@ -62,13 +62,13 @@ pub struct ColorMineRaw {
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct ColorMine {
-    xyz: Xyz<D65, f32>,
-    yxy: Yxy<D65, f32>,
-    rgb: LinSrgb<f32>,
-    linear_rgb: LinSrgb<f32>,
-    hsl: Hsl<::palette::encoding::Srgb, f32>,
-    hsv: Hsv<::palette::encoding::Srgb, f32>,
-    hwb: Hwb<::palette::encoding::Srgb, f32>,
+    pub xyz: Xyz<D65, f32>,
+    pub yxy: Yxy<D65, f32>,
+    pub rgb: LinSrgb<f32>,
+    pub linear_rgb: LinSrgb<f32>,
+    pub hsl: Hsl<::palette::encoding::Srgb, f32>,
+    pub hsv: Hsv<::palette::encoding::Srgb, f32>,
+    pub hwb: Hwb<::palette::encoding::Srgb, f32>,
 }
 
 impl From<ColorMineRaw> for ColorMine {


### PR DESCRIPTION
Add coverage for Rgb color family and Cie family conversions using the colormine test data
Add benchmarks for matrix operations
Add benchmarks for testing conversion of Srgb\<u8\> and LinSrgb\<f32\>
Small doc fixups

Benchmarks can be run with `cargo bench`. You can also run select benchmarks by typing in a regex pattern that matches the benchmark id name.

Closes #95