### PR TITLE
Optimize matrix functions, color conversion performance

### DIFF
--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -41,10 +41,11 @@ impl LumaStandard for Srgb {
 
 impl TransferFn for Srgb {
     fn into_linear<T: Float + FromF64>(x: T) -> T {
+        // Recip call shows performance benefits in benchmarks for this function
         if x <= from_f64(0.04045) {
-            x / from_f64(12.92)
+            x * from_f64::<T>(12.92).recip()
         } else {
-            ((x + from_f64(0.055)) / from_f64(1.055)).powf(from_f64(2.4))
+            ((x + from_f64(0.055)) * from_f64::<T>(1.055).recip()).powf(from_f64(2.4))
         }
     }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -296,15 +296,12 @@ where
     }
 }
 
-impl<S, Sp, T> FromColorUnclamped<Hwb<Sp, T>> for Hsv<S, T>
+impl<S, T> FromColorUnclamped<Hwb<S, T>> for Hsv<S, T>
 where
     T: FloatComponent,
     S: RgbSpace,
-    Sp: RgbSpace<WhitePoint = S::WhitePoint>,
 {
-    fn from_color_unclamped(color: Hwb<Sp, T>) -> Self {
-        let hwb = Hwb::<S, T>::from_color_unclamped(color);
-
+    fn from_color_unclamped(hwb: Hwb<S, T>) -> Self {
         let inv = T::one() - hwb.blackness;
         // avoid divide by zero
         let s = if inv.is_normal() {

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -246,9 +246,10 @@ where
     Wp: WhitePoint,
 {
     fn from_color_unclamped(color: Lab<Wp, T>) -> Self {
-        let y = (color.l + from_f64(16.0)) / from_f64(116.0);
-        let x = y + (color.a / from_f64(500.0));
-        let z = y - (color.b / from_f64(200.0));
+        // Recip call shows performance benefits in benchmarks for this function
+        let y = (color.l + from_f64(16.0)) * from_f64::<T>(116.0).recip();
+        let x = y + (color.a * from_f64::<T>(500.0).recip());
+        let z = y - (color.b * from_f64::<T>(200.0).recip());
 
         fn convert<T: FloatComponent>(c: T) -> T {
             let epsilon: T = from_f64(6.0 / 29.0);


### PR DESCRIPTION
Destructure slices to avoid bounds checking and panic path
Add #[inline] attribute to matrix functions
Improve Rgb into linear
Improve Lab to Xyz
Remove RgbSpace conversion from Hwb to Hsv