### PR TITLE
Optimize into_component for float_to_uint, u8 to f32/f64

### DIFF
--- a/palette/src/component.rs
+++ b/palette/src/component.rs
@@ -90,6 +90,21 @@ impl<T: Component> IntoComponent<T> for T {
     }
 }
 
+// C23 = 2^23, in f32
+// C52 = 2^52, in f64
+const C23: u32 = 0x4b00_0000;
+const C52: u64 = 0x4330_0000_0000_0000;
+
+// Float to uint conversion with rounding to nearest even number. Formula
+// follows the form (x_f32 + C23_f32) - C23_u32, where x is the component. From
+// Hacker's Delight, p. 378-380.
+// Works on the range of [-0.25, 2^23] for f32, [-0.25, 2^52] for f64.
+//
+// Special cases:
+// NaN -> uint::MAX
+// inf -> uint::MAX
+// -inf -> 0
+// Greater than 2^23 for f64, 2^52 for f64 -> uint::MAX
 macro_rules! convert_float_to_uint {
     ($float: ident; direct ($($direct_target: ident),+); $(via $temporary: ident ($($target: ident),+);)*) => {
         $(
@@ -97,8 +112,9 @@ macro_rules! convert_float_to_uint {
                 #[inline]
                 fn into_component(self) -> $direct_target {
                     let max = $direct_target::max_intensity() as $float;
-                    let scaled = self * max;
-                    clamp(scaled.round(), 0.0, max) as $direct_target
+                    let scaled = (self * max).min(max);
+                    let f = scaled + f32::from_bits(C23);
+                    (f.to_bits().saturating_sub(C23)) as $direct_target
                 }
             }
         )+
@@ -109,13 +125,59 @@ macro_rules! convert_float_to_uint {
                     #[inline]
                     fn into_component(self) -> $target {
                         let max = $target::max_intensity() as $temporary;
-                        let scaled = self as $temporary * max;
-                        clamp(scaled.round(), 0.0, max) as $target
+                        let scaled = (self as $temporary * max).min(max);
+                        let f = scaled + f64::from_bits(C52);
+                        (f.to_bits().saturating_sub(C52)) as  $target
                     }
                 }
             )+
         )*
     };
+}
+
+// Double to uint conversion with rounding to nearest even number. Formula
+// follows the form (x_f64 + C52_f64) - C52_u64, where x is the component.
+macro_rules! convert_double_to_uint {
+    ($double: ident; direct ($($direct_target: ident),+);) => {
+        $(
+            impl IntoComponent<$direct_target> for $double {
+                #[inline]
+                fn into_component(self) -> $direct_target {
+                    let max = $direct_target::max_intensity() as $double;
+                    let scaled = (self * max).min(max);
+                    let f = scaled + f64::from_bits(C52);
+                    (f.to_bits().saturating_sub(C52)) as $direct_target
+                }
+            }
+        )+
+    };
+}
+
+// Uint to float conversion with the formula (x_u32 + C23_u32) - C23_f32, where
+// x is the component. We convert the component to f32 then multiply it by the
+// reciprocal of the float representation max value for u8.
+// Works on the range of [0, 2^23] for f32, [0, 2^52 - 1] for f64.
+impl IntoComponent<f32> for u8 {
+    #[inline]
+    fn into_component(self) -> f32 {
+        let comp_u = self as u32 + C23;
+        let comp_f = f32::from_bits(comp_u) - f32::from_bits(C23);
+        let max_u = core::u8::MAX as u32 + C23;
+        let max_f = (f32::from_bits(max_u) - f32::from_bits(C23)).recip();
+        comp_f * max_f
+    }
+}
+
+// Uint to f64 conversion with the formula (x_u64 + C23_u64) - C23_f64.
+impl IntoComponent<f64> for u8 {
+    #[inline]
+    fn into_component(self) -> f64 {
+        let comp_u = self as u64 + C52;
+        let comp_f = f64::from_bits(comp_u) - f64::from_bits(C52);
+        let max_u = core::u8::MAX as u64 + C52;
+        let max_f = (f64::from_bits(max_u) - f64::from_bits(C52)).recip();
+        comp_f * max_f
+    }
 }
 
 macro_rules! convert_uint_to_float {
@@ -167,9 +229,8 @@ impl IntoComponent<f32> for f64 {
         self as f32
     }
 }
-convert_float_to_uint!(f64; direct (u8, u16, u32, u64, u128););
+convert_double_to_uint!(f64; direct (u8, u16, u32, u64, u128););
 
-convert_uint_to_float!(u8; via f32 (f32); via f64 (f64););
 convert_uint_to_uint!(u8; via f32 (u16); via f64 (u32, u64, u128););
 
 convert_uint_to_float!(u16; via f32 (f32); via f64 (f64););
@@ -183,3 +244,119 @@ convert_uint_to_uint!(u64; via f64 (u8, u16, u32, u128););
 
 convert_uint_to_float!(u128; via f64 (f32, f64););
 convert_uint_to_uint!(u128; via f64 (u8, u16, u32, u64););
+
+#[cfg(test)]
+mod test {
+    use crate::IntoComponent;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn float_to_uint() {
+        let data = vec![
+            -800.0,
+            -0.3,
+            0.0,
+            0.005,
+            0.024983,
+            0.01,
+            0.15,
+            0.3,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.8444,
+            0.9,
+            0.955,
+            0.999,
+            1.0,
+            1.4,
+            f32::from_bits(0x4b44_0000),
+            std::f32::MAX,
+            std::f32::MIN,
+            std::f32::NAN,
+            std::f32::INFINITY,
+            std::f32::NEG_INFINITY,
+        ];
+
+        let expected = vec![
+            0u8, 0, 0, 1, 6, 3, 38, 76, 128, 153, 178, 204, 215, 230, 244, 255, 255, 255, 255, 255,
+            0, 255, 255, 0,
+        ];
+
+        for (d, e) in data.into_iter().zip(expected) {
+            assert_eq!(IntoComponent::<u8>::into_component(d), e);
+        }
+    }
+
+    #[test]
+    fn double_to_uint() {
+        let data = vec![
+            -800.0,
+            -0.3,
+            0.0,
+            0.005,
+            0.024983,
+            0.01,
+            0.15,
+            0.3,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.8444,
+            0.9,
+            0.955,
+            0.999,
+            1.0,
+            1.4,
+            f64::from_bits(0x4334_0000_0000_0000),
+            std::f64::MAX,
+            std::f64::MIN,
+            std::f64::NAN,
+            std::f64::INFINITY,
+            std::f64::NEG_INFINITY,
+        ];
+
+        let expected = vec![
+            0u8, 0, 0, 1, 6, 3, 38, 76, 128, 153, 178, 204, 215, 230, 244, 255, 255, 255, 255, 255,
+            0, 255, 255, 0,
+        ];
+
+        for (d, e) in data.into_iter().zip(expected) {
+            assert_eq!(IntoComponent::<u8>::into_component(d), e);
+        }
+    }
+
+    #[test]
+    fn uint_to_float() {
+        fn into_component_old(n: u8) -> f32 {
+            let max = core::u8::MAX as f32;
+            let scaled = n as f32 / max;
+            scaled as f32
+        }
+
+        for n in (0..=255).step_by(5) {
+            assert_relative_eq!(
+                IntoComponent::<f32>::into_component(n),
+                into_component_old(n)
+            )
+        }
+    }
+
+    #[test]
+    fn uint_to_double() {
+        fn into_component_old(n: u8) -> f64 {
+            let max = core::u8::MAX as f64;
+            let scaled = n as f64 / max;
+            scaled as f64
+        }
+
+        for n in (0..=255).step_by(5) {
+            assert_relative_eq!(
+                IntoComponent::<f64>::into_component(n),
+                into_component_old(n)
+            )
+        }
+    }
+}

--- a/palette/src/rgb/packed.rs
+++ b/palette/src/rgb/packed.rs
@@ -39,11 +39,6 @@ use crate::Pixel;
 ///
 /// let rgba = Srgba::from(0xFF80007F);
 /// assert_eq!(Srgba::new(0xFF, 0x80, 0x00, 0x7F), rgba);
-///
-/// // The second assert is essentially how library components are converted
-/// let float = 0.5f32 * 255.0;
-/// assert_eq!(0x7F, float as u32);
-/// assert_eq!(0x80, float.round() as u32);
 /// ```
 ///
 /// When an `Rgb` type is packed, the alpha value will be `0xFF` in the


### PR DESCRIPTION
Optimize component conversion of f32/f64 to uint.
Add `IntoComponent` implementation for u8 to f32/f64.

The rounding mode for components from floating point types to unsigned integers now rounds half to nearest even.
Converting a NaN to uint now returns uint::MAX, previously it returned 0.
Uint to float conversion behavior is not changed.