### PR TITLE
Allow HSV, HSL and HWB to represent nonlinear RGB

### DIFF
--- a/palette/examples/hue.rs
+++ b/palette/examples/hue.rs
@@ -1,4 +1,4 @@
-use palette::{FromColor, Hsl, Hue, IntoColor, Lch, Pixel, Srgb};
+use palette::{FromColor, Hsl, Hue, Lch, Pixel, Srgb};
 
 fn main() {
     let mut image = image::open("res/fruits.png")
@@ -12,15 +12,11 @@ fn main() {
         let color = Srgb::from_raw(&pixel.0).into_format();
 
         pixel.0 = if x < y {
-            let saturated = Hsl::from_color(color).shift_hue(180.0);
-            Srgb::from_linear(saturated.into_color())
-                .into_format()
-                .into_raw()
+            let hue_shifted = Hsl::from_color(color).shift_hue(180.0);
+            Srgb::from_color(hue_shifted).into_format().into_raw()
         } else {
-            let saturated = Lch::from_color(color).shift_hue(180.0);
-            Srgb::from_linear(saturated.into_color())
-                .into_format()
-                .into_raw()
+            let hue_shifted = Lch::from_color(color).shift_hue(180.0);
+            Srgb::from_color(hue_shifted).into_format().into_raw()
         };
     }
 

--- a/palette/examples/saturate.rs
+++ b/palette/examples/saturate.rs
@@ -1,4 +1,4 @@
-use palette::{Hsl, IntoColor, Lch, Pixel, Saturate, Srgb};
+use palette::{FromColor, Hsl, IntoColor, Lch, Pixel, Saturate, Srgb};
 
 use image::{GenericImage, GenericImageView};
 
@@ -19,18 +19,13 @@ fn main() {
             for y in 0..height {
                 let color: Hsl = Srgb::from_raw(&sub_image.get_pixel(x, y).0)
                     .into_format()
-                    .into_linear()
                     .into_color();
 
                 let saturated = color.saturate(0.8);
                 sub_image.put_pixel(
                     x,
                     y,
-                    image::Rgb(
-                        Srgb::from_linear(saturated.into_color())
-                            .into_format()
-                            .into_raw(),
-                    ),
+                    image::Rgb(Srgb::from_color(saturated).into_format().into_raw()),
                 );
             }
         }
@@ -43,18 +38,13 @@ fn main() {
             for y in 0..height {
                 let color: Lch = Srgb::from_raw(&sub_image.get_pixel(x, y).0)
                     .into_format()
-                    .into_linear()
                     .into_color();
 
                 let saturated = color.saturate(0.8);
                 sub_image.put_pixel(
                     x,
                     y,
-                    image::Rgb(
-                        Srgb::from_linear(saturated.into_color())
-                            .into_format()
-                            .into_raw(),
-                    ),
+                    image::Rgb(Srgb::from_color(saturated).into_format().into_raw()),
                 );
             }
         }

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -27,7 +27,7 @@ pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 /// HSL color space.
 ///
 /// The HSL color space can be seen as a cylindrical version of
-/// [RGB](rgb/struct.LinRgb.html), where the `hue` is the angle around the color
+/// [RGB](rgb/struct.Rgb.html), where the `hue` is the angle around the color
 /// cylinder, the `saturation` is the distance from the center, and the
 /// `lightness` is the height from the bottom. Its composition makes it
 /// especially good for operations like changing green to red, making a color

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -10,9 +10,9 @@ use rand::distributions::{Distribution, Standard};
 #[cfg(feature = "random")]
 use rand::Rng;
 
-use crate::convert::{FromColorUnclamped, IntoColorUnclamped};
+use crate::convert::FromColorUnclamped;
 use crate::encoding::pixel::RawPixel;
-use crate::encoding::{Linear, Srgb};
+use crate::encoding::Srgb;
 use crate::float::Float;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 /// `Alpha`](struct.Alpha.html#Hsla).
 pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 
-/// Linear HSL color space.
+/// HSL color space.
 ///
 /// The HSL color space can be seen as a cylindrical version of
 /// [RGB](rgb/struct.LinRgb.html), where the `hue` is the angle around the color
@@ -39,16 +39,16 @@ pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
-    rgb_space = "S",
-    white_point = "S::WhitePoint",
+    rgb_standard = "S",
+    white_point = "<S::Space as RgbSpace>::WhitePoint",
     component = "T",
-    skip_derives(Xyz, Rgb, Hsv, Hsl)
+    skip_derives(Rgb, Hsv, Hsl)
 )]
 #[repr(C)]
 pub struct Hsl<S = Srgb, T = f32>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     /// The hue of the color, in degrees. Decides if it's red, blue, purple,
     /// etc.
@@ -67,20 +67,20 @@ where
     /// is the sRGB standard.
     #[cfg_attr(feature = "serializing", serde(skip))]
     #[palette(unsafe_zero_sized)]
-    pub space: PhantomData<S>,
+    pub standard: PhantomData<S>,
 }
 
 impl<S, T> Copy for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
 }
 
 impl<S, T> Clone for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn clone(&self) -> Hsl<S, T> {
         *self
@@ -97,7 +97,7 @@ where
             hue: hue.into(),
             saturation,
             lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -105,7 +105,7 @@ where
 impl<S, T> Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     /// Linear HSL.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, saturation: T, lightness: T) -> Hsl<S, T> {
@@ -113,7 +113,7 @@ where
             hue: hue.into(),
             saturation,
             lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 
@@ -128,12 +128,12 @@ where
     }
 
     #[inline]
-    fn reinterpret_as<Sp: RgbSpace>(self) -> Hsl<Sp, T> {
+    fn reinterpret_as<St: RgbStandard>(self) -> Hsl<St, T> {
         Hsl {
             hue: self.hue,
             saturation: self.saturation,
             lightness: self.lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 
@@ -178,7 +178,7 @@ impl<S, T, A> Alpha<Hsl<S, T>, A>
 where
     T: FloatComponent,
     A: Component,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     /// Linear HSL and transparency.
     pub fn with_wp<H: Into<RgbHue<T>>>(hue: H, saturation: T, lightness: T, alpha: A) -> Self {
@@ -201,31 +201,30 @@ where
     }
 }
 
-impl<S, Sp, T> FromColorUnclamped<Hsl<Sp, T>> for Hsl<S, T>
+impl<S1, S2, T> FromColorUnclamped<Hsl<S1, T>> for Hsl<S2, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
-    Sp: RgbSpace<WhitePoint = S::WhitePoint>,
+    S1: RgbStandard,
+    S2: RgbStandard,
+    S1::Space: RgbSpace<WhitePoint = <S2::Space as RgbSpace>::WhitePoint>,
 {
-    fn from_color_unclamped(hsl: Hsl<Sp, T>) -> Self {
-        if TypeId::of::<Sp::Primaries>() == TypeId::of::<S::Primaries>() {
+    fn from_color_unclamped(hsl: Hsl<S1, T>) -> Self {
+        if TypeId::of::<S1>() == TypeId::of::<S2>() {
             hsl.reinterpret_as()
         } else {
-            let rgb = Rgb::<Linear<Sp>, T>::from_color_unclamped(hsl);
-            let converted_rgb = Rgb::<Linear<S>, T>::from_color_unclamped(rgb);
+            let rgb = Rgb::<S1, T>::from_color_unclamped(hsl);
+            let converted_rgb = Rgb::<S2, T>::from_color_unclamped(rgb);
             Self::from_color_unclamped(converted_rgb)
         }
     }
 }
 
-impl<S, T> FromColorUnclamped<Rgb<S, T>> for Hsl<S::Space, T>
+impl<S, T> FromColorUnclamped<Rgb<S, T>> for Hsl<S, T>
 where
     T: FloatComponent,
     S: RgbStandard,
 {
-    fn from_color_unclamped(color: Rgb<S, T>) -> Self {
-        let rgb = color.into_linear();
-
+    fn from_color_unclamped(rgb: Rgb<S, T>) -> Self {
         let (max, min, sep, coeff) = {
             let (max, min, sep, coeff) = if rgb.red > rgb.green {
                 (rgb.red, rgb.green, rgb.green - rgb.blue, T::zero())
@@ -259,26 +258,15 @@ where
             hue: h.into(),
             saturation: s,
             lightness: l,
-            space: PhantomData,
+            standard: PhantomData,
         }
-    }
-}
-
-impl<S, T> FromColorUnclamped<Xyz<S::WhitePoint, T>> for Hsl<S, T>
-where
-    T: FloatComponent,
-    S: RgbSpace,
-{
-    fn from_color_unclamped(color: Xyz<S::WhitePoint, T>) -> Self {
-        let rgb: Rgb<Linear<S>, T> = color.into_color_unclamped();
-        Self::from_color_unclamped(rgb)
     }
 }
 
 impl<S, T> FromColorUnclamped<Hsv<S, T>> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn from_color_unclamped(hsv: Hsv<S, T>) -> Self {
         let x = (from_f64::<T>(2.0) - hsv.saturation) * hsv.value;
@@ -303,24 +291,24 @@ where
             hue: hsv.hue,
             saturation,
             lightness: x / from_f64(2.0),
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
 
-impl<S: RgbSpace, T: FloatComponent, H: Into<RgbHue<T>>> From<(H, T, T)> for Hsl<S, T> {
+impl<S: RgbStandard, T: FloatComponent, H: Into<RgbHue<T>>> From<(H, T, T)> for Hsl<S, T> {
     fn from(components: (H, T, T)) -> Self {
         Self::from_components(components)
     }
 }
 
-impl<S: RgbSpace, T: FloatComponent> Into<(RgbHue<T>, T, T)> for Hsl<S, T> {
+impl<S: RgbStandard, T: FloatComponent> Into<(RgbHue<T>, T, T)> for Hsl<S, T> {
     fn into(self) -> (RgbHue<T>, T, T) {
         self.into_components()
     }
 }
 
-impl<S: RgbSpace, T: FloatComponent, H: Into<RgbHue<T>>, A: Component> From<(H, T, T, A)>
+impl<S: RgbStandard, T: FloatComponent, H: Into<RgbHue<T>>, A: Component> From<(H, T, T, A)>
     for Alpha<Hsl<S, T>, A>
 {
     fn from(components: (H, T, T, A)) -> Self {
@@ -328,7 +316,7 @@ impl<S: RgbSpace, T: FloatComponent, H: Into<RgbHue<T>>, A: Component> From<(H, 
     }
 }
 
-impl<S: RgbSpace, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
+impl<S: RgbStandard, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
     for Alpha<Hsl<S, T>, A>
 {
     fn into(self) -> (RgbHue<T>, T, T, A) {
@@ -339,7 +327,7 @@ impl<S: RgbSpace, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
 impl<S, T> Limited for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     #[rustfmt::skip]
     fn is_valid(&self) -> bool {
@@ -362,7 +350,7 @@ where
 impl<S, T> Mix for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Scalar = T;
 
@@ -374,7 +362,7 @@ where
             hue: self.hue + factor * hue_diff,
             saturation: self.saturation + factor * (other.saturation - self.saturation),
             lightness: self.lightness + factor * (other.lightness - self.lightness),
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -382,7 +370,7 @@ where
 impl<S, T> Shade for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Scalar = T;
 
@@ -391,7 +379,7 @@ where
             hue: self.hue,
             saturation: self.saturation,
             lightness: self.lightness + amount,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -399,7 +387,7 @@ where
 impl<S, T> GetHue for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Hue = RgbHue<T>;
 
@@ -415,14 +403,14 @@ where
 impl<S, T> Hue for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Hsl<S, T> {
         Hsl {
             hue: hue.into(),
             saturation: self.saturation,
             lightness: self.lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 
@@ -431,7 +419,7 @@ where
             hue: self.hue + amount.into(),
             saturation: self.saturation,
             lightness: self.lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -439,7 +427,7 @@ where
 impl<S, T> Saturate for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Scalar = T;
 
@@ -448,7 +436,7 @@ where
             hue: self.hue,
             saturation: self.saturation * (T::one() + factor),
             lightness: self.lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -456,7 +444,7 @@ where
 impl<S, T> Default for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn default() -> Hsl<S, T> {
         Hsl::with_wp(RgbHue::from(T::zero()), T::zero(), T::zero())
@@ -466,7 +454,7 @@ where
 impl<S, T> Add<Hsl<S, T>> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Output = Hsl<S, T>;
 
@@ -475,7 +463,7 @@ where
             hue: self.hue + other.hue,
             saturation: self.saturation + other.saturation,
             lightness: self.lightness + other.lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -483,7 +471,7 @@ where
 impl<S, T> Add<T> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Output = Hsl<S, T>;
 
@@ -492,7 +480,7 @@ where
             hue: self.hue + c,
             saturation: self.saturation + c,
             lightness: self.lightness + c,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -500,7 +488,7 @@ where
 impl<S, T> AddAssign<Hsl<S, T>> for Hsl<S, T>
 where
     T: FloatComponent + AddAssign,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn add_assign(&mut self, other: Hsl<S, T>) {
         self.hue += other.hue;
@@ -512,7 +500,7 @@ where
 impl<S, T> AddAssign<T> for Hsl<S, T>
 where
     T: FloatComponent + AddAssign,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn add_assign(&mut self, c: T) {
         self.hue += c;
@@ -524,7 +512,7 @@ where
 impl<S, T> Sub<Hsl<S, T>> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Output = Hsl<S, T>;
 
@@ -533,7 +521,7 @@ where
             hue: self.hue - other.hue,
             saturation: self.saturation - other.saturation,
             lightness: self.lightness - other.lightness,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -541,7 +529,7 @@ where
 impl<S, T> Sub<T> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Output = Hsl<S, T>;
 
@@ -550,7 +538,7 @@ where
             hue: self.hue - c,
             saturation: self.saturation - c,
             lightness: self.lightness - c,
-            space: PhantomData,
+            standard: PhantomData,
         }
     }
 }
@@ -558,7 +546,7 @@ where
 impl<S, T> SubAssign<Hsl<S, T>> for Hsl<S, T>
 where
     T: FloatComponent + SubAssign,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn sub_assign(&mut self, other: Hsl<S, T>) {
         self.hue -= other.hue;
@@ -570,7 +558,7 @@ where
 impl<S, T> SubAssign<T> for Hsl<S, T>
 where
     T: FloatComponent + SubAssign,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     fn sub_assign(&mut self, c: T) {
         self.hue -= c;
@@ -582,7 +570,7 @@ where
 impl<S, T, P> AsRef<P> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
     P: RawPixel<T> + ?Sized,
 {
     fn as_ref(&self) -> &P {
@@ -593,7 +581,7 @@ where
 impl<S, T, P> AsMut<P> for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
     P: RawPixel<T> + ?Sized,
 {
     fn as_mut(&mut self) -> &mut P {
@@ -605,7 +593,7 @@ impl<S, T> AbsDiffEq for Hsl<S, T>
 where
     T: FloatComponent + AbsDiffEq,
     T::Epsilon: Copy + Float + FromF64,
-    S: RgbSpace + PartialEq,
+    S: RgbStandard + PartialEq,
 {
     type Epsilon = T::Epsilon;
 
@@ -624,7 +612,7 @@ impl<S, T> RelativeEq for Hsl<S, T>
 where
     T: FloatComponent + RelativeEq,
     T::Epsilon: Copy + Float + FromF64,
-    S: RgbSpace + PartialEq,
+    S: RgbStandard + PartialEq,
 {
     fn default_max_relative() -> Self::Epsilon {
         T::default_max_relative()
@@ -647,7 +635,7 @@ impl<S, T> UlpsEq for Hsl<S, T>
 where
     T: FloatComponent + UlpsEq,
     T::Epsilon: Copy + Float + FromF64,
-    S: RgbSpace + PartialEq,
+    S: RgbStandard + PartialEq,
 {
     fn default_max_ulps() -> u32 {
         T::default_max_ulps()
@@ -664,7 +652,7 @@ where
 impl<S, T> RelativeContrast for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     type Scalar = T;
 
@@ -682,7 +670,7 @@ where
 impl<S, T> Distribution<Hsl<S, T>> for Standard
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
     Standard: Distribution<T>,
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Hsl<S, T> {
@@ -694,7 +682,7 @@ where
 pub struct UniformHsl<S, T>
 where
     T: FloatComponent + SampleUniform,
-    S: RgbSpace + SampleUniform,
+    S: RgbStandard + SampleUniform,
 {
     hue: crate::hues::UniformRgbHue<T>,
     u1: Uniform<T>,
@@ -706,7 +694,7 @@ where
 impl<S, T> SampleUniform for Hsl<S, T>
 where
     T: FloatComponent + SampleUniform,
-    S: RgbSpace + SampleUniform,
+    S: RgbStandard + SampleUniform,
 {
     type Sampler = UniformHsl<S, T>;
 }
@@ -715,7 +703,7 @@ where
 impl<S, T> UniformSampler for UniformHsl<S, T>
 where
     T: FloatComponent + SampleUniform,
-    S: RgbSpace + SampleUniform,
+    S: RgbStandard + SampleUniform,
 {
     type X = Hsl<S, T>;
 
@@ -773,12 +761,11 @@ where
 #[cfg(test)]
 mod test {
     use super::Hsl;
-    use crate::encoding::Srgb;
-    use crate::{FromColor, Hsv, LinSrgb};
+    use crate::{FromColor, Hsv, Srgb};
 
     #[test]
     fn red() {
-        let a = Hsl::from_color(LinSrgb::new(1.0, 0.0, 0.0));
+        let a = Hsl::from_color(Srgb::new(1.0, 0.0, 0.0));
         let b = Hsl::new(0.0, 1.0, 0.5);
         let c = Hsl::from_color(Hsv::new(0.0, 1.0, 1.0));
 
@@ -788,7 +775,7 @@ mod test {
 
     #[test]
     fn orange() {
-        let a = Hsl::from_color(LinSrgb::new(1.0, 0.5, 0.0));
+        let a = Hsl::from_color(Srgb::new(1.0, 0.5, 0.0));
         let b = Hsl::new(30.0, 1.0, 0.5);
         let c = Hsl::from_color(Hsv::new(30.0, 1.0, 1.0));
 
@@ -798,7 +785,7 @@ mod test {
 
     #[test]
     fn green() {
-        let a = Hsl::from_color(LinSrgb::new(0.0, 1.0, 0.0));
+        let a = Hsl::from_color(Srgb::new(0.0, 1.0, 0.0));
         let b = Hsl::new(120.0, 1.0, 0.5);
         let c = Hsl::from_color(Hsv::new(120.0, 1.0, 1.0));
 
@@ -808,7 +795,7 @@ mod test {
 
     #[test]
     fn blue() {
-        let a = Hsl::from_color(LinSrgb::new(0.0, 0.0, 1.0));
+        let a = Hsl::from_color(Srgb::new(0.0, 0.0, 1.0));
         let b = Hsl::new(240.0, 1.0, 0.5);
         let c = Hsl::from_color(Hsv::new(240.0, 1.0, 1.0));
 
@@ -818,7 +805,7 @@ mod test {
 
     #[test]
     fn purple() {
-        let a = Hsl::from_color(LinSrgb::new(0.5, 0.0, 1.0));
+        let a = Hsl::from_color(Srgb::new(0.5, 0.0, 1.0));
         let b = Hsl::new(270.0, 1.0, 0.5);
         let c = Hsl::from_color(Hsv::new(270.0, 1.0, 1.0));
 
@@ -829,7 +816,7 @@ mod test {
     #[test]
     fn ranges() {
         assert_ranges! {
-            Hsl<Srgb, f64>;
+            Hsl<crate::encoding::Srgb, f64>;
             limited {
                 saturation: 0.0 => 1.0,
                 lightness: 0.0 => 1.0
@@ -841,11 +828,13 @@ mod test {
         }
     }
 
-    raw_pixel_conversion_tests!(Hsl<Srgb>: hue, saturation, lightness);
-    raw_pixel_conversion_fail_tests!(Hsl<Srgb>: hue, saturation, lightness);
+    raw_pixel_conversion_tests!(Hsl<crate::encoding::Srgb>: hue, saturation, lightness);
+    raw_pixel_conversion_fail_tests!(Hsl<crate::encoding::Srgb>: hue, saturation, lightness);
 
     #[test]
     fn check_min_max_components() {
+        use crate::encoding::Srgb;
+
         assert_relative_eq!(Hsl::<Srgb>::min_saturation(), 0.0);
         assert_relative_eq!(Hsl::<Srgb>::min_lightness(), 0.0);
         assert_relative_eq!(Hsl::<Srgb>::max_saturation(), 1.0);

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -26,7 +26,7 @@ pub type Hsva<S = Srgb, T = f32> = Alpha<Hsv<S, T>, T>;
 
 /// HSV color space.
 ///
-/// HSV is a cylindrical version of [RGB](rgb/struct.LinRgb.html) and it's very
+/// HSV is a cylindrical version of [RGB](rgb/struct.Rgb.html) and it's very
 /// similar to [HSL](struct.Hsl.html). The difference is that the `value`
 /// component in HSV determines the _brightness_ of the color, and not the
 /// _lightness_. The difference is that, for example, red (100% R, 0% G, 0% B)

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -26,7 +26,7 @@ pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 
 /// HWB color space.
 ///
-/// HWB is a cylindrical version of [RGB](rgb/struct.LinRgb.html) and it's very
+/// HWB is a cylindrical version of [RGB](rgb/struct.Rgb.html) and it's very
 /// closely related to [HSV](struct.Hsv.html). It describes colors with a
 /// starting hue, then a degree of whiteness and blackness to mix into that
 /// base hue.

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 macro_rules! raw_pixel_conversion_tests {
-    ($name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
+    ($name: ident <$($ty_param: path),+> : $($component: ident),+) => {
         #[test]
         fn convert_from_f32_array() {
             raw_pixel_conversion_tests!(@float_array_test f32, $name<$($ty_param),+>: $($component),+);
@@ -22,7 +22,7 @@ macro_rules! raw_pixel_conversion_tests {
         }
     };
 
-    (@float_array_test $float: ty, $name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
+    (@float_array_test $float: ty, $name: ident <$($ty_param: path),+> : $($component: ident),+) => {
         use crate::Pixel;
         use crate::Alpha;
 
@@ -49,7 +49,7 @@ macro_rules! raw_pixel_conversion_tests {
         assert_eq!(color_alpha, Alpha::<$name<$($ty_param,)+ $float>, $float>::new($($component,)+ alpha));
     };
 
-    (@float_slice_test $float: ty, $name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
+    (@float_slice_test $float: ty, $name: ident <$($ty_param: path),+> : $($component: ident),+) => {
         use crate::Pixel;
         use crate::Alpha;
 
@@ -86,7 +86,7 @@ macro_rules! raw_pixel_conversion_tests {
 
 #[cfg(test)]
 macro_rules! raw_pixel_conversion_fail_tests {
-    ($name: ident <$($ty_param: ident),+> : $($component: ident),+) => {
+    ($name: ident <$($ty_param: path),+> : $($component: ident),+) => {
         #[test]
         #[should_panic(expected = "not enough color channels")]
         fn convert_from_short_f32_array() {
@@ -112,13 +112,13 @@ macro_rules! raw_pixel_conversion_fail_tests {
         }
     };
 
-    (@float_array_test $float: ty, $name: ident <$($ty_param: ident),+>) => {
+    (@float_array_test $float: ty, $name: ident <$($ty_param: path),+>) => {
         use crate::Pixel;
         let raw: [$float; 1] = [0.1];
         let _: $name<$($ty_param,)+ $float> = *$name::from_raw(&raw);
     };
 
-    (@float_slice_test $float: ty, $name: ident <$($ty_param: ident),+>) => {
+    (@float_slice_test $float: ty, $name: ident <$($ty_param: path),+>) => {
         use crate::Pixel;
         let raw: &[$float] = &[0.1];
         let _: $name<$($ty_param,)+ $float> = *$name::from_raw(raw);

--- a/palette/src/random_sampling/cone.rs
+++ b/palette/src/random_sampling/cone.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 
 use crate::float::Float;
 use crate::hues::RgbHue;
-use crate::rgb::RgbSpace;
+use crate::rgb::RgbStandard;
 use crate::{from_f64, FloatComponent, Hsl, Hsv};
 
 // Based on https://stackoverflow.com/q/4778147 and https://math.stackexchange.com/q/18686,
@@ -19,7 +19,7 @@ use crate::{from_f64, FloatComponent, Hsl, Hsv};
 pub fn sample_hsv<S, T>(hue: RgbHue<T>, r1: T, r2: T) -> Hsv<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     let (value, saturation) = (Float::cbrt(r1), Float::sqrt(r2));
 
@@ -27,14 +27,14 @@ where
         hue,
         saturation,
         value,
-        space: PhantomData,
+        standard: PhantomData,
     }
 }
 
 pub fn sample_hsl<S, T>(hue: RgbHue<T>, r1: T, r2: T) -> Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     let (saturation, lightness) = if r1 <= from_f64::<T>(0.5) {
         // Scale it up to [0, 1]
@@ -56,14 +56,14 @@ where
         hue,
         saturation,
         lightness,
-        space: PhantomData,
+        standard: PhantomData,
     }
 }
 
 pub fn invert_hsl_sample<S, T>(color: Hsl<S, T>) -> (T, T)
 where
     T: FloatComponent,
-    S: RgbSpace,
+    S: RgbStandard,
 {
     let r1 = if color.lightness <= from_f64::<T>(0.5) {
         // ((x * 2)^3) / 2 = x^3 * 4.

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -47,7 +47,7 @@ pub type Rgba<S = Srgb, T = f32> = Alpha<Rgb<S, T>, T>;
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
-    rgb_space = "S::Space",
+    rgb_standard = "S",
     white_point = "<S::Space as RgbSpace>::WhitePoint",
     component = "T",
     skip_derives(Xyz, Hsv, Hsl, Luma, Rgb)
@@ -385,12 +385,12 @@ where
     }
 }
 
-impl<S, T> FromColorUnclamped<Hsl<S::Space, T>> for Rgb<S, T>
+impl<S, T> FromColorUnclamped<Hsl<S, T>> for Rgb<S, T>
 where
     S: RgbStandard,
     T: FloatComponent,
 {
-    fn from_color_unclamped(hsl: Hsl<S::Space, T>) -> Self {
+    fn from_color_unclamped(hsl: Hsl<S, T>) -> Self {
         let c = (T::one() - (hsl.lightness * from_f64(2.0) - T::one()).abs()) * hsl.saturation;
         let h = hsl.hue.to_positive_degrees() / from_f64(60.0);
         let x = c * (T::one() - (h % from_f64(2.0) - T::one()).abs());
@@ -410,21 +410,21 @@ where
             (c, T::zero(), x)
         };
 
-        Self::from_linear(Rgb {
+        Rgb {
             red: red + m,
             green: green + m,
             blue: blue + m,
             standard: PhantomData,
-        })
+        }
     }
 }
 
-impl<S, T> FromColorUnclamped<Hsv<S::Space, T>> for Rgb<S, T>
+impl<S, T> FromColorUnclamped<Hsv<S, T>> for Rgb<S, T>
 where
     S: RgbStandard,
     T: FloatComponent,
 {
-    fn from_color_unclamped(hsv: Hsv<S::Space, T>) -> Self {
+    fn from_color_unclamped(hsv: Hsv<S, T>) -> Self {
         let c = hsv.value * hsv.saturation;
         let h = hsv.hue.to_positive_degrees() / from_f64(60.0);
         let x = c * (T::one() - (h % from_f64(2.0) - T::one()).abs());
@@ -444,12 +444,12 @@ where
             (c, T::zero(), x)
         };
 
-        Self::from_linear(Rgb {
+        Rgb {
             red: red + m,
             green: green + m,
             blue: blue + m,
             standard: PhantomData,
-        })
+        }
     }
 }
 

--- a/palette_derive/src/meta/type_item_attributes.rs
+++ b/palette_derive/src/meta/type_item_attributes.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use quote::quote;
 use syn::spanned::Spanned;
 use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta, Result, Type};
 
@@ -12,7 +13,7 @@ pub struct TypeItemAttributes {
     pub internal_not_base_type: bool,
     pub component: Option<Type>,
     pub white_point: Option<Type>,
-    pub rgb_space: Option<Type>,
+    pub rgb_standard: Option<Type>,
 }
 
 impl AttributeArgumentParser for TypeItemAttributes {
@@ -98,26 +99,26 @@ impl AttributeArgumentParser for TypeItemAttributes {
                     ));
                 }
             }
-            Some("rgb_space") => {
-                if self.rgb_space.is_none() {
+            Some("rgb_standard") => {
+                if self.rgb_standard.is_none() {
                     let result = if let Meta::NameValue(MetaNameValue {
                         lit: Lit::Str(ty), ..
                     }) = argument
                     {
-                        self.rgb_space = Some(ty.parse()?);
+                        self.rgb_standard = Some(ty.parse()?);
                         Ok(())
                     } else {
                         Err(argument.span())
                     };
 
                     if let Err(span) = result {
-                        let message = "expected `rgb_space` to be a type or type parameter in a string, like `rgb_space = \"T\"`";
+                        let message = "expected `rgb_standard` to be a type or type parameter in a string, like `rgb_standard = \"T\"`";
                         return Err(::syn::parse::Error::new(span, message));
                     }
                 } else {
                     return Err(::syn::parse::Error::new(
                         argument.span(),
-                        "`rgb_space` appears more than once",
+                        "`rgb_standard` appears more than once",
                     ));
                 }
             }
@@ -144,7 +145,7 @@ impl AttributeArgumentParser for TypeItemAttributes {
             _ => {
                 return Err(::syn::parse::Error::new(
                     argument.span(),
-                    "unknown type item attribute",
+                    format!("`{}` is not a known type item attribute", quote!(#argument)),
                 ));
             }
         }


### PR DESCRIPTION
This removes the old restriction that meant HSV, HSL and HWB can only represent linear RGB. They can now be converted to and from RGB (and each other) as long as the RGB standard is the same. This restriction is there to still allow type inference and reduce implementation complexity. So converting `Hsl<Srgb>` (not linear) to `Rgb<Srgb>` is still a single step process, while converting to `Rgb<Linear<Srgb>>` is a two step process. There are still shortcuts in place to only change the RGB standard, meaning it's possible to write `Hsl::<Linear<Srgb>>::from_color(Hsl::<Srgb>::new(...))`, similar to how it worked before.

This will mean that existing code may have a different output, adding more breaking changes to the pile.

Fixes #160, fixes #187 