### PR TITLE
Correct scaling on random distribution of Lab/Lch

### DIFF
--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -701,7 +701,7 @@ where
     // `a` and `b` both range from (-128.0, 127.0)
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Lab<Wp, T> {
         Lab {
-            l: rng.gen(),
+            l: rng.gen() * from_f64(100.0),
             a: rng.gen() * from_f64(255.0) - from_f64(128.0),
             b: rng.gen() * from_f64(255.0) - from_f64(128.0),
             white_point: PhantomData,

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -589,7 +589,7 @@ where
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Lch<Wp, T> {
         Lch {
-            l: rng.gen(),
+            l: rng.gen() * from_f64(100.0),
             chroma: crate::Float::sqrt(rng.gen()) * from_f64(128.0),
             hue: rng.gen::<LabHue<T>>(),
             white_point: PhantomData,


### PR DESCRIPTION
Add the proper scaling factor for random color distribution in Lab/Lch.

Lab/Lch brightness was being treated as 0-1 instead of 0-100.