### PR TITLE
Convert documentation to intra doc links, add default whitepoint for Lab/Lch, make code fixups

### DIFF
--- a/palette/examples/hue.rs
+++ b/palette/examples/hue.rs
@@ -3,7 +3,7 @@ use palette::{FromColor, Hsl, Hue, Lch, Pixel, Srgb};
 fn main() {
     let mut image = image::open("example-data/input/fruits.png")
         .expect("could not open 'example-data/input/fruits.png'")
-        .to_rgb();
+        .to_rgb8();
 
     //Shift hue by 180 degrees as HSL in bottom left part, and as LCh in top
     //right part. Notice how LCh manages to preserve the apparent lightness of

--- a/palette/examples/saturate.rs
+++ b/palette/examples/saturate.rs
@@ -5,7 +5,7 @@ use image::{GenericImage, GenericImageView};
 fn main() {
     let mut image = image::open("example-data/input/cat.png")
         .expect("could not open 'example-data/input/cat.png'")
-        .to_rgb();
+        .to_rgb8();
 
     let width = image.width();
     let height = image.height();
@@ -49,7 +49,7 @@ fn main() {
             }
         }
     }
-    
+
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/saturate.png") {
         Ok(()) => println!("see 'example-data/output/saturate.png' for the result"),

--- a/palette/src/alpha/mod.rs
+++ b/palette/src/alpha/mod.rs
@@ -13,7 +13,7 @@ mod alpha;
 /// channel of a color type. The color type itself doesn't need to store the
 /// transparency value as it can be transformed into or wrapped in a type that
 /// has a representation of transparency. This would typically be done by
-/// wrapping it in an [`Alpha`](struct.Alpha.html) instance.
+/// wrapping it in an [`Alpha`](crate::Alpha) instance.
 ///
 /// # Deriving
 /// The trait is trivial enough to be automatically derived. If the color type

--- a/palette/src/blend/equations.rs
+++ b/palette/src/blend/equations.rs
@@ -94,12 +94,8 @@ where
             Equation::Add => src_color.component_wise(&dst_color, |a, b| a + b),
             Equation::Subtract => src_color.component_wise(&dst_color, |a, b| a - b),
             Equation::ReverseSubtract => dst_color.component_wise(&src_color, |a, b| a - b),
-            Equation::Min => source
-                .color
-                .component_wise(&destination.color, |a, b| a.min(b)),
-            Equation::Max => source
-                .color
-                .component_wise(&destination.color, |a, b| a.max(b)),
+            Equation::Min => source.color.component_wise(&destination.color, Float::min),
+            Equation::Max => source.color.component_wise(&destination.color, Float::max),
         };
 
         let alpha = match self.alpha_equation {

--- a/palette/src/blend/mod.rs
+++ b/palette/src/blend/mod.rs
@@ -3,7 +3,7 @@
 //! Palette offers both OpenGL style blending equations, as well as most of the
 //! SVG composition operators (also common in photo manipulation software). The
 //! composition operators are all implemented in the
-//! [`Blend`](trait.Blend.html) trait, and ready to use with any appropriate
+//! [`Blend`](crate::Blend) trait, and ready to use with any appropriate
 //! color type:
 //!
 //! ```
@@ -15,7 +15,7 @@
 //! ```
 //!
 //! Blending equations can be defined using the
-//! [`Equations`](struct.Equations.html) type, which is then passed to the
+//! [`Equations`](crate::blend::Equations) type, which is then passed to the
 //! `blend` function, from the `Blend` trait:
 //!
 //! ```
@@ -32,7 +32,7 @@
 //! let c = a.blend(b, blend_mode);
 //! ```
 //!
-//! Note that blending will use [premultiplied alpha](struct.PreAlpha.html),
+//! Note that blending will use [premultiplied alpha](crate::blend::PreAlpha),
 //! which may result in loss of some color information in some cases. One such
 //! case is that a completely transparent resultant color will become black.
 

--- a/palette/src/color_difference.rs
+++ b/palette/src/color_difference.rs
@@ -60,16 +60,12 @@ pub fn get_ciede_difference<T: FloatComponent>(this: &LabColorDiff<T>, other: &L
 
     let delta_h_prime: T = if c_one_prime == T::zero() || c_two_prime == T::zero() {
         from_f64(0.0)
+    } else if h_prime_difference <= from_f64(180.0) {
+        h_two_prime - h_one_prime
+    } else if h_two_prime <= h_one_prime {
+        h_two_prime - h_one_prime + from_f64(360.0)
     } else {
-        if h_prime_difference <= from_f64(180.0) {
-            h_two_prime - h_one_prime
-        } else {
-            if h_two_prime <= h_one_prime {
-                h_two_prime - h_one_prime + from_f64(360.0)
-            } else {
-                h_two_prime - h_one_prime - from_f64(360.0)
-            }
-        }
+        h_two_prime - h_one_prime - from_f64(360.0)
     };
 
     let delta_big_h_prime = from_f64::<T>(2.0)
@@ -77,12 +73,10 @@ pub fn get_ciede_difference<T: FloatComponent>(this: &LabColorDiff<T>, other: &L
         * (delta_h_prime / from_f64(2.0) * pi_over_180).sin();
     let h_bar_prime = if c_one_prime == T::zero() || c_two_prime == T::zero() {
         h_one_prime + h_two_prime
+    } else if h_prime_difference > from_f64(180.0) {
+        (h_one_prime + h_two_prime + from_f64(360.0)) / from_f64(2.0)
     } else {
-        if h_prime_difference > from_f64(180.0) {
-            (h_one_prime + h_two_prime + from_f64(360.0)) / from_f64(2.0)
-        } else {
-            (h_one_prime + h_two_prime) / from_f64(2.0)
-        }
+        (h_one_prime + h_two_prime) / from_f64(2.0)
     };
 
     let l_bar = (this.l + other.l) / from_f64(2.0);
@@ -103,13 +97,7 @@ pub fn get_ciede_difference<T: FloatComponent>(this: &LabColorDiff<T>, other: &L
         * (-(((h_bar_prime - from_f64(275.0)) / from_f64(25.0))
             * ((h_bar_prime - from_f64(275.0)) / from_f64(25.0))))
         .exp();
-    let c_bar_prime_pow_seven = c_bar_prime
-        * c_bar_prime
-        * c_bar_prime
-        * c_bar_prime
-        * c_bar_prime
-        * c_bar_prime
-        * c_bar_prime;
+    let c_bar_prime_pow_seven = c_bar_prime.powi(7);
     let r_c: T = from_f64::<T>(2.0)
         * (c_bar_prime_pow_seven / (c_bar_prime_pow_seven + twenty_five_pow_seven)).sqrt();
     let r_t = -r_c * (from_f64::<T>(2.0) * delta_theta * pi_over_180).sin();

--- a/palette/src/component.rs
+++ b/palette/src/component.rs
@@ -160,9 +160,9 @@ macro_rules! convert_double_to_uint {
 impl IntoComponent<f32> for u8 {
     #[inline]
     fn into_component(self) -> f32 {
-        let comp_u = self as u32 + C23;
+        let comp_u = u32::from(self) + C23;
         let comp_f = f32::from_bits(comp_u) - f32::from_bits(C23);
-        let max_u = core::u8::MAX as u32 + C23;
+        let max_u = u32::from(core::u8::MAX) + C23;
         let max_f = (f32::from_bits(max_u) - f32::from_bits(C23)).recip();
         comp_f * max_f
     }
@@ -172,9 +172,9 @@ impl IntoComponent<f32> for u8 {
 impl IntoComponent<f64> for u8 {
     #[inline]
     fn into_component(self) -> f64 {
-        let comp_u = self as u64 + C52;
+        let comp_u = u64::from(self) + C52;
         let comp_f = f64::from_bits(comp_u) - f64::from_bits(C52);
-        let max_u = core::u8::MAX as u64 + C52;
+        let max_u = u64::from(core::u8::MAX) + C52;
         let max_f = (f64::from_bits(max_u) - f64::from_bits(C52)).recip();
         comp_f * max_f
     }
@@ -218,7 +218,7 @@ macro_rules! convert_uint_to_uint {
 impl IntoComponent<f64> for f32 {
     #[inline]
     fn into_component(self) -> f64 {
-        self as f64
+        f64::from(self)
     }
 }
 convert_float_to_uint!(f32; direct (u8, u16); via f64 (u32, u64, u128););

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -6,7 +6,7 @@
 //! The default minimum requirement is to implement `FromColorUnclamped<Xyz>`, but it can
 //! also be customized to make use of generics and have other manual implementations.
 //!
-//! It is also recommended to derive or implement [`WithAlpha`](../trait.WithAlpha.html),
+//! It is also recommended to derive or implement [`WithAlpha`](crate::WithAlpha),
 //! to be able to convert between all `Alpha` wrapped color types.
 //!
 //! ## Configuration Attributes
@@ -319,7 +319,7 @@ impl<T> Display for OutOfBounds<T> {
 ///
 /// `U: IntoColor<T>` is implemented for every type `T: FromColor<U>`.
 ///
-/// See [`FromColor`](trait.FromColor.html) for more details.
+/// See [`FromColor`](crate::convert::FromColor) for more details.
 pub trait IntoColor<T>: Sized {
     /// Convert into T with values clamped to the color defined bounds
     ///
@@ -336,7 +336,7 @@ pub trait IntoColor<T>: Sized {
 ///
 /// `U: IntoColorUnclamped<T>` is implemented for every type `T: FromColorUnclamped<U>`.
 ///
-/// See [`FromColorUnclamped`](trait.FromColorUnclamped.html) for more details.
+/// See [`FromColorUnclamped`](crate::convert::FromColorUnclamped) for more details.
 pub trait IntoColorUnclamped<T>: Sized {
     /// Convert into T. The resulting color might be invalid in its color space
     ///
@@ -354,7 +354,7 @@ pub trait IntoColorUnclamped<T>: Sized {
 ///
 /// `U: TryIntoColor<T>` is implemented for every type `T: TryFromColor<U>`.
 ///
-/// See [`TryFromColor`](trait.TryFromColor.html) for more details.
+/// See [`TryFromColor`](crate::convert::TryFromColor) for more details.
 pub trait TryIntoColor<T>: Sized {
     /// Convert into T, returning ok if the color is inside of its defined
     /// range, otherwise an `OutOfBounds` error is returned which contains
@@ -379,8 +379,8 @@ pub trait TryIntoColor<T>: Sized {
 ///
 /// `U: FromColor<T>` is implemented for every type `U: FromColorUnclamped<T> + Limited`.
 ///
-/// See [`FromColorUnclamped`](trait.FromColorUnclamped.html) for a lossless version of this trait.
-/// See [`TryFromColor`](trait.TryFromColor.html) for a trait that gives an error when the result
+/// See [`FromColorUnclamped`](crate::convert::FromColorUnclamped) for a lossless version of this trait.
+/// See [`TryFromColor`](crate::convert::TryFromColor) for a trait that gives an error when the result
 /// is out of bounds.
 ///
 /// # The Difference Between FromColor and From
@@ -398,7 +398,7 @@ pub trait TryIntoColor<T>: Sized {
 /// traits, while `From` and `Into` would not be possible to blanket implement in the same way.
 /// This also reduces the work that needs to be done by macros.
 ///
-/// See the [`convert`](index.html) module for how to implement `FromColorUnclamped` for
+/// See the [`convert`](crate::convert) module for how to implement `FromColorUnclamped` for
 /// custom colors.
 pub trait FromColor<T>: Sized {
     /// Convert from T with values clamped to the color defined bounds.
@@ -414,11 +414,11 @@ pub trait FromColor<T>: Sized {
 
 /// A trait for unchecked conversion of one color from another.
 ///
-/// See [`FromColor`](trait.FromColor.html) for a lossy version of this trait.
-/// See [`TryFromColor`](trait.TryFromColor.html) for a trait that gives an error when the result
+/// See [`FromColor`](crate::convert::FromColor) for a lossy version of this trait.
+/// See [`TryFromColor`](crate::convert::TryFromColor) for a trait that gives an error when the result
 /// is out of bounds.
 ///
-/// See the [`convert`](index.html) module for how to implement `FromColorUnclamped` for
+/// See the [`convert`](crate::convert) module for how to implement `FromColorUnclamped` for
 /// custom colors.
 pub trait FromColorUnclamped<T>: Sized {
     /// Convert from T. The resulting color might be invalid in its color space.
@@ -437,10 +437,10 @@ pub trait FromColorUnclamped<T>: Sized {
 ///
 /// `U: TryFromColor<T>` is implemented for every type `U: FromColorUnclamped<T> + Limited`.
 ///
-/// See [`FromColor`](trait.FromColor.html) for a lossy version of this trait.
-/// See [`FromColorUnclamped`](trait.FromColorUnclamped.html) for a lossless version.
+/// See [`FromColor`](crate::convert::FromColor) for a lossy version of this trait.
+/// See [`FromColorUnclamped`](crate::convert::FromColorUnclamped) for a lossless version.
 ///
-/// See the [`convert`](index.html) module for how to implement `FromColorUnclamped` for
+/// See the [`convert`](crate::convert) module for how to implement `FromColorUnclamped` for
 /// custom colors.
 pub trait TryFromColor<T>: Sized {
     /// Convert from T, returning ok if the color is inside of its defined

--- a/palette/src/gradient.rs
+++ b/palette/src/gradient.rs
@@ -31,7 +31,7 @@ impl<C: Mix + Clone> Gradient<C> {
         C::Scalar: FromF64,
     {
         let mut points: Vec<_> = colors.into_iter().map(|c| (C::Scalar::zero(), c)).collect();
-        assert!(points.len() > 0);
+        assert!(!points.is_empty());
         let step_size = C::Scalar::one() / from_f64(max(points.len() - 1, 1) as f64);
 
         for (i, &mut (ref mut p, _)) in points.iter_mut().enumerate() {
@@ -45,7 +45,7 @@ impl<C: Mix + Clone> Gradient<C> {
     /// be at least one color and they are expected to be ordered by their
     /// position value.
     pub fn with_domain(colors: Vec<(C::Scalar, C)>) -> Gradient<C> {
-        assert!(colors.len() > 0);
+        assert!(!colors.is_empty());
 
         //Maybe sort the colors?
         Gradient(colors)

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -21,19 +21,19 @@ use crate::{
 };
 
 /// Linear HSL with an alpha component. See the [`Hsla` implementation in
-/// `Alpha`](struct.Alpha.html#Hsla).
+/// `Alpha`](crate::Alpha#Hsla).
 pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 
 /// HSL color space.
 ///
 /// The HSL color space can be seen as a cylindrical version of
-/// [RGB](rgb/struct.Rgb.html), where the `hue` is the angle around the color
+/// [RGB](crate::rgb::Rgb), where the `hue` is the angle around the color
 /// cylinder, the `saturation` is the distance from the center, and the
 /// `lightness` is the height from the bottom. Its composition makes it
 /// especially good for operations like changing green to red, making a color
 /// more gray, or making it darker.
 ///
-/// See [HSV](struct.Hsv.html) for a very similar color space, with brightness
+/// See [HSV](crate::Hsv) for a very similar color space, with brightness
 /// instead of lightness.
 #[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -158,7 +158,7 @@ where
     }
 }
 
-///<span id="Hsla"></span>[`Hsla`](type.Hsla.html) implementations.
+///<span id="Hsla"></span>[`Hsla`](crate::Hsla) implementations.
 impl<T, A> Alpha<Hsl<Srgb, T>, A>
 where
     T: FloatComponent,
@@ -173,7 +173,7 @@ where
     }
 }
 
-///<span id="Hsla"></span>[`Hsla`](type.Hsla.html) implementations.
+///<span id="Hsla"></span>[`Hsla`](crate::Hsla) implementations.
 impl<S, T, A> Alpha<Hsl<S, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -21,13 +21,13 @@ use crate::{
 };
 
 /// Linear HSV with an alpha component. See the [`Hsva` implementation in
-/// `Alpha`](struct.Alpha.html#Hsva).
+/// `Alpha`](crate::Alpha#Hsva).
 pub type Hsva<S = Srgb, T = f32> = Alpha<Hsv<S, T>, T>;
 
 /// HSV color space.
 ///
-/// HSV is a cylindrical version of [RGB](rgb/struct.Rgb.html) and it's very
-/// similar to [HSL](struct.Hsl.html). The difference is that the `value`
+/// HSV is a cylindrical version of [RGB](crate::rgb::Rgb) and it's very
+/// similar to [HSL](crate::Hsl). The difference is that the `value`
 /// component in HSV determines the _brightness_ of the color, and not the
 /// _lightness_. The difference is that, for example, red (100% R, 0% G, 0% B)
 /// and white (100% R, 100% G, 100% B) has the same brightness (or value), but
@@ -155,7 +155,7 @@ where
     }
 }
 
-///<span id="Hsva"></span>[`Hsva`](type.Hsva.html) implementations.
+///<span id="Hsva"></span>[`Hsva`](crate::Hsva) implementations.
 impl<T, A> Alpha<Hsv<Srgb, T>, A>
 where
     T: FloatComponent,
@@ -170,7 +170,7 @@ where
     }
 }
 
-///<span id="Hsva"></span>[`Hsva`](type.Hsva.html) implementations.
+///<span id="Hsva"></span>[`Hsva`](crate::Hsva) implementations.
 impl<S, T, A> Alpha<Hsv<S, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -21,13 +21,13 @@ use crate::{
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
-/// `Alpha`](struct.Alpha.html#Hwba).
+/// `Alpha`](crate::Alpha#Hwba).
 pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 
 /// HWB color space.
 ///
-/// HWB is a cylindrical version of [RGB](rgb/struct.Rgb.html) and it's very
-/// closely related to [HSV](struct.Hsv.html). It describes colors with a
+/// HWB is a cylindrical version of [RGB](crate::rgb::Rgb) and it's very
+/// closely related to [HSV](crate::Hsv). It describes colors with a
 /// starting hue, then a degree of whiteness and blackness to mix into that
 /// base hue.
 ///
@@ -161,7 +161,7 @@ where
     }
 }
 
-///<span id="Hwba"></span>[`Hwba`](type.Hwba.html) implementations.
+///<span id="Hwba"></span>[`Hwba`](crate::Hwba) implementations.
 impl<T, A> Alpha<Hwb<Srgb, T>, A>
 where
     T: FloatComponent,
@@ -176,7 +176,7 @@ where
     }
 }
 
-///<span id="Hwba"></span>[`Hwba`](type.Hwba.html) implementations.
+///<span id="Hwba"></span>[`Hwba`](crate::Hwba) implementations.
 impl<S, T, A> Alpha<Hwb<S, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -20,7 +20,7 @@ use crate::{
 
 /// CIE L\*a\*b\* (CIELAB) with an alpha component. See the [`Laba`
 /// implementation in `Alpha`](crate::Alpha#Laba).
-pub type Laba<Wp, T = f32> = Alpha<Lab<Wp, T>, T>;
+pub type Laba<Wp = D65, T = f32> = Alpha<Lab<Wp, T>, T>;
 
 /// The CIE L\*a\*b\* (CIELAB) color space.
 ///

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// CIE L\*a\*b\* (CIELAB) with an alpha component. See the [`Laba`
-/// implementation in `Alpha`](struct.Alpha.html#Laba).
+/// implementation in `Alpha`](crate::Alpha#Laba).
 pub type Laba<Wp, T = f32> = Alpha<Lab<Wp, T>, T>;
 
 /// The CIE L\*a\*b\* (CIELAB) color space.
@@ -152,7 +152,7 @@ where
     }
 }
 
-///<span id="Laba"></span>[`Laba`](type.Laba.html) implementations.
+///<span id="Laba"></span>[`Laba`](crate::Laba) implementations.
 impl<T, A> Alpha<Lab<D65, T>, A>
 where
     T: FloatComponent,
@@ -167,7 +167,7 @@ where
     }
 }
 
-///<span id="Laba"></span>[`Laba`](type.Laba.html) implementations.
+///<span id="Laba"></span>[`Laba`](crate::Laba) implementations.
 impl<Wp, T, A> Alpha<Lab<Wp, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -20,7 +20,7 @@ use crate::{
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
 /// `Alpha`](crate::Alpha#Lcha).
-pub type Lcha<Wp, T = f32> = Alpha<Lch<Wp, T>, T>;
+pub type Lcha<Wp = D65, T = f32> = Alpha<Lch<Wp, T>, T>;
 
 /// CIE L\*C\*h°, a polar version of [CIE L\*a\*b\*](crate::Lab).
 ///

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -19,14 +19,14 @@ use crate::{
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
-/// `Alpha`](struct.Alpha.html#Lcha).
+/// `Alpha`](crate::Alpha#Lcha).
 pub type Lcha<Wp, T = f32> = Alpha<Lch<Wp, T>, T>;
 
-/// CIE L\*C\*h°, a polar version of [CIE L\*a\*b\*](struct.Lab.html).
+/// CIE L\*C\*h°, a polar version of [CIE L\*a\*b\*](crate::Lab).
 ///
 /// L\*C\*h° shares its range and perceptual uniformity with L\*a\*b\*, but
-/// it's a cylindrical color space, like [HSL](struct.Hsl.html) and
-/// [HSV](struct.Hsv.html). This gives it the same ability to directly change
+/// it's a cylindrical color space, like [HSL](crate::Hsl) and
+/// [HSV](crate::Hsv). This gives it the same ability to directly change
 /// the hue and colorfulness of a color, while preserving other visual aspects.
 #[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -151,7 +151,7 @@ where
     }
 }
 
-///<span id="Lcha"></span>[`Lcha`](type.Lcha.html) implementations.
+///<span id="Lcha"></span>[`Lcha`](crate::Lcha) implementations.
 impl<T, A> Alpha<Lch<D65, T>, A>
 where
     T: FloatComponent,
@@ -166,7 +166,7 @@ where
     }
 }
 
-///<span id="Lcha"></span>[`Lcha`](type.Lcha.html) implementations.
+///<span id="Lcha"></span>[`Lcha`](crate::Lcha) implementations.
 impl<Wp, T, A> Alpha<Lch<Wp, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -13,7 +13,7 @@
 //! to perform on colors (addition, subtraction, multiplication, linear interpolation,
 //! etc.) will work unexpectedly when performed in such a non-linear color space. As
 //! such, the compression has to be reverted to restore linearity and make sure that
-//! many operations on the colors are accurate. 
+//! many operations on the colors are accurate.
 //!
 //! For example, this does not work:
 //!
@@ -96,7 +96,7 @@
 //! also many cases where it becomes a dead weight, if it's always stored
 //! together with the color, but not used. Palette has therefore adopted a
 //! structure where the transparency component (alpha) is attachable using the
-//! [`Alpha`](struct.Alpha.html) type, instead of having copies of each color
+//! [`Alpha`](crate::Alpha) type, instead of having copies of each color
 //! space.
 //!
 //! This approach comes with the extra benefit of allowing operations to
@@ -184,7 +184,7 @@
 //! # Working with Raw Data
 //!
 //! Oftentimes, pixel data is stored in a raw buffer such as a `[u8; 3]`. The
-//! [`Pixel`](encoding/pixel/trait.Pixel.html) trait allows for easy interoperation between
+//! [`Pixel`](crate::encoding::pixel::Pixel) trait allows for easy interoperation between
 //! Palette colors and other crates or systems. `from_raw` can be used to
 //! convert into a Palette color, `into_format` converts from  `Srgb<u8>` to
 //! `Srgb<f32>`, and finally `into_raw` to convert from a Palette color back to

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// Luminance with an alpha component. See the [`Lumaa` implementation
-/// in `Alpha`](struct.Alpha.html#Lumaa).
+/// in `Alpha`](crate::Alpha#Lumaa).
 pub type Lumaa<S = Srgb, T = f32> = Alpha<Luma<S, T>, T>;
 
 /// Luminance.
@@ -31,7 +31,7 @@ pub type Lumaa<S = Srgb, T = f32> = Alpha<Luma<S, T>, T>;
 /// Luma is a purely gray scale color space, which is included more for
 /// completeness than anything else, and represents how bright a color is
 /// perceived to be. It's basically the `Y` component of [CIE
-/// XYZ](struct.Xyz.html). The lack of any form of hue representation limits
+/// XYZ](crate::Xyz). The lack of any form of hue representation limits
 /// the set of operations that can be performed on it.
 #[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -166,7 +166,7 @@ where
     }
 }
 
-///<span id="Lumaa"></span>[`Lumaa`](type.Lumaa.html) implementations.
+///<span id="Lumaa"></span>[`Lumaa`](crate::luma::Lumaa) implementations.
 impl<S, T, A> Alpha<Luma<S, T>, A>
 where
     T: Component,
@@ -212,7 +212,7 @@ where
     }
 }
 
-///<span id="Lumaa"></span>[`Lumaa`](type.Lumaa.html) implementations.
+///<span id="Lumaa"></span>[`Lumaa`](crate::luma::Lumaa) implementations.
 impl<S, T, A> Alpha<Luma<S, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/relative_contrast.rs
+++ b/palette/src/relative_contrast.rs
@@ -52,7 +52,7 @@ pub trait RelativeContrast {
     /// The type of the contrast ratio.
     type Scalar: FromF64 + PartialOrd;
 
-    /// Calculate contrast ratio between two colors.
+    /// Calculate the contrast ratio between two colors.
     fn get_contrast_ratio(&self, other: &Self) -> Self::Scalar;
     /// Verify the contrast between two colors satisfies SC 1.4.3. Contrast
     /// is at least 4.5:1 (Level AA).
@@ -81,13 +81,10 @@ pub trait RelativeContrast {
     }
 }
 
-/// Calculate a ratio between two `luma` values.
+/// Calculate the ratio between two `luma` values.
 pub fn contrast_ratio<T>(luma1: T, luma2: T) -> T
 where
-    T: Add<Output = T>,
-    T: Div<Output = T>,
-    T: FromF64,
-    T: Component,
+    T: Component + FromF64 + Add<Output = T> + Div<Output = T>,
 {
     if luma1 > luma2 {
         (luma1 + from_f64(0.05)) / (luma2 + from_f64(0.05))

--- a/palette/src/rgb/packed.rs
+++ b/palette/src/rgb/packed.rs
@@ -45,7 +45,7 @@ use crate::Pixel;
 /// corresponding `u32`. Converting from a packed color type back to an `Rgb`
 /// type will disregard the alpha value.
 ///
-/// `Packed` implements [Pixel](encoding/pixel/trait.Pixel.html) and can be
+/// `Packed` implements [Pixel](crate::encoding::pixel::Pixel) and can be
 /// constructed from a slice of `&[u32]`.
 ///
 /// ```
@@ -68,7 +68,7 @@ pub struct Packed<C: RgbChannels = channels::Argb> {
 
     /// The channel ordering for red, green, blue, and alpha components in the
     /// packed integer; can be `Abgr`, `Argb`, `Bgra`, or `Rgba`. See
-    /// [RgbChannels](trait.RgbChannels.html).
+    /// [RgbChannels](crate::RgbChannels).
     #[palette(unsafe_zero_sized)]
     pub channel_order: PhantomData<C>,
 }

--- a/palette/src/rgb/packed/channels.rs
+++ b/palette/src/rgb/packed/channels.rs
@@ -4,7 +4,7 @@ use crate::rgb;
 
 /// RGBA color packed in ABGR order.
 ///
-/// See [Packed](struct.Packed.html) for more details.
+/// See [Packed](crate::Packed) for more details.
 pub struct Abgr;
 
 impl RgbChannels for Abgr {
@@ -19,7 +19,7 @@ impl RgbChannels for Abgr {
 
 /// RGBA color packed in ARGB order.
 ///
-/// See [Packed](struct.Packed.html) for more details.
+/// See [Packed](crate::Packed) for more details.
 pub struct Argb;
 
 impl RgbChannels for Argb {
@@ -34,7 +34,7 @@ impl RgbChannels for Argb {
 
 /// RGBA color packed in BGRA order.
 ///
-/// See [Packed](struct.Packed.html) for more details.
+/// See [Packed](crate::Packed) for more details.
 pub struct Bgra;
 
 impl RgbChannels for Bgra {
@@ -49,7 +49,7 @@ impl RgbChannels for Bgra {
 
 /// RGBA color packed in RGBA order.
 ///
-/// See [Packed](struct.Packed.html) for more details.
+/// See [Packed](crate::Packed) for more details.
 pub struct Rgba;
 
 impl RgbChannels for Rgba {

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1060,7 +1060,7 @@ impl<S: RgbStandard> FromStr for Rgb<S, u8> {
     // Parses a color hex code of format '#ff00bb' or '#abc' into a
     // Rgb<S, u8> instance.
     fn from_str(hex: &str) -> Result<Self, Self::Err> {
-        let hex_code = if hex.starts_with('#') { &hex[1..] } else { hex };
+        let hex_code = hex.strip_prefix('#').map_or(hex, |stripped| stripped);
         match hex_code.len() {
             3 => {
                 let red = u8::from_str_radix(&hex_code[..1], 16)?;

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -29,7 +29,7 @@ use crate::{
 use crate::{Hsl, Hsv, Luma, RgbHue, Xyz};
 
 /// Generic RGB with an alpha component. See the [`Rgba` implementation in
-/// `Alpha`](../struct.Alpha.html#Rgba).
+/// `Alpha`](crate::Alpha#Rgba).
 pub type Rgba<S = Srgb, T = f32> = Alpha<Rgb<S, T>, T>;
 
 /// Generic RGB.
@@ -41,7 +41,7 @@ pub type Rgba<S = Srgb, T = f32> = Alpha<Rgb<S, T>, T>;
 ///
 /// Many conversions and operations on this color space requires that it's
 /// linear, meaning that gamma correction is required when converting to and
-/// from a displayable RGB, such as sRGB. See the [`pixel`](pixel/index.html)
+/// from a displayable RGB, such as sRGB. See the [`pixel`](crate::encoding::pixel)
 /// module for encoding formats.
 #[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
@@ -169,7 +169,7 @@ impl<S: RgbStandard> Rgb<S, u8> {
     /// Convert to a packed `u32` with with specifiable component order.
     /// Defaults to ARGB ordering (0xAARRGGBB).
     ///
-    /// See [Packed](struct.Packed.html) for more details.
+    /// See [Packed](crate::Packed) for more details.
     pub fn into_u32<C: RgbChannels>(self) -> u32 {
         Packed::<C>::from(self).color
     }
@@ -177,7 +177,7 @@ impl<S: RgbStandard> Rgb<S, u8> {
     /// Convert from a packed `u32` with specifiable component order. Defaults
     /// to ARGB ordering (0xAARRGGBB).
     ///
-    /// See [Packed](struct.Packed.html) for more details.
+    /// See [Packed](crate::Packed) for more details.
     pub fn from_u32<C: RgbChannels>(color: u32) -> Self {
         Packed::<C>::from(color).into()
     }
@@ -236,7 +236,7 @@ impl<S: RgbStandard, T: Component> Rgb<S, T> {
     }
 }
 
-/// <span id="Rgba"></span>[`Rgba`](rgb/type.Rgba.html) implementations.
+/// <span id="Rgba"></span>[`Rgba`](crate::rgb::Rgba) implementations.
 impl<S: RgbStandard, T: Component, A: Component> Alpha<Rgb<S, T>, A> {
     /// Nonlinear RGB.
     pub fn new(red: T, green: T, blue: T, alpha: A) -> Self {
@@ -297,7 +297,7 @@ impl<S: RgbStandard> Rgba<S, u8> {
     /// Convert to a packed `u32` with with specifiable component order.
     /// Defaults to ARGB ordering (0xAARRGGBB).
     ///
-    /// See [Packed](struct.Packed.html) for more details.
+    /// See [Packed](crate::Packed) for more details.
     pub fn into_u32<C: RgbChannels>(self) -> u32 {
         Packed::<C>::from(self).color
     }
@@ -305,13 +305,13 @@ impl<S: RgbStandard> Rgba<S, u8> {
     /// Convert from a packed `u32` with specifiable component order. Defaults
     /// to ARGB ordering (0xAARRGGBB).
     ///
-    /// See [Packed](struct.Packed.html) for more details.
+    /// See [Packed](crate::Packed) for more details.
     pub fn from_u32<C: RgbChannels>(color: u32) -> Self {
         Packed::<C>::from(color).into()
     }
 }
 
-/// <span id="Rgba"></span>[`Rgba`](rgb/type.Rgba.html) implementations.
+/// <span id="Rgba"></span>[`Rgba`](crate::rgb::Rgba) implementations.
 impl<S: RgbStandard, T: FloatComponent, A: Component> Alpha<Rgb<S, T>, A> {
     /// Convert the color to linear RGB with transparency.
     pub fn into_linear(self) -> Alpha<Rgb<Linear<S::Space>, T>, A> {

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in
-/// `Alpha`](struct.Alpha.html#Xyza).
+/// `Alpha`](crate::Alpha#Xyza).
 pub type Xyza<Wp = D65, T = f32> = Alpha<Xyz<Wp, T>, T>;
 
 /// The CIE 1931 XYZ color space.
@@ -157,7 +157,7 @@ where
     }
 }
 
-///<span id="Xyza"></span>[`Xyza`](type.Xyza.html) implementations.
+///<span id="Xyza"></span>[`Xyza`](crate::Xyza) implementations.
 impl<T, A> Alpha<Xyz<D65, T>, A>
 where
     T: FloatComponent,
@@ -172,7 +172,7 @@ where
     }
 }
 
-///<span id="Xyza"></span>[`Xyza`](type.Xyza.html) implementations.
+///<span id="Xyza"></span>[`Xyza`](crate::Xyza) implementations.
 impl<Wp, T, A> Alpha<Xyz<Wp, T>, A>
 where
     T: FloatComponent,

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 /// CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation
-/// in `Alpha`](struct.Alpha.html#Yxya).
+/// in `Alpha`](crate::Alpha#Yxya).
 pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 
 /// The CIE 1931 Yxy (xyY)  color space.
@@ -150,7 +150,7 @@ where
     }
 }
 
-///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
+///<span id="Yxya"></span>[`Yxya`](crate::Yxya) implementations.
 impl<T, A> Alpha<Yxy<D65, T>, A>
 where
     T: FloatComponent,
@@ -164,7 +164,7 @@ where
         }
     }
 }
-///<span id="Yxya"></span>[`Yxya`](type.Yxya.html) implementations.
+///<span id="Yxya"></span>[`Yxya`](crate::Yxya) implementations.
 impl<Wp, T, A> Alpha<Yxy<Wp, T>, A>
 where
     T: FloatComponent,

--- a/palette_derive/src/alpha/with_alpha.rs
+++ b/palette_derive/src/alpha/with_alpha.rs
@@ -20,7 +20,7 @@ pub fn derive(item: TokenStream) -> ::std::result::Result<TokenStream, Vec<::syn
         attrs,
         ..
     } = syn::parse(item).map_err(|error| vec![error])?;
-    let generics = original_generics.clone();
+    let generics = original_generics;
 
     let item_meta: TypeItemAttributes = parse_namespaced_attributes(attrs)?;
 

--- a/palette_derive/src/convert/from_color_unclamped.rs
+++ b/palette_derive/src/convert/from_color_unclamped.rs
@@ -105,9 +105,7 @@ fn prepare_from_impl(
     generics: &Generics,
     generic_component: bool,
 ) -> Result<Vec<FromImplParameters>> {
-    let included_colors = COLOR_TYPES
-        .into_iter()
-        .filter(|&&color| !skip.contains(color));
+    let included_colors = COLOR_TYPES.iter().filter(|&&color| !skip.contains(color));
     let linear_path = util::path(&["encoding", "Linear"], meta.internal);
 
     let mut parameters = Vec::new();

--- a/palette_derive/src/encoding/pixel.rs
+++ b/palette_derive/src/encoding/pixel.rs
@@ -111,7 +111,7 @@ pub fn derive(tokens: TokenStream) -> std::result::Result<TokenStream, Vec<syn::
     } else {
         errors.push(syn::Error::new(
             Span::call_site(),
-            format!("`Pixel` can only be derived for structs with one or more fields"),
+            "`Pixel` can only be derived for structs with one or more fields".to_string(),
         ));
 
         return Err(errors);
@@ -127,23 +127,20 @@ fn is_repr_c(attributes: &[Attribute]) -> std::result::Result<bool, Vec<syn::Err
     for attribute in attributes {
         let attribute_name = attribute.path.get_ident().map(ToString::to_string);
 
-        match attribute_name.as_deref() {
-            Some("repr") => {
-                let items = match meta::parse_tuple_attribute(attribute.tokens.clone()) {
-                    Ok(items) => items,
-                    Err(error) => {
-                        errors.push(error);
-                        continue;
-                    }
-                };
-
-                let contains_c = items.into_iter().find(|item: &Ident| item == "C").is_some();
-
-                if contains_c {
-                    return Ok(true);
+        if let Some("repr") = attribute_name.as_deref() {
+            let items = match meta::parse_tuple_attribute(attribute.tokens.clone()) {
+                Ok(items) => items,
+                Err(error) => {
+                    errors.push(error);
+                    continue;
                 }
+            };
+
+            let contains_c = items.iter().any(|item: &Ident| item == "C");
+
+            if contains_c {
+                return Ok(true);
             }
-            _ => {}
         }
     }
 

--- a/palette_derive/src/meta/mod.rs
+++ b/palette_derive/src/meta/mod.rs
@@ -157,7 +157,7 @@ pub fn parse_tuple_attribute<T: Parse>(tts: TokenStream) -> Result<Vec<T>> {
         Ok(tuple)
     }
 
-    parse_generic_tuple.parse2(tts.clone())
+    parse_generic_tuple.parse2(tts)
 }
 
 fn parse_meta_list(buffer: &ParseBuffer) -> syn::Result<Punctuated<NestedMeta, Token![,]>> {

--- a/palette_derive/src/util.rs
+++ b/palette_derive/src/util.rs
@@ -5,7 +5,7 @@ use syn::{parse_quote, Ident, Type};
 pub fn path<'a, P: AsRef<[&'a str]>>(path: P, internal: bool) -> TokenStream {
     let path = path
         .as_ref()
-        .into_iter()
+        .iter()
         .map(|&ident| Ident::new(ident, Span::call_site()));
 
     if internal {
@@ -18,7 +18,7 @@ pub fn path<'a, P: AsRef<[&'a str]>>(path: P, internal: bool) -> TokenStream {
 
 pub fn path_type(path: &[&str], internal: bool) -> Type {
     let path = path
-        .into_iter()
+        .iter()
         .map(|&ident| Ident::new(ident, Span::call_site()));
 
     if internal {


### PR DESCRIPTION
Add default D65 WhitePoint to Lab and Lch
Collapse if else statements in color_difference.rs
Use !is_empty instead of `len > 0` comparisons in gradient.rs
Use strip_prefix instead of manually stripping, avoids manual indexing
Remove extraneous clones, into_iters, and closures
Simplify matching on single condition into an if let
Remove format! in favor of to_string
Fix deprecated `image` functions in examples
Change some `as` casts to use direct `from` casts when applicable

Closes #177 