### PR TITLE
Add uniformity tests for random colors and fix mistakes

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -38,7 +38,7 @@ version = "0.8"
 optional = true
 
 [dependencies.rand]
-version = "0.7"
+version = "0.8"
 default-features = false
 optional = true
 
@@ -66,6 +66,11 @@ default-features = false
 version = "0.23"
 default-features = false
 features = ["png"]
+
+[dev-dependencies.rand_mt]
+version = "4"
+default-features = false
+features = ["rand-traits"]
 
 [build-dependencies.phf_codegen]
 version = "0.8"

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -678,4 +678,16 @@ mod test {
 
         assert_eq!(deserialized, Rgba::<Srgb>::new(0.3, 0.8, 0.1, 0.5));
     }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Rgba<Srgb, f32> {
+            red: (0.0, 1.0),
+            green: (0.0, 1.0),
+            blue: (0.0, 1.0),
+            alpha: (0.0, 1.0)
+        },
+        min: Rgba::new(0.0f32, 0.0, 0.0, 0.0),
+        max: Rgba::new(1.0, 1.0, 1.0, 1.0)
+    }
 }

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -689,7 +689,7 @@ where
 pub struct UniformHsv<S, T>
 where
     T: FloatComponent + SampleUniform,
-    S: RgbStandard + SampleUniform,
+    S: RgbStandard,
 {
     hue: crate::hues::UniformRgbHue<T>,
     u1: Uniform<T>,
@@ -701,7 +701,7 @@ where
 impl<S, T> SampleUniform for Hsv<S, T>
 where
     T: FloatComponent + SampleUniform,
-    S: RgbStandard + SampleUniform,
+    S: RgbStandard,
 {
     type Sampler = UniformHsv<S, T>;
 }
@@ -710,7 +710,7 @@ where
 impl<S, T> UniformSampler for UniformHsv<S, T>
 where
     T: FloatComponent + SampleUniform,
-    S: RgbStandard + SampleUniform,
+    S: RgbStandard,
 {
     type X = Hsv<S, T>;
 
@@ -871,5 +871,16 @@ mod test {
             ::serde_json::from_str(r#"{"hue":0.3,"saturation":0.8,"value":0.1}"#).unwrap();
 
         assert_eq!(deserialized, Hsv::new(0.3, 0.8, 0.1));
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Hsv<crate::encoding::Srgb, f32> as crate::rgb::Rgb {
+            red: (0.0, 1.0),
+            green: (0.0, 1.0),
+            blue: (0.0, 1.0)
+        },
+        min: Hsv::new(0.0f32, 0.0, 0.0),
+        max: Hsv::new(360.0, 1.0, 1.0)
     }
 }

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -317,13 +317,18 @@ where
         B2: SampleBorrow<Self::X> + Sized,
     {
         let low = *low_b.borrow();
+        let normalized_low = LabHue::to_positive_degrees(low);
         let high = *high_b.borrow();
+        let normalized_high = LabHue::to_positive_degrees(high);
+
+        let normalized_high = if normalized_low >= normalized_high && low.0 < high.0 {
+            normalized_high + from_f64(360.0)
+        } else {
+            normalized_high
+        };
 
         UniformLabHue {
-            hue: Uniform::new(
-                LabHue::to_positive_degrees(low),
-                LabHue::to_positive_degrees(high),
-            ),
+            hue: Uniform::new(normalized_low, normalized_high),
         }
     }
 
@@ -333,13 +338,18 @@ where
         B2: SampleBorrow<Self::X> + Sized,
     {
         let low = *low_b.borrow();
+        let normalized_low = LabHue::to_positive_degrees(low);
         let high = *high_b.borrow();
+        let normalized_high = LabHue::to_positive_degrees(high);
+
+        let normalized_high = if normalized_low >= normalized_high && low.0 < high.0 {
+            normalized_high + from_f64(360.0)
+        } else {
+            normalized_high
+        };
 
         UniformLabHue {
-            hue: Uniform::new_inclusive(
-                LabHue::to_positive_degrees(low),
-                LabHue::to_positive_degrees(high),
-            ),
+            hue: Uniform::new_inclusive(normalized_low, normalized_high),
         }
     }
 
@@ -377,13 +387,18 @@ where
         B2: SampleBorrow<Self::X> + Sized,
     {
         let low = *low_b.borrow();
+        let normalized_low = RgbHue::to_positive_degrees(low);
         let high = *high_b.borrow();
+        let normalized_high = RgbHue::to_positive_degrees(high);
+
+        let normalized_high = if normalized_low >= normalized_high && low.0 < high.0 {
+            normalized_high + from_f64(360.0)
+        } else {
+            normalized_high
+        };
 
         UniformRgbHue {
-            hue: Uniform::new(
-                RgbHue::to_positive_degrees(low),
-                RgbHue::to_positive_degrees(high),
-            ),
+            hue: Uniform::new(normalized_low, normalized_high),
         }
     }
 
@@ -393,13 +408,18 @@ where
         B2: SampleBorrow<Self::X> + Sized,
     {
         let low = *low_b.borrow();
+        let normalized_low = RgbHue::to_positive_degrees(low);
         let high = *high_b.borrow();
+        let normalized_high = RgbHue::to_positive_degrees(high);
+
+        let normalized_high = if normalized_low >= normalized_high && low.0 < high.0 {
+            normalized_high + from_f64(360.0)
+        } else {
+            normalized_high
+        };
 
         UniformRgbHue {
-            hue: Uniform::new_inclusive(
-                RgbHue::to_positive_degrees(low),
-                RgbHue::to_positive_degrees(high),
-            ),
+            hue: Uniform::new_inclusive(normalized_low, normalized_high),
         }
     }
 

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -713,7 +713,7 @@ where
 pub struct UniformLab<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     l: Uniform<T>,
     a: Uniform<T>,
@@ -725,7 +725,7 @@ where
 impl<Wp, T> SampleUniform for Lab<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type Sampler = UniformLab<Wp, T>;
 }
@@ -734,7 +734,7 @@ where
 impl<Wp, T> UniformSampler for UniformLab<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type X = Lab<Wp, T>;
 
@@ -848,5 +848,16 @@ mod test {
         let deserialized: Lab = ::serde_json::from_str(r#"{"l":0.3,"a":0.8,"b":0.1}"#).unwrap();
 
         assert_eq!(deserialized, Lab::new(0.3, 0.8, 0.1));
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Lab<D65, f32> {
+            l: (0.0, 100.0),
+            a: (-128.0, 127.0),
+            b: (-128.0, 127.0)
+        },
+        min: Lab::new(0.0f32, -128.0, -128.0),
+        max: Lab::new(100.0, 127.0, 127.0)
     }
 }

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -601,7 +601,7 @@ where
 pub struct UniformLch<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     l: Uniform<T>,
     chroma: Uniform<T>,
@@ -613,7 +613,7 @@ where
 impl<Wp, T> SampleUniform for Lch<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type Sampler = UniformLch<Wp, T>;
 }
@@ -622,7 +622,7 @@ where
 impl<Wp, T> UniformSampler for UniformLch<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type X = Lch<Wp, T>;
 
@@ -719,5 +719,16 @@ mod test {
             ::serde_json::from_str(r#"{"l":0.3,"chroma":0.8,"hue":0.1}"#).unwrap();
 
         assert_eq!(deserialized, Lch::new(0.3, 0.8, 0.1));
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Lch<D65, f32> as crate::Lab {
+            l: (0.0, 100.0),
+            a: (-89.0, 89.0),
+            b: (-89.0, 89.0),
+        },
+        min: Lch::new(0.0f32, 0.0, 0.0),
+        max: Lch::new(100.0, 128.0, 360.0)
     }
 }

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -783,7 +783,7 @@ where
 pub struct UniformLuma<S, T>
 where
     T: Component + SampleUniform,
-    S: LumaStandard + SampleUniform,
+    S: LumaStandard,
 {
     luma: Uniform<T>,
     standard: PhantomData<S>,
@@ -793,7 +793,7 @@ where
 impl<S, T> SampleUniform for Luma<S, T>
 where
     T: Component + SampleUniform,
-    S: LumaStandard + SampleUniform,
+    S: LumaStandard,
 {
     type Sampler = UniformLuma<S, T>;
 }
@@ -802,7 +802,7 @@ where
 impl<S, T> UniformSampler for UniformLuma<S, T>
 where
     T: Component + SampleUniform,
-    S: LumaStandard + SampleUniform,
+    S: LumaStandard,
 {
     type X = Luma<S, T>;
 
@@ -929,5 +929,14 @@ mod test {
         let deserialized: Luma<Srgb> = ::serde_json::from_str(r#"{"luma":0.3}"#).unwrap();
 
         assert_eq!(deserialized, Luma::<Srgb>::new(0.3));
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Luma<Srgb, f32> {
+            luma: (0.0, 1.0)
+        },
+        min: Luma::new(0.0f32),
+        max: Luma::new(1.0)
     }
 }

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -124,3 +124,135 @@ macro_rules! raw_pixel_conversion_fail_tests {
         let _: $name<$($ty_param,)+ $float> = *$name::from_raw(raw);
     };
 }
+
+#[cfg(all(test, feature = "random"))]
+macro_rules! assert_uniform_distribution {
+    ($bins:expr) => {{
+        let bins = &$bins;
+
+        for (i, &bin) in bins.iter().enumerate() {
+            if bin < 5 {
+                panic!("{}[{}] < 5: {:?}", stringify!($bins), i, bins);
+            }
+        }
+        const P_LIMIT: f64 = 0.01; // Keeping it low to account for the RNG noise
+        let p_value = crate::random_sampling::test_utils::uniform_distribution_test(bins);
+        if p_value < P_LIMIT {
+            panic!(
+                "distribution of {} is not uniform enough (p-value {} < {}): {:?}",
+                stringify!($bins),
+                p_value,
+                P_LIMIT,
+                bins
+            );
+        }
+    }};
+}
+
+#[cfg(all(test, feature = "random"))]
+macro_rules! test_uniform_distribution {
+    (
+        $ty:path $(as $base_ty:path)? {
+            $($component:ident: ($component_min:expr, $component_max:expr)),+$(,)?
+        },
+        min: $min:expr,
+        max: $max:expr$(,)?
+    ) => {
+        #[cfg(feature = "random")]
+        #[test]
+        fn uniform_distribution_rng_gen() {
+            use rand::Rng;
+
+            const BINS: usize = crate::random_sampling::test_utils::BINS;
+            const SAMPLES: usize = crate::random_sampling::test_utils::SAMPLES;
+
+            $(let mut $component = [0; BINS];)+
+
+            let mut rng = rand_mt::Mt::new(1234); // We want the same seed on every run to avoid random fails
+
+            for _ in 0..SAMPLES {
+                let color: $ty = rng.gen();
+                $(let color: $base_ty = crate::convert::IntoColorUnclamped::into_color_unclamped(color);)?
+
+                if $(color.$component < $component_min || color.$component > $component_max)||+ {
+                    continue;
+                }
+
+                $({
+                    let min = $component_min;
+                    let range = $component_max - min;
+                    let normalized = (color.$component - min) / range;
+                    $component[((normalized * BINS as f32) as usize).min(BINS - 1)] += 1;
+                })+
+            }
+
+            $(assert_uniform_distribution!($component);)+
+        }
+
+        #[cfg(feature = "random")]
+        #[test]
+        fn uniform_distribution_uniform_sample() {
+            use rand::distributions::uniform::Uniform;
+            use rand::Rng;
+
+            const BINS: usize = crate::random_sampling::test_utils::BINS;
+            const SAMPLES: usize = crate::random_sampling::test_utils::SAMPLES;
+
+            $(let mut $component = [0; BINS];)+
+
+            let mut rng = rand_mt::Mt::new(1234); // We want the same seed on every run to avoid random fails
+            let uniform_sampler = Uniform::new($min, $max);
+
+            for _ in 0..SAMPLES {
+                let color: $ty = rng.sample(&uniform_sampler);
+                $(let color: $base_ty = crate::convert::IntoColorUnclamped::into_color_unclamped(color);)?
+
+                if $(color.$component < $component_min || color.$component > $component_max)||+ {
+                    continue;
+                }
+
+                $({
+                    let min = $component_min;
+                    let range = $component_max - min;
+                    let normalized = (color.$component - min) / range;
+                    $component[((normalized * BINS as f32) as usize).min(BINS - 1)] += 1;
+                })+
+            }
+
+            $(assert_uniform_distribution!($component);)+
+        }
+
+        #[cfg(feature = "random")]
+        #[test]
+        fn uniform_distribution_uniform_sample_inclusive() {
+            use rand::distributions::uniform::Uniform;
+            use rand::Rng;
+
+            const BINS: usize = crate::random_sampling::test_utils::BINS;
+            const SAMPLES: usize = crate::random_sampling::test_utils::SAMPLES;
+
+            $(let mut $component = [0; BINS];)+
+
+            let mut rng = rand_mt::Mt::new(1234); // We want the same seed on every run to avoid random fails
+            let uniform_sampler = Uniform::new_inclusive($min, $max);
+
+            for _ in 0..SAMPLES {
+                let color: $ty = rng.sample(&uniform_sampler);
+                $(let color: $base_ty = crate::convert::IntoColorUnclamped::into_color_unclamped(color);)?
+
+                if $(color.$component < $component_min || color.$component > $component_max)||+ {
+                    continue;
+                }
+
+                $({
+                    let min = $component_min;
+                    let range = $component_max - min;
+                    let normalized = (color.$component - min) / range;
+                    $component[((normalized * BINS as f32) as usize).min(BINS - 1)] += 1;
+                })+
+            }
+
+            $(assert_uniform_distribution!($component);)+
+        }
+    };
+}

--- a/palette/src/random_sampling/mod.rs
+++ b/palette/src/random_sampling/mod.rs
@@ -1,3 +1,81 @@
 mod cone;
 
 pub use self::cone::*;
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    pub(crate) const BINS: usize = 10;
+    pub(crate) const SAMPLES: usize = 20_000;
+
+    /// Perform a Chi-squared goodness-of-fit test to check if the bins are
+    /// uniformly distributed. Returns the p-value.
+    pub(crate) fn uniform_distribution_test(bins: &[usize]) -> f64 {
+        let sum = bins.iter().sum::<usize>() as f64;
+        let expected = sum / bins.len() as f64;
+        let critical_value = bins
+            .iter()
+            .map(|&bin| {
+                let difference = bin as f64 - expected;
+                difference * difference / expected
+            })
+            .sum::<f64>();
+
+        chi_square(bins.len() - 1, critical_value)
+    }
+
+    // Shamelessly taken from https://www.codeproject.com/Articles/432194/How-to-Calculate-the-Chi-Squared-P-Value
+    fn chi_square(dof: usize, critical_value: f64) -> f64 {
+        if critical_value < 0.0 || dof < 1 {
+            return 0.0;
+        }
+        let k = dof as f64 * 0.5;
+        let x = critical_value * 0.5;
+        if dof == 2 {
+            return (-x).exp();
+        }
+
+        let mut p_value = incomplete_gamma_function(k, x);
+        if p_value.is_nan() || p_value.is_infinite() || p_value <= 1e-8 {
+            return 1e-14;
+        }
+
+        p_value /= approximate_gamma(k);
+
+        1.0 - p_value
+    }
+
+    fn incomplete_gamma_function(mut s: f64, z: f64) -> f64 {
+        if z < 0.0 {
+            return 0.0;
+        }
+        let mut sc = 1.0 / s;
+        sc *= z.powf(s);
+        sc *= (-z).exp();
+
+        let mut sum = 1.0;
+        let mut nom = 1.0;
+        let mut denom = 1.0;
+
+        for _ in 0..200 {
+            nom *= z;
+            s += 1.0;
+            denom *= s;
+            sum += nom / denom;
+        }
+
+        sum * sc
+    }
+
+    fn approximate_gamma(z: f64) -> f64 {
+        const RECIP_E: f64 = 0.36787944117144232159552377016147; // RECIP_E = (E^-1) = (1.0 / E)
+        const TWOPI: f64 = core::f64::consts::TAU;
+
+        let mut d = 1.0 / (10.0 * z);
+        d = 1.0 / ((12.0 * z) - d);
+        d = (d + z) * RECIP_E;
+        d = d.powf(z);
+        d *= (TWOPI / z).sqrt();
+
+        d
+    }
+}

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1119,7 +1119,7 @@ where
 pub struct UniformRgb<S, T>
 where
     T: Component + SampleUniform,
-    S: RgbStandard + SampleUniform,
+    S: RgbStandard,
 {
     red: Uniform<T>,
     green: Uniform<T>,
@@ -1131,7 +1131,7 @@ where
 impl<S, T> SampleUniform for Rgb<S, T>
 where
     T: Component + SampleUniform,
-    S: RgbStandard + SampleUniform,
+    S: RgbStandard,
 {
     type Sampler = UniformRgb<S, T>;
 }
@@ -1140,7 +1140,7 @@ where
 impl<S, T> UniformSampler for UniformRgb<S, T>
 where
     T: Component + SampleUniform,
-    S: RgbStandard + SampleUniform,
+    S: RgbStandard,
 {
     type X = Rgb<S, T>;
 
@@ -1396,5 +1396,16 @@ mod test {
         assert_relative_eq!(Rgb::<Srgb, f32>::max_red(), 1.0);
         assert_relative_eq!(Rgb::<Srgb, f32>::max_green(), 1.0);
         assert_relative_eq!(Rgb::<Srgb, f32>::max_blue(), 1.0);
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Rgb<Srgb, f32> {
+            red: (0.0, 1.0),
+            green: (0.0, 1.0),
+            blue: (0.0, 1.0)
+        },
+        min: Rgb::new(0.0f32, 0.0, 0.0),
+        max: Rgb::new(1.0, 1.0, 1.0)
     }
 }

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -689,7 +689,7 @@ where
 pub struct UniformXyz<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     x: Uniform<T>,
     y: Uniform<T>,
@@ -701,7 +701,7 @@ where
 impl<Wp, T> SampleUniform for Xyz<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type Sampler = UniformXyz<Wp, T>;
 }
@@ -710,7 +710,7 @@ where
 impl<Wp, T> UniformSampler for UniformXyz<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type X = Xyz<Wp, T>;
 
@@ -761,6 +761,10 @@ mod test {
     use super::Xyz;
     use crate::white_point::D65;
     use crate::{FromColor, LinLuma, LinSrgb};
+
+    #[cfg(feature = "random")]
+    use crate::white_point::WhitePoint;
+
     const X_N: f64 = 0.95047;
     const Y_N: f64 = 1.0;
     const Z_N: f64 = 1.08883;
@@ -834,5 +838,16 @@ mod test {
         let deserialized: Xyz = ::serde_json::from_str(r#"{"x":0.3,"y":0.8,"z":0.1}"#).unwrap();
 
         assert_eq!(deserialized, Xyz::new(0.3, 0.8, 0.1));
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Xyz<D65, f32> {
+            x: (0.0, D65::get_xyz::<D65, f32>().x),
+            y: (0.0, D65::get_xyz::<D65, f32>().y),
+            z: (0.0, D65::get_xyz::<D65, f32>().z)
+        },
+        min: Xyz::new(0.0f32, 0.0, 0.0),
+        max: D65::get_xyz::<D65, f32>()
     }
 }

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -650,7 +650,7 @@ where
 pub struct UniformYxy<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     x: Uniform<T>,
     y: Uniform<T>,
@@ -662,7 +662,7 @@ where
 impl<Wp, T> SampleUniform for Yxy<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type Sampler = UniformYxy<Wp, T>;
 }
@@ -671,7 +671,7 @@ where
 impl<Wp, T> UniformSampler for UniformYxy<Wp, T>
 where
     T: FloatComponent + SampleUniform,
-    Wp: WhitePoint + SampleUniform,
+    Wp: WhitePoint,
 {
     type X = Yxy<Wp, T>;
 
@@ -792,5 +792,16 @@ mod test {
         let deserialized: Yxy = ::serde_json::from_str(r#"{"x":0.3,"y":0.8,"luma":0.1}"#).unwrap();
 
         assert_eq!(deserialized, Yxy::new(0.3, 0.8, 0.1));
+    }
+
+    #[cfg(feature = "random")]
+    test_uniform_distribution! {
+        Yxy<D65, f32> {
+            x: (0.0, 1.0),
+            y: (0.0, 1.0),
+            luma: (0.0, 1.0)
+        },
+        min: Yxy::new(0.0f32, 0.0, 0.0),
+        max: Yxy::new(1.0, 1.0, 1.0),
     }
 }


### PR DESCRIPTION
Adds tests that makes sure randomly generated colors are uniform within their "main" color space. I realized a Chi-squared goodness-of-fit test would do the trick, so I put this together over the past couple of days. Also found a few mistakes. I'm considering replacing the RNG with a fake RNG to avoid requiring as many samples, but that can wait.

The only space I didn't find a good test method for is `Lch`, which covers a circle. My attempts showed a slight bias towards the center, but I can't explain it. I ended up not looking further into it for now, since the test method I used (sampling only a central square) rejects too many samples anyway.