### PR TITLE
Rename Limited trait to Clamp

### DIFF
--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -14,7 +14,7 @@ use crate::convert::{FromColorUnclamped, IntoColorUnclamped};
 use crate::encoding::pixel::RawPixel;
 use crate::float::Float;
 use crate::{
-    clamp, Blend, Component, ComponentWise, GetHue, Hue, Limited, Mix, Pixel, Saturate, Shade,
+    clamp, Blend, Clamp, Component, ComponentWise, GetHue, Hue, Mix, Pixel, Saturate, Shade,
     WithAlpha,
 };
 
@@ -147,9 +147,9 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
     }
 }
 
-impl<C: Limited, T: Component> Limited for Alpha<C, T> {
-    fn is_valid(&self) -> bool {
-        self.color.is_valid() && self.alpha >= T::zero() && self.alpha <= T::max_intensity()
+impl<C: Clamp, T: Component> Clamp for Alpha<C, T> {
+    fn is_within_bounds(&self) -> bool {
+        self.color.is_within_bounds() && self.alpha >= T::zero() && self.alpha <= T::max_intensity()
     }
 
     fn clamp(&self) -> Alpha<C, T> {

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -16,8 +16,8 @@ use crate::encoding::Srgb;
 use crate::float::Float;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Component, FloatComponent, FromF64, GetHue, Hsv, Hue,
-    Limited, Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
+    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, FloatComponent, FromF64, GetHue, Hsv,
+    Hue, Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
 };
 
 /// Linear HSL with an alpha component. See the [`Hsla` implementation in
@@ -324,13 +324,13 @@ impl<S: RgbStandard, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
     }
 }
 
-impl<S, T> Limited for Hsl<S, T>
+impl<S, T> Clamp for Hsl<S, T>
 where
     T: FloatComponent,
     S: RgbStandard,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::one() &&
         self.lightness >= T::zero() && self.lightness <= T::one()
     }
@@ -817,12 +817,12 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Hsl<crate::encoding::Srgb, f64>;
-            limited {
+            clamped {
                 saturation: 0.0 => 1.0,
                 lightness: 0.0 => 1.0
             }
-            limited_min {}
-            unlimited {
+            clamped_min {}
+            unclamped {
                 hue: -360.0 => 360.0
             }
         }

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -16,8 +16,8 @@ use crate::encoding::Srgb;
 use crate::float::Float;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Component, FloatComponent, FromColor, FromF64, GetHue,
-    Hsl, Hue, Hwb, Limited, Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
+    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, FloatComponent, FromColor, FromF64,
+    GetHue, Hsl, Hue, Hwb, Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
 };
 
 /// Linear HSV with an alpha component. See the [`Hsva` implementation in
@@ -333,13 +333,13 @@ impl<S: RgbStandard, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
     }
 }
 
-impl<S, T> Limited for Hsv<S, T>
+impl<S, T> Clamp for Hsv<S, T>
 where
     T: FloatComponent,
     S: RgbStandard,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::one() &&
         self.value >= T::zero() && self.value <= T::one()
     }
@@ -832,12 +832,12 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Hsv<crate::encoding::Srgb, f64>;
-            limited {
+            clamped {
                 saturation: 0.0 => 1.0,
                 value: 0.0 => 1.0
             }
-            limited_min {}
-            unlimited {
+            clamped_min {}
+            unclamped {
                 hue: -360.0 => 360.0
             }
         }

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -16,8 +16,8 @@ use crate::encoding::Srgb;
 use crate::float::Float;
 use crate::rgb::{RgbSpace, RgbStandard};
 use crate::{
-    clamp, contrast_ratio, Alpha, Component, FloatComponent, FromF64, GetHue, Hsv, Hue, Limited,
-    Mix, Pixel, RelativeContrast, RgbHue, Shade, Xyz,
+    clamp, contrast_ratio, Alpha, Clamp, Component, FloatComponent, FromF64, GetHue, Hsv, Hue, Mix,
+    Pixel, RelativeContrast, RgbHue, Shade, Xyz,
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
@@ -265,13 +265,13 @@ impl<S: RgbStandard, T: FloatComponent, A: Component> Into<(RgbHue<T>, T, T, A)>
     }
 }
 
-impl<S, T> Limited for Hwb<S, T>
+impl<S, T> Clamp for Hwb<S, T>
 where
     T: FloatComponent,
     S: RgbStandard,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.blackness >= T::zero() && self.blackness <= T::one() &&
         self.whiteness >= T::zero() && self.whiteness <= T::one() &&
         self.whiteness + self.blackness <= T::one()
@@ -725,7 +725,7 @@ where
 #[cfg(test)]
 mod test {
     use super::Hwb;
-    use crate::{FromColor, Limited, Srgb};
+    use crate::{Clamp, FromColor, Srgb};
 
     #[test]
     fn red() {

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -14,8 +14,8 @@ use crate::convert::FromColorUnclamped;
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Component, ComponentWise, FloatComponent, GetHue,
-    LabHue, Lch, Limited, Mix, Pixel, RelativeContrast, Shade, Xyz,
+    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, ComponentWise, FloatComponent,
+    GetHue, LabHue, Lch, Mix, Pixel, RelativeContrast, Shade, Xyz,
 };
 
 /// CIE L\*a\*b\* (CIELAB) with an alpha component. See the [`Laba`
@@ -279,13 +279,13 @@ impl<Wp: WhitePoint, T: FloatComponent, A: Component> Into<(T, T, T, A)> for Alp
     }
 }
 
-impl<Wp, T> Limited for Lab<Wp, T>
+impl<Wp, T> Clamp for Lab<Wp, T>
 where
     T: FloatComponent,
     Wp: WhitePoint,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.l >= T::zero() && self.l <= from_f64(100.0) &&
         self.a >= from_f64(-128.0) && self.a <= from_f64(127.0) &&
         self.b >= from_f64(-128.0) && self.b <= from_f64(127.0)
@@ -811,13 +811,13 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Lab<D65, f64>;
-            limited {
+            clamped {
                 l: 0.0 => 100.0,
                 a: -128.0 => 127.0,
                 b: -128.0 => 127.0
             }
-            limited_min {}
-            unlimited {}
+            clamped_min {}
+            unclamped {}
         }
     }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -14,8 +14,8 @@ use crate::convert::{FromColorUnclamped, IntoColorUnclamped};
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Component, FloatComponent, FromColor, GetHue, Hue, Lab,
-    LabHue, Limited, Mix, Pixel, RelativeContrast, Saturate, Shade, Xyz,
+    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, FloatComponent, FromColor, GetHue,
+    Hue, Lab, LabHue, Mix, Pixel, RelativeContrast, Saturate, Shade, Xyz,
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
@@ -256,12 +256,12 @@ impl<Wp: WhitePoint, T: FloatComponent, A: Component> Into<(T, T, LabHue<T>, A)>
     }
 }
 
-impl<Wp, T> Limited for Lch<Wp, T>
+impl<Wp, T> Clamp for Lch<Wp, T>
 where
     T: FloatComponent,
     Wp: WhitePoint,
 {
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.l >= T::zero() && self.l <= from_f64(100.0) && self.chroma >= T::zero()
     }
 
@@ -680,13 +680,13 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Lch<D65, f64>;
-            limited {
+            clamped {
                 l: 0.0 => 100.0
             }
-            limited_min {
+            clamped_min {
                 chroma: 0.0 => 200.0
             }
-            unlimited {
+            unclamped {
                 hue: -360.0 => 360.0
             }
         }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -266,53 +266,53 @@ macro_rules! assert_ranges {
 
     (
         $ty:ident < $($ty_params:ty),+ >;
-        limited {$($limited:ident: $limited_from:expr => $limited_to:expr),+}
-        limited_min {$($limited_min:ident: $limited_min_from:expr => $limited_min_to:expr),*}
-        unlimited {$($unlimited:ident: $unlimited_from:expr => $unlimited_to:expr),*}
+        clamped {$($clamped:ident: $clamped_from:expr => $clamped_to:expr),+}
+        clamped_min {$($clamped_min:ident: $clamped_min_from:expr => $clamped_min_to:expr),*}
+        unclamped {$($unclamped:ident: $unclamped_from:expr => $unclamped_to:expr),*}
     ) => (
         {
             use core::iter::repeat;
-            use crate::Limited;
+            use crate::Clamp;
 
             {
-                print!("checking below limits ... ");
+                print!("checking below clamp bounds... ");
                 $(
-                    let from = $limited_from;
-                    let to = $limited_to;
+                    let from = $clamped_from;
+                    let to = $clamped_to;
                     let diff = to - from;
-                    let $limited = (1..11).map(|i| from - (i as f64 / 10.0) * diff);
+                    let $clamped = (1..11).map(|i| from - (i as f64 / 10.0) * diff);
                 )+
 
                 $(
-                    let from = $limited_min_from;
-                    let to = $limited_min_to;
+                    let from = $clamped_min_from;
+                    let to = $clamped_min_to;
                     let diff = to - from;
-                    let $limited_min = (1..11).map(|i| from - (i as f64 / 10.0) * diff);
+                    let $clamped_min = (1..11).map(|i| from - (i as f64 / 10.0) * diff);
                 )*
 
                 $(
-                    let from = $unlimited_from;
-                    let to = $unlimited_to;
+                    let from = $unclamped_from;
+                    let to = $unclamped_to;
                     let diff = to - from;
-                    let $unlimited = (1..11).map(|i| from - (i as f64 / 10.0) * diff);
+                    let $unclamped = (1..11).map(|i| from - (i as f64 / 10.0) * diff);
                 )*
 
-                for assert_ranges!(@make_tuple (), $($limited,)+ $($limited_min,)* $($unlimited,)* ) in repeat(()) $(.zip($limited))+ $(.zip($limited_min))* $(.zip($unlimited))* {
+                for assert_ranges!(@make_tuple (), $($clamped,)+ $($clamped_min,)* $($unclamped,)* ) in repeat(()) $(.zip($clamped))+ $(.zip($clamped_min))* $(.zip($unclamped))* {
                     let c: $ty<$($ty_params),+> = $ty {
-                        $($limited: $limited.into(),)+
-                        $($limited_min: $limited_min.into(),)*
-                        $($unlimited: $unlimited.into(),)*
+                        $($clamped: $clamped.into(),)+
+                        $($clamped_min: $clamped_min.into(),)*
+                        $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
                     let clamped = c.clamp();
                     let expected: $ty<$($ty_params),+> = $ty {
-                        $($limited: $limited_from.into(),)+
-                        $($limited_min: $limited_min_from.into(),)*
-                        $($unlimited: $unlimited.into(),)*
+                        $($clamped: $clamped_from.into(),)+
+                        $($clamped_min: $clamped_min_from.into(),)*
+                        $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
 
-                    assert!(!c.is_valid());
+                    assert!(!c.is_within_bounds());
                     assert_relative_eq!(clamped, expected);
                 }
 
@@ -320,38 +320,38 @@ macro_rules! assert_ranges {
             }
 
             {
-                print!("checking within limits ... ");
+                print!("checking within clamp bounds... ");
                 $(
-                    let from = $limited_from;
-                    let to = $limited_to;
+                    let from = $clamped_from;
+                    let to = $clamped_to;
                     let diff = to - from;
-                    let $limited = (0..11).map(|i| from + (i as f64 / 10.0) * diff);
+                    let $clamped = (0..11).map(|i| from + (i as f64 / 10.0) * diff);
                 )+
 
                 $(
-                    let from = $limited_min_from;
-                    let to = $limited_min_to;
+                    let from = $clamped_min_from;
+                    let to = $clamped_min_to;
                     let diff = to - from;
-                    let $limited_min = (0..11).map(|i| from + (i as f64 / 10.0) * diff);
+                    let $clamped_min = (0..11).map(|i| from + (i as f64 / 10.0) * diff);
                 )*
 
                 $(
-                    let from = $unlimited_from;
-                    let to = $unlimited_to;
+                    let from = $unclamped_from;
+                    let to = $unclamped_to;
                     let diff = to - from;
-                    let $unlimited = (0..11).map(|i| from + (i as f64 / 10.0) * diff);
+                    let $unclamped = (0..11).map(|i| from + (i as f64 / 10.0) * diff);
                 )*
 
-                for assert_ranges!(@make_tuple (), $($limited,)+ $($limited_min,)* $($unlimited,)* ) in repeat(()) $(.zip($limited))+ $(.zip($limited_min))* $(.zip($unlimited))* {
+                for assert_ranges!(@make_tuple (), $($clamped,)+ $($clamped_min,)* $($unclamped,)* ) in repeat(()) $(.zip($clamped))+ $(.zip($clamped_min))* $(.zip($unclamped))* {
                     let c: $ty<$($ty_params),+> = $ty {
-                        $($limited: $limited.into(),)+
-                        $($limited_min: $limited_min.into(),)*
-                        $($unlimited: $unlimited.into(),)*
+                        $($clamped: $clamped.into(),)+
+                        $($clamped_min: $clamped_min.into(),)*
+                        $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
                     let clamped = c.clamp();
 
-                    assert!(c.is_valid());
+                    assert!(c.is_within_bounds());
                     assert_relative_eq!(clamped, c);
                 }
 
@@ -359,44 +359,44 @@ macro_rules! assert_ranges {
             }
 
             {
-                print!("checking above limits ... ");
+                print!("checking above clamp bounds... ");
                 $(
-                    let from = $limited_from;
-                    let to = $limited_to;
+                    let from = $clamped_from;
+                    let to = $clamped_to;
                     let diff = to - from;
-                    let $limited = (1..11).map(|i| to + (i as f64 / 10.0) * diff);
+                    let $clamped = (1..11).map(|i| to + (i as f64 / 10.0) * diff);
                 )+
 
                 $(
-                    let from = $limited_min_from;
-                    let to = $limited_min_to;
+                    let from = $clamped_min_from;
+                    let to = $clamped_min_to;
                     let diff = to - from;
-                    let $limited_min = (1..11).map(|i| to + (i as f64 / 10.0) * diff);
+                    let $clamped_min = (1..11).map(|i| to + (i as f64 / 10.0) * diff);
                 )*
 
                 $(
-                    let from = $unlimited_from;
-                    let to = $unlimited_to;
+                    let from = $unclamped_from;
+                    let to = $unclamped_to;
                     let diff = to - from;
-                    let $unlimited = (1..11).map(|i| to + (i as f64 / 10.0) * diff);
+                    let $unclamped = (1..11).map(|i| to + (i as f64 / 10.0) * diff);
                 )*
 
-                for assert_ranges!(@make_tuple (), $($limited,)+ $($limited_min,)* $($unlimited,)* ) in repeat(()) $(.zip($limited))+ $(.zip($limited_min))* $(.zip($unlimited))* {
+                for assert_ranges!(@make_tuple (), $($clamped,)+ $($clamped_min,)* $($unclamped,)* ) in repeat(()) $(.zip($clamped))+ $(.zip($clamped_min))* $(.zip($unclamped))* {
                     let c: $ty<$($ty_params),+> = $ty {
-                        $($limited: $limited.into(),)+
-                        $($limited_min: $limited_min.into(),)*
-                        $($unlimited: $unlimited.into(),)*
+                        $($clamped: $clamped.into(),)+
+                        $($clamped_min: $clamped_min.into(),)*
+                        $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
                     let clamped = c.clamp();
                     let expected: $ty<$($ty_params),+> = $ty {
-                        $($limited: $limited_to.into(),)+
-                        $($limited_min: $limited_min.into(),)*
-                        $($unlimited: $unlimited.into(),)*
+                        $($clamped: $clamped_to.into(),)+
+                        $($clamped_min: $clamped_min.into(),)*
+                        $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
 
-                    assert!(!c.is_valid());
+                    assert!(!c.is_within_bounds());
                     assert_relative_eq!(clamped, expected);
                 }
 
@@ -457,11 +457,12 @@ fn clamp<T: PartialOrd>(v: T, min: T, max: T) -> T {
 }
 
 /// A trait for clamping and checking if colors are within their ranges.
-pub trait Limited {
-    /// Check if the color's components are within the expected ranges.
-    fn is_valid(&self) -> bool;
+pub trait Clamp {
+    /// Check if the color's components are within the expected clamped range
+    /// bounds.
+    fn is_within_bounds(&self) -> bool;
 
-    /// Return a new color where the components has been clamped to the nearest
+    /// Return a new color where the components have been clamped to the nearest
     /// valid values.
     fn clamp(&self) -> Self;
 

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -18,8 +18,8 @@ use crate::encoding::pixel::RawPixel;
 use crate::encoding::{Linear, Srgb, TransferFn};
 use crate::luma::LumaStandard;
 use crate::{
-    clamp, contrast_ratio, Alpha, Blend, Component, ComponentWise, FloatComponent, FromComponent,
-    Limited, Mix, Pixel, RelativeContrast, Shade, Xyz, Yxy,
+    clamp, contrast_ratio, Alpha, Blend, Clamp, Component, ComponentWise, FloatComponent,
+    FromComponent, Mix, Pixel, RelativeContrast, Shade, Xyz, Yxy,
 };
 
 /// Luminance with an alpha component. See the [`Lumaa` implementation
@@ -318,12 +318,12 @@ impl<S: LumaStandard, T: Component, A: Component> Into<(T, A)> for Alpha<Luma<S,
     }
 }
 
-impl<S, T> Limited for Luma<S, T>
+impl<S, T> Clamp for Luma<S, T>
 where
     T: Component,
     S: LumaStandard,
 {
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.luma >= T::zero() && self.luma <= T::max_intensity()
     }
 
@@ -851,11 +851,11 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Luma<Srgb, f64>;
-            limited {
+            clamped {
                 luma: 0.0 => 1.0
             }
-            limited_min {}
-            unlimited {}
+            clamped_min {}
+            unclamped {}
         }
     }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -23,8 +23,8 @@ use crate::luma::LumaStandard;
 use crate::matrix::{matrix_inverse, multiply_xyz_to_rgb, rgb_to_xyz_matrix};
 use crate::rgb::{Packed, RgbChannels, RgbSpace, RgbStandard, TransferFn};
 use crate::{
-    clamp, contrast_ratio, from_f64, Blend, Component, ComponentWise, FloatComponent,
-    FromComponent, GetHue, Limited, Mix, Pixel, RelativeContrast, Shade,
+    clamp, contrast_ratio, from_f64, Blend, Clamp, Component, ComponentWise, FloatComponent,
+    FromComponent, GetHue, Mix, Pixel, RelativeContrast, Shade,
 };
 use crate::{Hsl, Hsv, Luma, RgbHue, Xyz};
 
@@ -471,13 +471,13 @@ where
     }
 }
 
-impl<S, T> Limited for Rgb<S, T>
+impl<S, T> Clamp for Rgb<S, T>
 where
     S: RgbStandard,
     T: Component,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.red >= T::zero() && self.red <= T::max_intensity() &&
         self.green >= T::zero() && self.green <= T::max_intensity() &&
         self.blue >= T::zero() && self.blue <= T::max_intensity()
@@ -1198,13 +1198,13 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Rgb<Srgb, f64>;
-            limited {
+            clamped {
                 red: 0.0 => 1.0,
                 green: 0.0 => 1.0,
                 blue: 0.0 => 1.0
             }
-            limited_min {}
-            unlimited {}
+            clamped_min {}
+            unclamped {}
         }
     }
 

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -15,7 +15,7 @@ use crate::matrix::{multiply_rgb_to_xyz, rgb_to_xyz_matrix};
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Component, ComponentWise, FloatComponent, Lab, Limited,
+    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, ComponentWise, FloatComponent, Lab,
     Luma, Mix, Pixel, RelativeContrast, Shade, Yxy,
 };
 
@@ -302,13 +302,13 @@ impl<Wp: WhitePoint, T: FloatComponent, A: Component> Into<(T, T, T, A)> for Alp
     }
 }
 
-impl<Wp, T> Limited for Xyz<Wp, T>
+impl<Wp, T> Clamp for Xyz<Wp, T>
 where
     T: FloatComponent,
     Wp: WhitePoint,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         let xyz_ref: Self = Wp::get_xyz();
         self.x >= T::zero() && self.x <= xyz_ref.x &&
         self.y >= T::zero() && self.y <= xyz_ref.y &&
@@ -801,13 +801,13 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Xyz<D65, f64>;
-            limited {
+            clamped {
                 x: 0.0 => X_N,
                 y: 0.0 => Y_N,
                 z: 0.0 => Z_N
             }
-            limited_min {}
-            unlimited {}
+            clamped_min {}
+            unclamped {}
         }
     }
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -13,7 +13,7 @@ use crate::encoding::pixel::RawPixel;
 use crate::luma::LumaStandard;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, Alpha, Component, ComponentWise, FloatComponent, Limited, Luma, Mix,
+    clamp, contrast_ratio, Alpha, Clamp, Component, ComponentWise, FloatComponent, Luma, Mix,
     Pixel, RelativeContrast, Shade, Xyz,
 };
 
@@ -259,13 +259,13 @@ where
     }
 }
 
-impl<Wp, T> Limited for Yxy<Wp, T>
+impl<Wp, T> Clamp for Yxy<Wp, T>
 where
     T: FloatComponent,
     Wp: WhitePoint,
 {
     #[rustfmt::skip]
-    fn is_valid(&self) -> bool {
+    fn is_within_bounds(&self) -> bool {
         self.x >= T::zero() && self.x <= T::one() &&
         self.y >= T::zero() && self.y <= T::one() &&
         self.luma >= T::zero() && self.luma <= T::one()
@@ -755,13 +755,13 @@ mod test {
     fn ranges() {
         assert_ranges! {
             Yxy<D65, f64>;
-            limited {
+            clamped {
                 x: 0.0 => 1.0,
                 y: 0.0 => 1.0,
                 luma: 0.0 => 1.0
             }
-            limited_min {}
-            unlimited {}
+            clamped_min {}
+            unclamped {}
         }
     }
 


### PR DESCRIPTION
Rename `is_valid` to `is_within_bounds`
Update the `assert_ranges` macro to use `clamped` instead of `limited`
Update relevant documentation and examples

Closes #209