### PR TITLE
Implement PartialEq/Eq for all colorspaces, Alpha, PreAlpha, and LabHue/RgbHue

### DIFF
--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// An alpha component wrapper for colors.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Alpha<C, T> {

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// An alpha component wrapper for colors.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Alpha<C, T> {
@@ -42,6 +42,23 @@ impl<C, T: Component> Alpha<C, T> {
     pub fn max_alpha() -> T {
         T::max_intensity()
     }
+}
+
+impl<C, T> PartialEq for Alpha<C, T>
+where
+    T: Component + PartialEq,
+    C: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.color == other.color && self.alpha == other.alpha
+    }
+}
+
+impl<C, T> Eq for Alpha<C, T>
+where
+    T: Component + Eq,
+    C: Eq,
+{
 }
 
 impl<C1: WithAlpha<T>, C2, T: Component> FromColorUnclamped<C1> for Alpha<C2, T>
@@ -215,7 +232,7 @@ impl<C: Default, T: Component> Default for Alpha<C, T> {
 impl<C, T> AbsDiffEq for Alpha<C, T>
 where
     C: AbsDiffEq<Epsilon = T::Epsilon>,
-    T: AbsDiffEq,
+    T: AbsDiffEq + Component,
     T::Epsilon: Clone,
 {
     type Epsilon = T::Epsilon;
@@ -233,7 +250,7 @@ where
 impl<C, T> RelativeEq for Alpha<C, T>
 where
     C: RelativeEq<Epsilon = T::Epsilon>,
-    T: RelativeEq,
+    T: RelativeEq + Component,
     T::Epsilon: Clone,
 {
     fn default_max_relative() -> Self::Epsilon {
@@ -255,7 +272,7 @@ where
 impl<C, T> UlpsEq for Alpha<C, T>
 where
     C: UlpsEq<Epsilon = T::Epsilon>,
-    T: UlpsEq,
+    T: UlpsEq + Component,
     T::Epsilon: Clone,
 {
     fn default_max_ulps() -> u32 {

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -46,7 +46,7 @@ impl<C, T: Component> Alpha<C, T> {
 
 impl<C, T> PartialEq for Alpha<C, T>
 where
-    T: Component + PartialEq,
+    T: PartialEq,
     C: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
@@ -56,7 +56,7 @@ where
 
 impl<C, T> Eq for Alpha<C, T>
 where
-    T: Component + Eq,
+    T: Eq,
     C: Eq,
 {
 }
@@ -232,7 +232,7 @@ impl<C: Default, T: Component> Default for Alpha<C, T> {
 impl<C, T> AbsDiffEq for Alpha<C, T>
 where
     C: AbsDiffEq<Epsilon = T::Epsilon>,
-    T: AbsDiffEq + Component,
+    T: AbsDiffEq,
     T::Epsilon: Clone,
 {
     type Epsilon = T::Epsilon;
@@ -250,7 +250,7 @@ where
 impl<C, T> RelativeEq for Alpha<C, T>
 where
     C: RelativeEq<Epsilon = T::Epsilon>,
-    T: RelativeEq + Component,
+    T: RelativeEq,
     T::Epsilon: Clone,
 {
     fn default_max_relative() -> Self::Epsilon {
@@ -272,7 +272,7 @@ where
 impl<C, T> UlpsEq for Alpha<C, T>
 where
     C: UlpsEq<Epsilon = T::Epsilon>,
-    T: UlpsEq + Component,
+    T: UlpsEq,
     T::Epsilon: Clone,
 {
     fn default_max_ulps() -> u32 {

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -27,7 +27,7 @@ use crate::{clamp, Alpha, Blend, ComponentWise, Mix, Pixel};
 ///
 /// Note that converting to and from premultiplied alpha will cause the alpha
 /// component to be clamped to [0.0, 1.0].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct PreAlpha<C, T: Float> {
@@ -38,6 +38,23 @@ pub struct PreAlpha<C, T: Float> {
     /// The transparency component. 0.0 is fully transparent and 1.0 is fully
     /// opaque.
     pub alpha: T,
+}
+
+impl<C, T> PartialEq for PreAlpha<C, T>
+where
+    T: Float + PartialEq,
+    C: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.color == other.color && self.alpha == other.alpha
+    }
+}
+
+impl<C, T> Eq for PreAlpha<C, T>
+where
+    T: Float + Eq,
+    C: Eq,
+{
 }
 
 impl<C, T> From<Alpha<C, T>> for PreAlpha<C, T>

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -27,7 +27,7 @@ use crate::{clamp, Alpha, Blend, ComponentWise, Mix, Pixel};
 ///
 /// Note that converting to and from premultiplied alpha will cause the alpha
 /// component to be clamped to [0.0, 1.0].
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct PreAlpha<C, T: Float> {

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -35,7 +35,7 @@ pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 ///
 /// See [HSV](crate::Hsv) for a very similar color space, with brightness
 /// instead of lightness.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -35,7 +35,7 @@ pub type Hsla<S = Srgb, T = f32> = Alpha<Hsl<S, T>, T>;
 ///
 /// See [HSV](crate::Hsv) for a very similar color space, with brightness
 /// instead of lightness.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -156,6 +156,23 @@ where
     pub fn max_lightness() -> T {
         T::max_intensity()
     }
+}
+
+impl<S, T> PartialEq for Hsl<S, T>
+where
+    T: FloatComponent + PartialEq,
+    S: RgbStandard,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.hue == other.hue && self.saturation == other.saturation && self.lightness == other.lightness
+    }
+}
+
+impl<S, T> Eq for Hsl<S, T>
+where
+    T: FloatComponent + Eq,
+    S: RgbStandard,
+{
 }
 
 ///<span id="Hsla"></span>[`Hsla`](crate::Hsla) implementations.

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -32,7 +32,7 @@ pub type Hsva<S = Srgb, T = f32> = Alpha<Hsv<S, T>, T>;
 /// _lightness_. The difference is that, for example, red (100% R, 0% G, 0% B)
 /// and white (100% R, 100% G, 100% B) has the same brightness (or value), but
 /// not the same lightness.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -153,6 +153,23 @@ where
     pub fn max_value() -> T {
         T::max_intensity()
     }
+}
+
+impl<S, T> PartialEq for Hsv<S, T>
+where
+    T: FloatComponent + PartialEq,
+    S: RgbStandard,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.hue == other.hue && self.saturation == other.saturation && self.value == other.value
+    }
+}
+
+impl<S, T> Eq for Hsv<S, T>
+where
+    T: FloatComponent + Eq,
+    S: RgbStandard,
+{
 }
 
 ///<span id="Hsva"></span>[`Hsva`](crate::Hsva) implementations.

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -32,7 +32,7 @@ pub type Hsva<S = Srgb, T = f32> = Alpha<Hsv<S, T>, T>;
 /// _lightness_. The difference is that, for example, red (100% R, 0% G, 0% B)
 /// and white (100% R, 100% G, 100% B) has the same brightness (or value), but
 /// not the same lightness.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -119,6 +119,8 @@ macro_rules! make_hues {
             }
         }
 
+        impl<T: Float + FromF64 + Eq> Eq for $name<T> {}
+
         impl<T: Float> Add<$name<T>> for $name<T> {
             type Output = $name<T>;
 

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -33,7 +33,7 @@ pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 ///
 /// It is very intuitive for humans to use and many color-pickers are based on
 /// the HWB color system
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -33,7 +33,7 @@ pub type Hwba<S = Srgb, T = f32> = Alpha<Hwb<S, T>, T>;
 ///
 /// It is very intuitive for humans to use and many color-pickers are based on
 /// the HWB color system
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -159,6 +159,25 @@ where
     pub fn max_blackness() -> T {
         T::max_intensity()
     }
+}
+
+impl<S, T> PartialEq for Hwb<S, T>
+where
+    T: FloatComponent + PartialEq,
+    S: RgbStandard,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.hue == other.hue
+            && self.whiteness == other.whiteness
+            && self.blackness == other.blackness
+    }
+}
+
+impl<S, T> Eq for Hwb<S, T>
+where
+    T: FloatComponent + Eq,
+    S: RgbStandard,
+{
 }
 
 ///<span id="Hwba"></span>[`Hwba`](crate::Hwba) implementations.

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -33,7 +33,7 @@ pub type Laba<Wp = D65, T = f32> = Alpha<Lab<Wp, T>, T>;
 ///
 /// The parameters of L\*a\*b\* are quite different, compared to many other
 /// color spaces, so manipulating them manually may be unintuitive.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -150,6 +150,23 @@ where
     pub fn max_b() -> T {
         from_f64(127.0)
     }
+}
+
+impl<Wp, T> PartialEq for Lab<Wp, T>
+where
+    T: FloatComponent + PartialEq,
+    Wp: WhitePoint,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.l == other.l && self.a == other.a && self.b == other.b
+    }
+}
+
+impl<Wp, T> Eq for Lab<Wp, T>
+where
+    T: FloatComponent + Eq,
+    Wp: WhitePoint,
+{
 }
 
 ///<span id="Laba"></span>[`Laba`](crate::Laba) implementations.

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -33,7 +33,7 @@ pub type Laba<Wp = D65, T = f32> = Alpha<Lab<Wp, T>, T>;
 ///
 /// The parameters of L\*a\*b\* are quite different, compared to many other
 /// color spaces, so manipulating them manually may be unintuitive.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -28,7 +28,7 @@ pub type Lcha<Wp = D65, T = f32> = Alpha<Lch<Wp, T>, T>;
 /// it's a cylindrical color space, like [HSL](crate::Hsl) and
 /// [HSV](crate::Hsv). This gives it the same ability to directly change
 /// the hue and colorfulness of a color, while preserving other visual aspects.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -149,6 +149,23 @@ where
     pub fn max_extended_chroma() -> T {
         from_f64(crate::float::Float::sqrt(128.0f64 * 128.0 + 128.0 * 128.0))
     }
+}
+
+impl<Wp, T> PartialEq for Lch<Wp, T>
+where
+    T: FloatComponent + PartialEq,
+    Wp: WhitePoint,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.l == other.l && self.chroma == other.chroma && self.hue == other.hue
+    }
+}
+
+impl<Wp, T> Eq for Lch<Wp, T>
+where
+    T: FloatComponent + Eq,
+    Wp: WhitePoint,
+{
 }
 
 ///<span id="Lcha"></span>[`Lcha`](crate::Lcha) implementations.

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -28,7 +28,7 @@ pub type Lcha<Wp = D65, T = f32> = Alpha<Lch<Wp, T>, T>;
 /// it's a cylindrical color space, like [HSL](crate::Hsl) and
 /// [HSV](crate::Hsv). This gives it the same ability to directly change
 /// the hue and colorfulness of a color, while preserving other visual aspects.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -33,7 +33,7 @@ pub type Lumaa<S = Srgb, T = f32> = Alpha<Luma<S, T>, T>;
 /// perceived to be. It's basically the `Y` component of [CIE
 /// XYZ](crate::Xyz). The lack of any form of hue representation limits
 /// the set of operations that can be performed on it.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -164,6 +164,23 @@ where
             color.luma,
         )))
     }
+}
+
+impl<S, T> PartialEq for Luma<S, T>
+where
+    T: Component + PartialEq,
+    S: LumaStandard,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.luma == other.luma
+    }
+}
+
+impl<S, T> Eq for Luma<S, T>
+where
+    T: Component + Eq,
+    S: LumaStandard,
+{
 }
 
 ///<span id="Lumaa"></span>[`Lumaa`](crate::luma::Lumaa) implementations.

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -33,7 +33,7 @@ pub type Lumaa<S = Srgb, T = f32> = Alpha<Luma<S, T>, T>;
 /// perceived to be. It's basically the `Y` component of [CIE
 /// XYZ](crate::Xyz). The lack of any form of hue representation limits
 /// the set of operations that can be performed on it.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -43,7 +43,7 @@ pub type Rgba<S = Srgb, T = f32> = Alpha<Rgb<S, T>, T>;
 /// linear, meaning that gamma correction is required when converting to and
 /// from a displayable RGB, such as sRGB. See the [`pixel`](crate::encoding::pixel)
 /// module for encoding formats.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -152,6 +152,23 @@ impl<S: RgbStandard, T: Component> Rgb<S, T> {
     pub fn max_blue() -> T {
         T::max_intensity()
     }
+}
+
+impl<S, T> PartialEq for Rgb<S, T>
+where
+    T: Component + PartialEq,
+    S: RgbStandard,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.red == other.red && self.green == other.green && self.blue == other.blue
+    }
+}
+
+impl<S, T> Eq for Rgb<S, T>
+where
+    T: Component + Eq,
+    S: RgbStandard,
+{
 }
 
 /// Convenience functions to convert between a packed `u32` and `Rgb`.

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -43,7 +43,7 @@ pub type Rgba<S = Srgb, T = f32> = Alpha<Rgb<S, T>, T>;
 /// linear, meaning that gamma correction is required when converting to and
 /// from a displayable RGB, such as sRGB. See the [`pixel`](crate::encoding::pixel)
 /// module for encoding formats.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -32,7 +32,7 @@ pub type Xyza<Wp = D65, T = f32> = Alpha<Xyz<Wp, T>, T>;
 ///
 /// Conversions and operations on this color space depend on the defined white
 /// point
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -32,7 +32,7 @@ pub type Xyza<Wp = D65, T = f32> = Alpha<Xyz<Wp, T>, T>;
 ///
 /// Conversions and operations on this color space depend on the defined white
 /// point
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -155,6 +155,23 @@ where
         let xyz_ref: Xyz<Wp, _> = Wp::get_xyz();
         xyz_ref.z
     }
+}
+
+impl<Wp, T> PartialEq for Xyz<Wp, T>
+where
+    T: FloatComponent + PartialEq,
+    Wp: WhitePoint,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y && self.z == other.z
+    }
+}
+
+impl<Wp, T> Eq for Xyz<Wp, T>
+where
+    T: FloatComponent + Eq,
+    Wp: WhitePoint,
+{
 }
 
 ///<span id="Xyza"></span>[`Xyza`](crate::Xyza) implementations.

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -28,7 +28,7 @@ pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 /// for the color spaces are a plot of this color space's x and y coordinates.
 ///
 /// Conversions and operations on this color space depend on the white point.
-#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,
@@ -148,6 +148,23 @@ where
     pub fn max_luma() -> T {
         T::max_intensity()
     }
+}
+
+impl<Wp, T> PartialEq for Yxy<Wp, T>
+where
+    T: FloatComponent + PartialEq,
+    Wp: WhitePoint,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.luma == other.luma && self.x == other.x && self.y == other.y
+    }
+}
+
+impl<Wp, T> Eq for Yxy<Wp, T>
+where
+    T: FloatComponent + Eq,
+    Wp: WhitePoint,
+{
 }
 
 ///<span id="Yxya"></span>[`Yxya`](crate::Yxya) implementations.

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -28,7 +28,7 @@ pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 /// for the color spaces are a plot of this color space's x and y coordinates.
 ///
 /// Conversions and operations on this color space depend on the white point.
-#[derive(Debug, PartialEq, Pixel, FromColorUnclamped, WithAlpha)]
+#[derive(Debug, PartialEq, Eq, Pixel, FromColorUnclamped, WithAlpha)]
 #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
 #[palette(
     palette_internal,


### PR DESCRIPTION
Implement PartialEq/Eq for:
- Alpha, PreAlpha, Luma, Rgb, Hsl, Hsv, LabHue/RgbHue, Hwb, Lab, Lch, Xyz, Yxy

closes #206 