### PR TITLE
Implement relative and absolute methods for Lighten/Darken, Saturate

### DIFF
--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -121,9 +121,16 @@ impl<C: Mix> Mix for Alpha<C, C::Scalar> {
 impl<C: Shade> Shade for Alpha<C, C::Scalar> {
     type Scalar = C::Scalar;
 
-    fn lighten(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+    fn lighten(&self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
-            color: self.color.lighten(amount),
+            color: self.color.lighten(factor),
+            alpha: self.alpha,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+        Alpha {
+            color: self.color.lighten_fixed(amount),
             alpha: self.alpha,
         }
     }
@@ -159,6 +166,13 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
     fn saturate(&self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
             color: self.color.saturate(factor),
+            alpha: self.alpha,
+        }
+    }
+
+    fn saturate_fixed(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+        Alpha {
+            color: self.color.saturate_fixed(amount),
             alpha: self.alpha,
         }
     }

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -164,7 +164,9 @@ where
     S: RgbStandard,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.hue == other.hue && self.saturation == other.saturation && self.lightness == other.lightness
+        self.hue == other.hue
+            && self.saturation == other.saturation
+            && self.lightness == other.lightness
     }
 }
 
@@ -391,11 +393,28 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Hsl<S, T> {
+    fn lighten(&self, factor: T) -> Hsl<S, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.lightness
+        } else {
+            self.lightness
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Hsl {
             hue: self.hue,
             saturation: self.saturation,
-            lightness: self.lightness + amount,
+            lightness: (self.lightness + delta).max(T::zero()),
+            standard: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Hsl<S, T> {
+        Hsl {
+            hue: self.hue,
+            saturation: self.saturation,
+            lightness: (self.lightness + T::max_intensity() * amount).max(T::zero()),
             standard: PhantomData,
         }
     }
@@ -449,9 +468,26 @@ where
     type Scalar = T;
 
     fn saturate(&self, factor: T) -> Hsl<S, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.saturation
+        } else {
+            self.saturation
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Hsl {
             hue: self.hue,
-            saturation: self.saturation * (T::one() + factor),
+            saturation: (self.saturation + delta).max(T::zero()),
+            lightness: self.lightness,
+            standard: PhantomData,
+        }
+    }
+
+    fn saturate_fixed(&self, amount: T) -> Hsl<S, T> {
+        Hsl {
+            hue: self.hue,
+            saturation: (self.saturation + T::max_intensity() * amount).max(T::zero()),
             lightness: self.lightness,
             standard: PhantomData,
         }

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -401,11 +401,28 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Hsv<S, T> {
+    fn lighten(&self, factor: T) -> Hsv<S, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.value
+        } else {
+            self.value
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Hsv {
             hue: self.hue,
             saturation: self.saturation,
-            value: self.value + amount,
+            value: (self.value + delta).max(T::zero()),
+            standard: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Hsv<S, T> {
+        Hsv {
+            hue: self.hue,
+            saturation: self.saturation,
+            value: (self.value + T::max_intensity() * amount).max(T::zero()),
             standard: PhantomData,
         }
     }
@@ -459,9 +476,26 @@ where
     type Scalar = T;
 
     fn saturate(&self, factor: T) -> Hsv<S, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.saturation
+        } else {
+            self.saturation
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Hsv {
             hue: self.hue,
-            saturation: self.saturation * (T::one() + factor),
+            saturation: (self.saturation + delta).max(T::zero()),
+            value: self.value,
+            standard: PhantomData,
+        }
+    }
+
+    fn saturate_fixed(&self, amount: T) -> Hsv<S, T> {
+        Hsv {
+            hue: self.hue,
+            saturation: (self.saturation + T::max_intensity() * amount).max(T::zero()),
             value: self.value,
             standard: PhantomData,
         }

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -340,11 +340,34 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Hwb<S, T> {
+    fn lighten(&self, factor: T) -> Hwb<S, T> {
+        let difference_whiteness = if factor >= T::zero() {
+            T::max_intensity() - self.whiteness
+        } else {
+            self.whiteness
+        };
+        let delta_whiteness = difference_whiteness.max(T::zero()) * factor;
+
+        let difference_blackness = if factor >= T::zero() {
+            self.blackness
+        } else {
+            T::max_intensity() - self.blackness
+        };
+        let delta_blackness = difference_blackness.max(T::zero()) * factor;
+
         Hwb {
             hue: self.hue,
-            whiteness: self.whiteness + amount,
-            blackness: self.blackness - amount,
+            whiteness: (self.whiteness + delta_whiteness).max(T::zero()),
+            blackness: (self.blackness - delta_blackness).max(T::zero()),
+            standard: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Hwb<S, T> {
+        Hwb {
+            hue: self.hue,
+            whiteness: (self.whiteness + T::max_intensity() * amount).max(T::zero()),
+            blackness: (self.blackness - T::max_intensity() * amount).max(T::zero()),
             standard: PhantomData,
         }
     }

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -347,9 +347,26 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Lab<Wp, T> {
+    fn lighten(&self, factor: T) -> Lab<Wp, T> {
+        let difference = if factor >= T::zero() {
+            T::from_f64(100.0) - self.l
+        } else {
+            self.l
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Lab {
-            l: self.l + amount * from_f64(100.0),
+            l: (self.l + delta).max(T::zero()),
+            a: self.a,
+            b: self.b,
+            white_point: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Lab<Wp, T> {
+        Lab {
+            l: (self.l + T::from_f64(100.0) * amount).max(T::zero()),
             a: self.a,
             b: self.b,
             white_point: PhantomData,

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -320,9 +320,26 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Lch<Wp, T> {
+    fn lighten(&self, factor: T) -> Lch<Wp, T> {
+        let difference = if factor >= T::zero() {
+            T::from_f64(100.0) - self.l
+        } else {
+            self.l
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Lch {
-            l: self.l + amount * from_f64(100.0),
+            l: (self.l + delta).max(T::zero()),
+            chroma: self.chroma,
+            hue: self.hue,
+            white_point: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Lch<Wp, T> {
+        Lch {
+            l: (self.l + T::from_f64(100.0) * amount).max(T::zero()),
             chroma: self.chroma,
             hue: self.hue,
             white_point: PhantomData,
@@ -425,9 +442,26 @@ where
     type Scalar = T;
 
     fn saturate(&self, factor: T) -> Lch<Wp, T> {
+        let difference = if factor >= T::zero() {
+            Self::max_chroma() - self.chroma
+        } else {
+            self.chroma
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Lch {
             l: self.l,
-            chroma: self.chroma * (T::one() + factor),
+            chroma: (self.chroma + delta).max(T::zero()),
+            hue: self.hue,
+            white_point: PhantomData,
+        }
+    }
+
+    fn saturate_fixed(&self, amount: T) -> Lch<Wp, T> {
+        Lch {
+            l: self.l,
+            chroma: (self.chroma + Self::max_chroma() * amount).max(T::zero()),
             hue: self.hue,
             white_point: PhantomData,
         }

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -381,9 +381,24 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Luma<S, T> {
+    fn lighten(&self, factor: T) -> Luma<S, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.luma
+        } else {
+            self.luma
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Luma {
-            luma: (self.luma + amount).max(T::zero()),
+            luma: (self.luma + delta).max(T::zero()),
+            standard: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Luma<S, T> {
+        Luma {
+            luma: (self.luma + T::max_intensity() * amount).max(T::zero()),
             standard: PhantomData,
         }
     }

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -539,11 +539,41 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Rgb<S, T> {
+    fn lighten(&self, factor: T) -> Rgb<S, T> {
+        let difference_red = if factor >= T::zero() {
+            T::max_intensity() - self.red
+        } else {
+            self.red
+        };
+        let delta_red = difference_red.max(T::zero()) * factor;
+
+        let difference_green = if factor >= T::zero() {
+            T::max_intensity() - self.green
+        } else {
+            self.green
+        };
+        let delta_green = difference_green.max(T::zero()) * factor;
+
+        let difference_blue = if factor >= T::zero() {
+            T::max_intensity() - self.blue
+        } else {
+            self.blue
+        };
+        let delta_blue = difference_blue.max(T::zero()) * factor;
+
         Rgb {
-            red: self.red + amount,
-            green: self.green + amount,
-            blue: self.blue + amount,
+            red: (self.red + delta_red).max(T::zero()),
+            green: (self.green + delta_green).max(T::zero()),
+            blue: (self.blue + delta_blue).max(T::zero()),
+            standard: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Rgb<S, T> {
+        Rgb {
+            red: (self.red + T::max_intensity() * amount).max(T::zero()),
+            green: (self.green + T::max_intensity() * amount).max(T::zero()),
+            blue: (self.blue + T::max_intensity() * amount).max(T::zero()),
             standard: PhantomData,
         }
     }

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -372,10 +372,27 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Xyz<Wp, T> {
+    fn lighten(&self, factor: T) -> Xyz<Wp, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.y
+        } else {
+            self.y
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Xyz {
             x: self.x,
-            y: self.y + amount,
+            y: (self.y + delta).max(T::zero()),
+            z: self.z,
+            white_point: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Xyz<Wp, T> {
+        Xyz {
+            x: self.x,
+            y: (self.y + T::max_intensity() * amount).max(T::zero()),
             z: self.z,
             white_point: PhantomData,
         }

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -328,11 +328,28 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, amount: T) -> Yxy<Wp, T> {
+    fn lighten(&self, factor: T) -> Yxy<Wp, T> {
+        let difference = if factor >= T::zero() {
+            T::max_intensity() - self.luma
+        } else {
+            self.luma
+        };
+
+        let delta = difference.max(T::zero()) * factor;
+
         Yxy {
             x: self.x,
             y: self.y,
-            luma: self.luma + amount,
+            luma: (self.luma + delta).max(T::zero()),
+            white_point: PhantomData,
+        }
+    }
+
+    fn lighten_fixed(&self, amount: T) -> Yxy<Wp, T> {
+        Yxy {
+            x: self.x,
+            y: self.y,
+            luma: (self.luma + T::max_intensity() * amount).max(T::zero()),
             white_point: PhantomData,
         }
     }


### PR DESCRIPTION
Add `lighten_fixed` and `darken_fixed` methods to the Shade trait. The
`_fixed` functions inherit similar behavior to the old `lighten/darken`.
The new implementation scales the color toward the maximum or minimum
value for lightness or saturation. This should be more intuitive to
adjust as a small factor could have drastically different results based
on the color space. The same change is made for saturate/desaturate with
corresponding `_fixed` methods.

Add doc tests showing new behavior of Saturate and Shade
Differentiate between the absolute and relative lighten/darken/saturate
by using `amount` to refer to the fixed/absolute functions and `factor`
when using the relative versions (the new default version is relative).

Account for negative factors in the saturate and shade functions.

closes #215 