### PR TITLE
Upgrade phf to 0.9 and enable named_from_str for no_std

### DIFF
--- a/no_std_test/Cargo.toml
+++ b/no_std_test/Cargo.toml
@@ -22,4 +22,4 @@ default-features = false
 [dependencies.palette]
 path = "../palette"
 default-features = false
-features = ["libm", "named"]
+features = ["libm", "named_from_str"]

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -2,7 +2,17 @@
 name = "palette"
 version = "0.5.0" #automatically updated
 authors = ["Erik Hedvall <hello@erikhedvall.nu>"]
-exclude = ["scripts/*", "examples/*", "tests/*", "res/*", ".travis.yml", ".gitignore", "CHANGELOG.md", "CONTRIBUTING.md", "version.sh"]
+exclude = [
+    "scripts/*",
+    "examples/*",
+    "tests/*",
+    "res/*",
+    ".travis.yml",
+    ".gitignore",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "version.sh"
+]
 description = "Convert and manage colors with a focus on correctness, flexibility and ease of use."
 documentation = "https://docs.rs/palette/0.5.0/palette/"
 repository = "https://github.com/Ogeon/palette"
@@ -11,17 +21,15 @@ keywords = ["color", "conversion", "linear", "pixel", "rgb"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 categories = ["graphics", "multimedia::images", "no-std"]
-
 build = "build/main.rs"
 
 [features]
 default = ["named_from_str", "named_gradients", "std"]
-named_from_str = ["named", "phf", "phf_codegen", "std"]
+named_from_str = ["named", "phf"]
 named = []
 named_gradients = ["std"]
 random = ["rand"]
 serializing = ["serde", "std"]
-
 #ignore in feature test
 std = ["approx/std", "num-traits/std"]
 libm = ["num-traits/libm"]
@@ -30,13 +38,15 @@ libm = ["num-traits/libm"]
 bench = false
 
 [dependencies]
-palette_derive = {version = "0.5.0", path = "../palette_derive"}
-num-traits = {version = "0.2", default-features = false}
-approx = {version = "0.5", default-features = false}
+palette_derive = { version = "0.5.0", path = "../palette_derive" }
+num-traits = { version = "0.2", default-features = false }
+approx = { version = "0.5", default-features = false }
 
 [dependencies.phf]
-version = "0.8"
+version = "0.9"
 optional = true
+default-features = false
+features = ["macros"]
 
 [dependencies.rand]
 version = "0.8"
@@ -76,10 +86,6 @@ features = ["png"]
 version = "4"
 default-features = false
 features = ["rand-traits"]
-
-[build-dependencies.phf_codegen]
-version = "0.8"
-optional = true
 
 [[bench]]
 path = "benches/cie.rs"

--- a/palette/README.md
+++ b/palette/README.md
@@ -9,7 +9,7 @@ A color management and conversion library that focuses on maintaining correctnes
 * Color operations implemented as traits, such as arithmetic, lighten/darken, hue shifting, mixing/interpolating, and SVG blend functions.
 * Provides types for creating gradients.
 * Color spaces can be customized, using type parameters, to support different levels of precision, linearity, white points, RGB standards, etc.
-* Supports `#[no_std]`, with gradients and dynamic named colors disabled.
+* Supports `#[no_std]`, with only gradients disabled.
 * Optional `serde` and `rand` integration.
 
 ## Minimum Supported Rust Version (MSRV)
@@ -39,7 +39,8 @@ features = ["libm"] # Uses libm instead of std for floating point math
 These features are enabled by default:
 
 * `"named"` - Enables color constants, located in the `named` module.
-* `"named_from_str"` - Enables `named::from_str`, which maps name strings to colors. This requires the standard library.
+* `"named_from_str"` - Enables `named::from_str`, which maps name strings to colors.
+* `"named_gradients"`- Enables gradient constants, located in `gradient::named`. This requires the standard library.
 * `"std"` - Enables use of the standard library.
 
 These features are disabled by default:
@@ -53,9 +54,8 @@ These features are disabled by default:
 
 Palette supports `#![no_std]` environments by disabling the `"std"` feature. However, there are some things that are unavailable without the standard library:
 
-* Gradients are unavailable, because they depend heavily on Vectors
-* The `"named_from_str"` feature requires the standard library as well
-* Serialization using `serde` is unavailable
+* Gradients are unavailable, because they depend heavily on Vectors.
+* Serialization using `serde` is unavailable.
 
 It uses [`libm`] to provide the floating-point operations that are typically in `std`.
 

--- a/palette/build/main.rs
+++ b/palette/build/main.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "phf_codegen")]
-extern crate phf_codegen;
-
 mod named;
 
 fn main() {

--- a/palette/build/named.rs
+++ b/palette/build/named.rs
@@ -54,24 +54,34 @@ pub fn build_colors(writer: &mut File) {
 pub fn build_gradients(writer: &mut File) {
     use std::io::{BufRead, BufReader, Write};
 
-    let reader =
-        BufReader::new(File::open("build/svg_gradients_mpl.txt").expect("could not open svg_gradients_mpl.txt"));
+    let reader = BufReader::new(
+        File::open("build/svg_gradients_mpl.txt").expect("could not open svg_gradients_mpl.txt"),
+    );
 
     let mut line_iter = reader.lines();
-    while let Some(Ok(line)) = line_iter.next(){
+    while let Some(Ok(line)) = line_iter.next() {
         //empty lines are allowed
-        if line.is_empty() {continue;}
+        if line.is_empty() {
+            continue;
+        }
         let mut parts = line.split_whitespace();
         //every line should have the same info: name type number_of_colors [\n red green blue]^number_of_colors
         let name = parts.next().expect("couldn't get the color name");
         let color_type = parts.next().expect("couldn't get the type of the colors");
         //we assume that color_type is a rgb type
         let color_type = format!("crate::rgb::{}", color_type);
-        let number_of_colors : usize = parts.next().expect("couldn't get the number of colors")
-            .parse().unwrap_or_else(|_| panic!("couldn't parse the number of colors for color {}", name));
+        let number_of_colors: usize = parts
+            .next()
+            .expect("couldn't get the number of colors")
+            .parse()
+            .unwrap_or_else(|_| panic!("couldn't parse the number of colors for color {}", name));
         writeln!(writer, "/// New matplotlib colormap by Nathaniel J. Smith, Stefan van der Walt, and (in the case of viridis) Eric Firing.").unwrap();
         writeln!(writer, "/// This gradient is perfectly perceptually-uniform, both in regular form and also when converted to black-and-white.").unwrap();
-        writeln!(writer, "/// The colormap is released under the CC0 license public domain dedication.").unwrap();
+        writeln!(
+            writer,
+            "/// The colormap is released under the CC0 license public domain dedication."
+        )
+        .unwrap();
         write!(writer,
             "pub const {0}: crate::gradient::Gradient<{1}, [(f32,{1});{2}]> = crate::gradient::Gradient([",
             name.to_uppercase(), color_type, number_of_colors).unwrap();
@@ -103,16 +113,18 @@ pub fn build_gradients(writer: &mut File) {
 fn gen_from_str(writer: &mut File, entries: &[(String, String)]) {
     use std::io::Write;
 
-    let mut map = ::phf_codegen::Map::new();
-    for &(ref key, ref value) in entries {
-        map.entry(&**key, value);
+    writer
+        .write_all(
+            "static COLORS: ::phf::Map<&'static str, crate::rgb::Srgb<u8>> = phf::phf_map! {\n"
+                .as_bytes(),
+        )
+        .unwrap();
+
+    for (key, value) in entries {
+        writeln!(writer, "    \"{}\" => {},", key, value).unwrap();
     }
-    write!(
-        writer,
-        "static COLORS: ::phf::Map<&'static str, crate::rgb::Srgb<u8>> = {};",
-        map.build()
-    )
-    .unwrap();
+
+    writer.write_all("};\n".as_bytes()).unwrap();
 }
 
 #[cfg(not(feature = "named"))]


### PR DESCRIPTION
While upgrading `phf` to 0.9, I also realized that it could easily be made available with `no_std` by switching to the macro instead of `phf_codegen`.

I also noticed that I forgot to add `named_gradients` in the readme.