### PR TITLE
Relax trait bounds for all color types

### DIFF
--- a/palette/examples/random.rs
+++ b/palette/examples/random.rs
@@ -5,7 +5,7 @@ fn main() {
 
 #[cfg(feature = "random")]
 fn main() {
-    use palette::{FromColor, Hsl, Hsv, Hwb, Pixel, RgbHue, Srgb};
+    use palette::{Hsl, Hsv, Hwb, IntoColor, Pixel, RgbHue, Srgb};
 
     use image::{GenericImage, GenericImageView, RgbImage};
     use rand::Rng;
@@ -19,7 +19,7 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color = Srgb::<f32>::new(rng.gen(), rng.gen(), rng.gen());
+                let random_color: Srgb = Srgb::new(rng.gen(), rng.gen(), rng.gen());
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -30,7 +30,7 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color = rng.gen::<Srgb>();
+                let random_color: Srgb = rng.gen();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -42,8 +42,8 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color =
-                    Srgb::from_color(Hsv::new(rng.gen::<RgbHue>(), rng.gen(), rng.gen()));
+                let random_color: Srgb =
+                    Hsv::new(rng.gen::<RgbHue>(), rng.gen(), rng.gen()).into_color();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -54,7 +54,7 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color = Srgb::from_color(rng.gen::<Hsv>());
+                let random_color: Srgb = rng.gen::<Hsv>().into_color();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -66,8 +66,8 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color =
-                    Srgb::from_color(Hsl::new(rng.gen::<RgbHue>(), rng.gen(), rng.gen()));
+                let random_color: Srgb =
+                    Hsl::new(rng.gen::<RgbHue>(), rng.gen(), rng.gen()).into_color();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -78,7 +78,7 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color = Srgb::from_color(rng.gen::<Hsl>());
+                let random_color: Srgb = rng.gen::<Hsl>().into_color();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -90,8 +90,8 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color =
-                    Srgb::from_color(Hwb::new(rng.gen::<RgbHue>(), rng.gen(), rng.gen()));
+                let random_color: Srgb =
+                    Hwb::new(rng.gen::<RgbHue>(), rng.gen(), rng.gen()).into_color();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }
@@ -102,7 +102,7 @@ fn main() {
         let (width, height) = sub_image.dimensions();
         for x in 0..width {
             for y in 0..height {
-                let random_color = Srgb::from_color(rng.gen::<Hwb>());
+                let random_color: Srgb = rng.gen::<Hwb>().into_color();
                 sub_image.put_pixel(x, y, image::Rgb(random_color.into_format().into_raw()));
             }
         }

--- a/palette/src/alpha.rs
+++ b/palette/src/alpha.rs
@@ -1,5 +1,6 @@
 use crate::Component;
 
+use num_traits::Zero;
 #[doc(hidden)]
 pub use palette_derive::WithAlpha;
 
@@ -67,7 +68,7 @@ mod alpha;
 ///
 /// assert_eq!(transparent.alpha, 10);
 /// ```
-pub trait WithAlpha<A: Component>: Sized {
+pub trait WithAlpha<A>: Sized {
     /// The opaque color type, without any transparency.
     ///
     /// This is typically `Self`.
@@ -142,7 +143,10 @@ pub trait WithAlpha<A: Component>: Sized {
     /// let opaque: Srgba<u8> = color.opaque();
     /// assert_eq!(opaque.alpha, 255);
     /// ```
-    fn opaque(self) -> Self::WithAlpha {
+    fn opaque(self) -> Self::WithAlpha
+    where
+        A: Component,
+    {
         self.with_alpha(A::max_intensity())
     }
 
@@ -157,7 +161,10 @@ pub trait WithAlpha<A: Component>: Sized {
     /// let transparent: Srgba<u8> = color.transparent();
     /// assert_eq!(transparent.alpha, 0);
     /// ```
-    fn transparent(self) -> Self::WithAlpha {
+    fn transparent(self) -> Self::WithAlpha
+    where
+        A: Zero,
+    {
         self.with_alpha(A::zero())
     }
 }

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -17,16 +17,15 @@
 //! ```
 //! # use palette::rgb::{RgbStandard, RgbSpace};
 //! # use palette::convert::FromColorUnclamped;
-//! # use palette::{Xyz, Component, FloatComponent};
+//! # use palette::{Xyz, FloatComponent};
 //! #
 //! #[palette(
 //!     component = "T",
 //!     rgb_standard = "S",
-//!     white_point = "<S::Space as RgbSpace>::WhitePoint",
 //! )]
 //! #[derive(FromColorUnclamped)]
 //! #[repr(C)]
-//! struct ExampleType<S: RgbStandard, T: Component> {
+//! struct ExampleType<S, T> {
 //!     // ...
 //!     #[palette(alpha)]
 //!     alpha: T,
@@ -72,6 +71,9 @@
 //! type that should be used when deriving. The default is to either use `Srgb`
 //! or a best effort to convert between standards, but sometimes it has to be set
 //! to a specific type. This also accepts type parameters.
+//!
+//! * `luma_standard = "some::rgb_standard::Type"`: Sets the Luma standard
+//! type that should be used when deriving, similar to `rgb_standard`.
 //!
 //! ## Field Attributes
 //!

--- a/palette/src/equality.rs
+++ b/palette/src/equality.rs
@@ -1,7 +1,6 @@
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 use crate::float::Float;
-use crate::white_point::WhitePoint;
 use crate::{
     from_f64, FloatComponent, FromF64, Hsluv, Lab, LabHue, Lch, Lchuv, Luv, LuvHue, OklabHue,
     RgbHue, Xyz, Yxy,
@@ -9,10 +8,21 @@ use crate::{
 
 macro_rules! impl_eq {
     (  $self_ty: ident , [$($element: ident),+]) => {
+
+        impl<Wp, T> PartialEq for $self_ty<Wp, T>
+        where
+            T: FloatComponent + PartialEq,
+        {
+            fn eq(&self, other: &Self) -> bool {
+                $( self.$element == other.$element )&&+
+            }
+        }
+
+        impl<S, T> Eq for $self_ty<S, T> where T: FloatComponent + Eq {}
+
         impl<Wp, T> AbsDiffEq for $self_ty<Wp, T>
         where T: FloatComponent + AbsDiffEq,
-            T::Epsilon: Copy + FloatComponent,
-            Wp: WhitePoint + PartialEq
+            T::Epsilon: Clone + FloatComponent,
         {
             type Epsilon = T::Epsilon;
 
@@ -21,44 +31,42 @@ macro_rules! impl_eq {
             }
 
             fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
-                $( self.$element.abs_diff_eq(&other.$element, epsilon) )&&+
+                $( self.$element.abs_diff_eq(&other.$element, epsilon.clone()) )&&+
             }
             fn abs_diff_ne(&self, other: &Self, epsilon: T::Epsilon) -> bool {
-                $( self.$element.abs_diff_ne(&other.$element, epsilon) )||+
+                $( self.$element.abs_diff_ne(&other.$element, epsilon.clone()) )||+
             }
         }
 
         impl<Wp, T> RelativeEq for $self_ty<Wp, T>
         where T: FloatComponent + RelativeEq,
-            T::Epsilon: Copy + FloatComponent,
-            Wp: WhitePoint + PartialEq
+            T::Epsilon: Clone + FloatComponent,
         {
             fn default_max_relative() -> T::Epsilon {
                 T::default_max_relative()
             }
 
             fn relative_eq(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
-                $( self.$element.relative_eq(&other.$element, epsilon, max_relative) )&&+
+                $( self.$element.relative_eq(&other.$element, epsilon.clone(), max_relative) )&&+
             }
             fn relative_ne(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
-                $( self.$element.relative_ne(&other.$element, epsilon, max_relative) )||+
+                $( self.$element.relative_ne(&other.$element, epsilon.clone(), max_relative) )||+
             }
         }
 
         impl<Wp, T> UlpsEq for $self_ty<Wp, T>
         where T: FloatComponent + UlpsEq,
-            T::Epsilon: Copy + FloatComponent,
-            Wp: WhitePoint + PartialEq
+            T::Epsilon: Clone + FloatComponent,
         {
             fn default_max_ulps() -> u32 {
                 T::default_max_ulps()
             }
 
             fn ulps_eq(&self, other: &Self, epsilon: T::Epsilon, max_ulps: u32) -> bool {
-                $( self.$element.ulps_eq(&other.$element, epsilon, max_ulps) )&&+
+                $( self.$element.ulps_eq(&other.$element, epsilon.clone(), max_ulps) )&&+
             }
             fn ulps_ne(&self, other: &Self, epsilon: T::Epsilon, max_ulps: u32) -> bool {
-                $( self.$element.ulps_ne(&other.$element, epsilon, max_ulps) )||+
+                $( self.$element.ulps_ne(&other.$element, epsilon.clone(), max_ulps) )||+
             }
         }
     }

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -23,15 +23,23 @@ macro_rules! make_hues {
         #[derive(Clone, Copy, Debug, Default)]
         #[cfg_attr(feature = "serializing", derive(Serialize, Deserialize))]
         #[repr(C)]
-        pub struct $name<T: Float = f32>(T);
+        pub struct $name<T = f32>(T);
 
-        impl<T: Float + FromF64> $name<T> {
+        impl<T> $name<T> {
             /// Create a new hue from degrees.
             #[inline]
             pub fn from_degrees(degrees: T) -> $name<T> {
                 $name(degrees)
             }
 
+            /// Get the internal representation, without normalizing it.
+            #[inline]
+            pub fn to_raw_degrees(self) -> T {
+                self.0
+            }
+        }
+
+        impl<T: Float + FromF64> $name<T> {
             /// Create a new hue from radians, instead of degrees.
             #[inline]
             pub fn from_radians(radians: T) -> $name<T> {
@@ -62,12 +70,6 @@ macro_rules! make_hues {
                 normalize_angle_positive(self.0).to_radians()
             }
 
-            /// Get the internal representation, without normalizing it.
-            #[inline]
-            pub fn to_raw_degrees(self) -> T {
-                self.0
-            }
-
             /// Get the internal representation as radians, without normalizing it.
             #[inline]
             pub fn to_raw_radians(self) -> T {
@@ -75,7 +77,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: Float> From<T> for $name<T> {
+        impl<T> From<T> for $name<T> {
             #[inline]
             fn from(degrees: T) -> $name<T> {
                 $name(degrees)
@@ -121,7 +123,7 @@ macro_rules! make_hues {
 
         impl<T: Float + FromF64 + Eq> Eq for $name<T> {}
 
-        impl<T: Float> Add<$name<T>> for $name<T> {
+        impl<T: Add<Output=T>> Add<$name<T>> for $name<T> {
             type Output = $name<T>;
 
             #[inline]
@@ -130,7 +132,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: Float> Add<T> for $name<T> {
+        impl<T: Add<Output=T>> Add<T> for $name<T> {
             type Output = $name<T>;
 
             #[inline]
@@ -157,14 +159,14 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: Float + AddAssign> AddAssign<$name<T>> for $name<T> {
+        impl<T: AddAssign> AddAssign<$name<T>> for $name<T> {
             #[inline]
             fn add_assign(&mut self, other: $name<T>) {
                 self.0 += other.0;
             }
         }
 
-        impl<T: Float + AddAssign> AddAssign<T> for $name<T> {
+        impl<T: AddAssign> AddAssign<T> for $name<T> {
             #[inline]
             fn add_assign(&mut self, other: T) {
                 self.0 += other;
@@ -185,7 +187,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: Float> Sub<$name<T>> for $name<T> {
+        impl<T: Sub<Output=T>> Sub<$name<T>> for $name<T> {
             type Output = $name<T>;
 
             #[inline]
@@ -194,7 +196,7 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: Float> Sub<T> for $name<T> {
+        impl<T: Sub<Output=T>> Sub<T> for $name<T> {
             type Output = $name<T>;
 
             #[inline]
@@ -221,14 +223,14 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: Float + SubAssign> SubAssign<$name<T>> for $name<T> {
+        impl<T: SubAssign> SubAssign<$name<T>> for $name<T> {
             #[inline]
             fn sub_assign(&mut self, other: $name<T>) {
                 self.0 -= other.0;
             }
         }
 
-        impl<T: Float + SubAssign> SubAssign<T> for $name<T> {
+        impl<T: SubAssign> SubAssign<T> for $name<T> {
             #[inline]
             fn sub_assign(&mut self, other: T) {
                 self.0 -= other;
@@ -261,9 +263,9 @@ macro_rules! make_hues {
         }
 
         #[cfg(feature = "bytemuck")]
-        unsafe impl<T: Float + bytemuck::Zeroable> bytemuck::Zeroable for $name<T> {}
+        unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for $name<T> {}
         #[cfg(feature = "bytemuck")]
-        unsafe impl<T: Float + bytemuck::Pod> bytemuck::Pod for $name<T> {}
+        unsafe impl<T: bytemuck::Pod> bytemuck::Pod for $name<T> {}
     )+)
 }
 

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -258,112 +258,391 @@ macro_rules! test_uniform_distribution {
 }
 
 macro_rules! impl_color_add {
-    ($self_ty: ident , [$($element: ident),+], $phantom: ident) => {
-	impl<Wp, T> Add<$self_ty<Wp, T>> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent,
-	    Wp: WhitePoint,
-	{
-	    type Output = $self_ty<Wp, T>;
+    ($self_ty: ident < $phantom_ty: ident, $component_ty: ident > , [$($element: ident),+], $phantom: ident) => {
+        impl<$phantom_ty, $component_ty> Add<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Add<Output=$component_ty>
+        {
+            type Output = Self;
 
-	    fn add(self, other: $self_ty<Wp, T>) -> Self::Output {
-		$self_ty {
-		    $( $element: self.$element + other.$element ),+,
-		    $phantom: PhantomData,
-		}
-	    }
-	}
-	impl<Wp, T> Add<T> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent,
-	    Wp: WhitePoint,
-	{
-	    type Output = $self_ty<Wp, T>;
+            fn add(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element + other.$element, )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
 
-	    fn add(self, c: T) -> Self::Output {
-		$self_ty {
-		    $( $element: self.$element + c ),+,
-		    $phantom: PhantomData,
-		}
-	    }
-	}
+        impl<$phantom_ty, $component_ty> Add<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Add<Output=$component_ty> + Clone
+        {
+            type Output = Self;
 
-	impl<Wp, T> AddAssign<$self_ty<Wp, T>> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent + AddAssign,
-	    Wp: WhitePoint,
-	{
-	    fn add_assign(&mut self, other: $self_ty<Wp, T>) {
-		$( self.$element += other.$element );+
-	    }
-	}
+            fn add(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element + c.clone(), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
 
-	impl<Wp, T> AddAssign<T> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent + AddAssign,
-	    Wp: WhitePoint,
-	{
-	    fn add_assign(&mut self, c: T) {
-		$( self.$element += c );+
-	    }
-	}
-    }
+        impl<$phantom_ty, $component_ty> AddAssign<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: AddAssign,
+        {
+            fn add_assign(&mut self, other: Self) {
+                $( self.$element += other.$element; )+
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> AddAssign<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T:  AddAssign + Clone
+        {
+            fn add_assign(&mut self, c: $component_ty) {
+                $( self.$element += c.clone(); )+
+            }
+        }
+    };
+    ($self_ty: ident < $component_ty: ident > , [$($element: ident),+]) => {
+        impl<$component_ty> Add<Self> for $self_ty<$component_ty>
+        where
+            T: Add<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn add(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element + other.$element, )+
+                }
+            }
+        }
+
+        impl<$component_ty> Add<$component_ty> for $self_ty<$component_ty>
+        where
+            T: Add<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn add(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element + c.clone(), )+
+                }
+            }
+        }
+
+        impl<$component_ty> AddAssign<Self> for $self_ty<$component_ty>
+        where
+            T: AddAssign,
+        {
+            fn add_assign(&mut self, other: Self) {
+                $( self.$element += other.$element; )+
+            }
+        }
+
+        impl<$component_ty> AddAssign<$component_ty> for $self_ty<$component_ty>
+        where
+            T:  AddAssign + Clone
+        {
+            fn add_assign(&mut self, c: $component_ty) {
+                $( self.$element += c.clone(); )+
+            }
+        }
+    };
 }
 
 /// Implement `Sub` and `SubAssign` traits for a color space.
 ///
 /// Both scalars and color arithmetic are implemented.
 macro_rules! impl_color_sub {
-    ($self_ty: ident , [$($element: ident),+], $phantom: ident) => {
+    ($self_ty: ident < $phantom_ty: ident, $component_ty: ident > , [$($element: ident),+], $phantom: ident) => {
+        impl<$phantom_ty, $component_ty> Sub<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Sub<Output=$component_ty>
+        {
+            type Output = Self;
 
-	impl<Wp, T> Sub<$self_ty<Wp, T>> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent,
-	    Wp: WhitePoint,
-	{
-	    type Output = $self_ty<Wp, T>;
+            fn sub(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element - other.$element, )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
 
-	    fn sub(self, other: $self_ty<Wp, T>) -> Self::Output {
-		$self_ty {
-		    $( $element: self.$element - other.$element ),+,
-		    $phantom: PhantomData,
-		}
-	    }
-	}
+        impl<$phantom_ty, $component_ty> Sub<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Sub<Output=$component_ty> + Clone
+        {
+            type Output = Self;
 
-	impl<Wp, T> Sub<T> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent,
-	    Wp: WhitePoint,
-	{
-	    type Output = $self_ty<Wp, T>;
+            fn sub(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element - c.clone(), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
 
-	    fn sub(self, c: T) -> Self::Output {
-		$self_ty {
-		    $( $element: self.$element - c ),+,
-		    $phantom: PhantomData,
-		}
-	    }
-	}
+        impl<$phantom_ty, $component_ty> SubAssign<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: SubAssign,
+        {
+            fn sub_assign(&mut self, other: Self) {
+                $( self.$element -= other.$element; )+
+            }
+        }
 
-	impl<Wp, T> SubAssign<$self_ty<Wp, T>> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent + SubAssign,
-	    Wp: WhitePoint,
-	{
-	    fn sub_assign(&mut self, other: $self_ty<Wp, T>) {
-		$( self.$element -= other.$element; )+
-	    }
-	}
+        impl<$phantom_ty, $component_ty> SubAssign<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T:  SubAssign + Clone
+        {
+            fn sub_assign(&mut self, c: $component_ty) {
+                $( self.$element -= c.clone(); )+
+            }
+        }
+    };
 
-	impl<Wp, T> SubAssign<T> for $self_ty<Wp, T>
-	where
-	    T: FloatComponent + SubAssign,
-	    Wp: WhitePoint,
-	{
-	    fn sub_assign(&mut self, c: T) {
-		$( self.$element -= c; )+
-	    }
-	}
-    }
+    ($self_ty: ident < $component_ty: ident > , [$($element: ident),+]) => {
+        impl<$component_ty> Sub<Self> for $self_ty<$component_ty>
+        where
+            T: Sub<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn sub(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element - other.$element, )+
+                }
+            }
+        }
+
+        impl<$component_ty> Sub<$component_ty> for $self_ty<$component_ty>
+        where
+            T: Sub<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn sub(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element - c.clone(), )+
+                }
+            }
+        }
+
+        impl<$component_ty> SubAssign<Self> for $self_ty<$component_ty>
+        where
+            T: SubAssign,
+        {
+            fn sub_assign(&mut self, other: Self) {
+                $( self.$element -= other.$element; )+
+            }
+        }
+
+        impl<$component_ty> SubAssign<$component_ty> for $self_ty<$component_ty>
+        where
+            T:  SubAssign + Clone
+        {
+            fn sub_assign(&mut self, c: $component_ty) {
+                $( self.$element -= c.clone(); )+
+            }
+        }
+    };
+}
+
+/// Implement `Mul` and `MulAssign` traits for a color space.
+///
+/// Both scalars and color arithmetic are implemented.
+macro_rules! impl_color_mul {
+    ($self_ty: ident < $phantom_ty: ident, $component_ty: ident > , [$($element: ident),+], $phantom: ident) => {
+        impl<$phantom_ty, $component_ty> Mul<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Mul<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn mul(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element * other.$element, )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> Mul<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Mul<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn mul(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element * c.clone(), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> MulAssign<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: MulAssign,
+        {
+            fn mul_assign(&mut self, other: Self) {
+                $( self.$element *= other.$element; )+
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> MulAssign<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T:  MulAssign + Clone
+        {
+            fn mul_assign(&mut self, c: $component_ty) {
+                $( self.$element *= c.clone(); )+
+            }
+        }
+    };
+    ($self_ty: ident < $component_ty: ident > , [$($element: ident),+]) => {
+        impl<$component_ty> Mul<Self> for $self_ty<$component_ty>
+        where
+            T: Mul<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn mul(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element * other.$element, )+
+                }
+            }
+        }
+
+        impl<$component_ty> Mul<$component_ty> for $self_ty<$component_ty>
+        where
+            T: Mul<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn mul(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element * c.clone(), )+
+                }
+            }
+        }
+
+        impl<$component_ty> MulAssign<Self> for $self_ty<$component_ty>
+        where
+            T: MulAssign,
+        {
+            fn mul_assign(&mut self, other: Self) {
+                $( self.$element *= other.$element; )+
+            }
+        }
+
+        impl<$component_ty> MulAssign<$component_ty> for $self_ty<$component_ty>
+        where
+            T:  MulAssign + Clone
+        {
+            fn mul_assign(&mut self, c: $component_ty) {
+                $( self.$element *= c.clone(); )+
+            }
+        }
+    };
+}
+
+/// Implement `Div` and `DivAssign` traits for a color space.
+///
+/// Both scalars and color arithmetic are implemented.
+macro_rules! impl_color_div {
+    ($self_ty: ident < $phantom_ty: ident, $component_ty: ident > , [$($element: ident),+], $phantom: ident) => {
+        impl<$phantom_ty, $component_ty> Div<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Div<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn div(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element / other.$element, )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> Div<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: Div<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn div(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element / c.clone(), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> DivAssign<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: DivAssign,
+        {
+            fn div_assign(&mut self, other: Self) {
+                $( self.$element /= other.$element; )+
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> DivAssign<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T:  DivAssign + Clone
+        {
+            fn div_assign(&mut self, c: $component_ty) {
+                $( self.$element /= c.clone(); )+
+            }
+        }
+    };
+    ($self_ty: ident < $component_ty: ident > , [$($element: ident),+]) => {
+        impl<$component_ty> Div<Self> for $self_ty<$component_ty>
+        where
+            T: Div<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn div(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element / other.$element, )+
+                }
+            }
+        }
+
+        impl<$component_ty> Div<$component_ty> for $self_ty<$component_ty>
+        where
+            T: Div<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn div(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element / c.clone(), )+
+                }
+            }
+        }
+
+        impl<$component_ty> DivAssign<Self> for $self_ty<$component_ty>
+        where
+            T: DivAssign,
+        {
+            fn div_assign(&mut self, other: Self) {
+                $( self.$element /= other.$element; )+
+            }
+        }
+
+        impl<$component_ty> DivAssign<$component_ty> for $self_ty<$component_ty>
+        where
+            T:  DivAssign + Clone
+        {
+            fn div_assign(&mut self, c: $component_ty) {
+                $( self.$element /= c.clone(); )+
+            }
+        }
+    };
 }

--- a/palette/src/random_sampling/cone.rs
+++ b/palette/src/random_sampling/cone.rs
@@ -2,9 +2,7 @@ use core::marker::PhantomData;
 
 use crate::float::Float;
 use crate::hues::{LuvHue, RgbHue};
-use crate::rgb::RgbStandard;
-use crate::white_point::WhitePoint;
-use crate::{from_f64, FloatComponent, Hsl, Hsluv, Hsv};
+use crate::{from_f64, FromF64, Hsl, Hsluv, Hsv};
 
 // Based on https://stackoverflow.com/q/4778147 and https://math.stackexchange.com/q/18686,
 // picking A = (0, 0), B = (0, 1), C = (1, 1) gives us:
@@ -19,8 +17,7 @@ use crate::{from_f64, FloatComponent, Hsl, Hsluv, Hsv};
 
 pub fn sample_hsv<S, T>(hue: RgbHue<T>, r1: T, r2: T) -> Hsv<S, T>
 where
-    T: FloatComponent,
-    S: RgbStandard,
+    T: Float,
 {
     let (value, saturation) = (Float::cbrt(r1), Float::sqrt(r2));
 
@@ -34,8 +31,7 @@ where
 
 pub fn sample_hsl<S, T>(hue: RgbHue<T>, r1: T, r2: T) -> Hsl<S, T>
 where
-    T: FloatComponent,
-    S: RgbStandard,
+    T: Float + FromF64,
 {
     let (saturation, lightness) = if r1 <= from_f64::<T>(0.5) {
         // Scale it up to [0, 1]
@@ -63,8 +59,7 @@ where
 
 pub fn sample_hsluv<Wp, T>(hue: LuvHue<T>, r1: T, r2: T) -> Hsluv<Wp, T>
 where
-    T: FloatComponent,
-    Wp: WhitePoint,
+    T: Float + FromF64,
 {
     let (saturation, l) = if r1 <= from_f64::<T>(0.5) {
         // Scale it up to [0, 1]
@@ -92,8 +87,7 @@ where
 
 pub fn invert_hsl_sample<S, T>(color: Hsl<S, T>) -> (T, T)
 where
-    T: FloatComponent,
-    S: RgbStandard,
+    T: Float + FromF64,
 {
     let r1 = if color.lightness <= from_f64::<T>(0.5) {
         // ((x * 2)^3) / 2 = x^3 * 4.
@@ -114,8 +108,7 @@ where
 
 pub fn invert_hsluv_sample<Wp, T>(color: Hsluv<Wp, T>) -> (T, T)
 where
-    T: FloatComponent,
-    Wp: WhitePoint,
+    T: Float + FromF64,
 {
     let lightness: T = color.l / from_f64::<T>(100.0);
     let r1 = if lightness <= from_f64::<T>(0.5) {

--- a/palette/src/rgb/packed.rs
+++ b/palette/src/rgb/packed.rs
@@ -2,7 +2,7 @@ pub mod channels;
 
 use core::marker::PhantomData;
 
-use crate::rgb::{Rgb, RgbStandard, Rgba};
+use crate::rgb::{Rgb, Rgba};
 use crate::Pixel;
 
 /// RGBA color packed into a 32-bit unsigned integer. Defaults to ARGB
@@ -84,18 +84,18 @@ impl<C> Clone for Packed<C> {
 /// ordered as `Abgr`, `Argb`, `Bgra`, or `Rgba`.
 pub trait RgbChannels {
     /// Split RGBA components into a `(u8, u8, u8, u8)` tuple.
-    fn split_rgb<S: RgbStandard>(rgb: Rgba<S, u8>) -> (u8, u8, u8, u8);
+    fn split_rgb<S>(rgb: Rgba<S, u8>) -> (u8, u8, u8, u8);
     /// Create an RGBA color from a `(u8, u8, u8, u8)` tuple.
-    fn combine_rgb<S: RgbStandard>(channels: (u8, u8, u8, u8)) -> Rgba<S, u8>;
+    fn combine_rgb<S>(channels: (u8, u8, u8, u8)) -> Rgba<S, u8>;
 }
 
-impl<S: RgbStandard> From<Rgb<S, u8>> for u32 {
+impl<S> From<Rgb<S, u8>> for u32 {
     fn from(color: Rgb<S, u8>) -> Self {
         Rgb::into_u32::<channels::Argb>(color)
     }
 }
 
-impl<S: RgbStandard> From<Rgba<S, u8>> for u32 {
+impl<S> From<Rgba<S, u8>> for u32 {
     fn from(color: Rgba<S, u8>) -> Self {
         Rgba::into_u32::<channels::Rgba>(color)
     }
@@ -112,7 +112,6 @@ impl<C: RgbChannels> From<u32> for Packed<C> {
 
 impl<S, C> From<Rgb<S, u8>> for Packed<C>
 where
-    S: RgbStandard,
     C: RgbChannels,
 {
     fn from(color: Rgb<S, u8>) -> Self {
@@ -122,7 +121,6 @@ where
 
 impl<S, C> From<Rgba<S, u8>> for Packed<C>
 where
-    S: RgbStandard,
     C: RgbChannels,
 {
     fn from(color: Rgba<S, u8>) -> Self {
@@ -134,7 +132,7 @@ where
     }
 }
 
-impl<S: RgbStandard> From<u32> for Rgb<S, u8> {
+impl<S> From<u32> for Rgb<S, u8> {
     fn from(color: u32) -> Self {
         Self::from_u32::<channels::Argb>(color)
     }
@@ -142,7 +140,6 @@ impl<S: RgbStandard> From<u32> for Rgb<S, u8> {
 
 impl<S, C> From<Packed<C>> for Rgb<S, u8>
 where
-    S: RgbStandard,
     C: RgbChannels,
 {
     fn from(packed: Packed<C>) -> Self {
@@ -150,7 +147,7 @@ where
     }
 }
 
-impl<S: RgbStandard> From<u32> for Rgba<S, u8> {
+impl<S> From<u32> for Rgba<S, u8> {
     fn from(color: u32) -> Self {
         Self::from_u32::<channels::Rgba>(color)
     }
@@ -158,7 +155,6 @@ impl<S: RgbStandard> From<u32> for Rgba<S, u8> {
 
 impl<S, C> From<Packed<C>> for Rgba<S, u8>
 where
-    S: RgbStandard,
     C: RgbChannels,
 {
     fn from(packed: Packed<C>) -> Self {

--- a/palette/src/rgb/packed/channels.rs
+++ b/palette/src/rgb/packed/channels.rs
@@ -8,11 +8,11 @@ use crate::rgb;
 pub struct Abgr;
 
 impl RgbChannels for Abgr {
-    fn split_rgb<S: rgb::RgbStandard>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
+    fn split_rgb<S>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
         (rgb.alpha, rgb.blue, rgb.green, rgb.red)
     }
 
-    fn combine_rgb<S: rgb::RgbStandard>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
+    fn combine_rgb<S>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
         rgb::Rgba::new(channels.3, channels.2, channels.1, channels.0)
     }
 }
@@ -23,11 +23,11 @@ impl RgbChannels for Abgr {
 pub struct Argb;
 
 impl RgbChannels for Argb {
-    fn split_rgb<S: rgb::RgbStandard>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
+    fn split_rgb<S>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
         (rgb.alpha, rgb.red, rgb.green, rgb.blue)
     }
 
-    fn combine_rgb<S: rgb::RgbStandard>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
+    fn combine_rgb<S>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
         rgb::Rgba::new(channels.1, channels.2, channels.3, channels.0)
     }
 }
@@ -38,11 +38,11 @@ impl RgbChannels for Argb {
 pub struct Bgra;
 
 impl RgbChannels for Bgra {
-    fn split_rgb<S: rgb::RgbStandard>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
+    fn split_rgb<S>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
         (rgb.blue, rgb.green, rgb.red, rgb.alpha)
     }
 
-    fn combine_rgb<S: rgb::RgbStandard>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
+    fn combine_rgb<S>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
         rgb::Rgba::new(channels.2, channels.1, channels.0, channels.3)
     }
 }
@@ -53,11 +53,11 @@ impl RgbChannels for Bgra {
 pub struct Rgba;
 
 impl RgbChannels for Rgba {
-    fn split_rgb<S: rgb::RgbStandard>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
+    fn split_rgb<S>(rgb: rgb::Rgba<S, u8>) -> (u8, u8, u8, u8) {
         (rgb.red, rgb.green, rgb.blue, rgb.alpha)
     }
 
-    fn combine_rgb<S: rgb::RgbStandard>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
+    fn combine_rgb<S>(channels: (u8, u8, u8, u8)) -> rgb::Rgba<S, u8> {
         rgb::Rgba::new(channels.0, channels.1, channels.2, channels.3)
     }
 }

--- a/palette/src/white_point.rs
+++ b/palette/src/white_point.rs
@@ -6,7 +6,7 @@
 //! daylight. Defining "white" as daylight will give unacceptable results when
 //! attempting to color-correct a photograph taken with incandescent lighting.
 
-use crate::{from_f64, FloatComponent, Xyz};
+use crate::{from_f64, FromF64, Xyz};
 
 /// WhitePoint defines the Xyz color co-ordinates for a given white point.
 ///
@@ -20,7 +20,7 @@ use crate::{from_f64, FloatComponent, Xyz};
 /// library.
 pub trait WhitePoint: 'static {
     /// Get the Xyz chromaticity co-ordinates for the white point.
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T>;
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T>;
 }
 
 /// CIE standard illuminant A
@@ -32,8 +32,8 @@ pub trait WhitePoint: 'static {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct A;
 impl WhitePoint for A {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(1.09850), T::one(), from_f64(0.35585))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(1.09850), from_f64(1.0), from_f64(0.35585))
     }
 }
 /// CIE standard illuminant B
@@ -43,8 +43,8 @@ impl WhitePoint for A {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct B;
 impl WhitePoint for B {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.99072), T::one(), from_f64(0.85223))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.99072), from_f64(1.0), from_f64(0.85223))
     }
 }
 /// CIE standard illuminant C
@@ -54,8 +54,8 @@ impl WhitePoint for B {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct C;
 impl WhitePoint for C {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.98074), T::one(), from_f64(1.18232))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.98074), from_f64(1.0), from_f64(1.18232))
     }
 }
 /// CIE D series standard illuminant - D50
@@ -65,8 +65,8 @@ impl WhitePoint for C {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50;
 impl WhitePoint for D50 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.96422), T::one(), from_f64(0.82521))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.96422), from_f64(1.0), from_f64(0.82521))
     }
 }
 /// CIE D series standard illuminant - D55
@@ -76,8 +76,8 @@ impl WhitePoint for D50 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55;
 impl WhitePoint for D55 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.95682), T::one(), from_f64(0.92149))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.95682), from_f64(1.0), from_f64(0.92149))
     }
 }
 /// CIE D series standard illuminant - D65
@@ -87,8 +87,8 @@ impl WhitePoint for D55 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65;
 impl WhitePoint for D65 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.95047), T::one(), from_f64(1.08883))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.95047), from_f64(1.0), from_f64(1.08883))
     }
 }
 /// CIE D series standard illuminant - D75
@@ -98,8 +98,8 @@ impl WhitePoint for D65 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75;
 impl WhitePoint for D75 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.94972), T::one(), from_f64(1.22638))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.94972), from_f64(1.0), from_f64(1.22638))
     }
 }
 /// CIE standard illuminant E
@@ -109,8 +109,8 @@ impl WhitePoint for D75 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct E;
 impl WhitePoint for E {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(T::one(), T::one(), T::one())
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(1.0), from_f64(1.0), from_f64(1.0))
     }
 }
 /// CIE fluorescent illuminant series - F2
@@ -119,8 +119,8 @@ impl WhitePoint for E {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F2;
 impl WhitePoint for F2 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.99186), T::one(), from_f64(0.67393))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.99186), from_f64(1.0), from_f64(0.67393))
     }
 }
 /// CIE fluorescent illuminant series - F7
@@ -129,8 +129,8 @@ impl WhitePoint for F2 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F7;
 impl WhitePoint for F7 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.95041), T::one(), from_f64(1.08747))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.95041), from_f64(1.0), from_f64(1.08747))
     }
 }
 /// CIE fluorescent illuminant series - F11
@@ -139,8 +139,8 @@ impl WhitePoint for F7 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F11;
 impl WhitePoint for F11 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(1.00962), T::one(), from_f64(0.64350))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(1.00962), from_f64(1.0), from_f64(0.64350))
     }
 }
 /// CIE D series standard illuminant - D50
@@ -150,8 +150,8 @@ impl WhitePoint for F11 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50Degree10;
 impl WhitePoint for D50Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.9672), T::one(), from_f64(0.8143))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.9672), from_f64(1.0), from_f64(0.8143))
     }
 }
 /// CIE D series standard illuminant - D55
@@ -161,8 +161,8 @@ impl WhitePoint for D50Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55Degree10;
 impl WhitePoint for D55Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.958), T::one(), from_f64(0.9093))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.958), from_f64(1.0), from_f64(0.9093))
     }
 }
 /// CIE D series standard illuminant - D65
@@ -172,8 +172,8 @@ impl WhitePoint for D55Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65Degree10;
 impl WhitePoint for D65Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.9481), T::one(), from_f64(1.073))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.9481), from_f64(1.0), from_f64(1.073))
     }
 }
 /// CIE D series standard illuminant - D75
@@ -183,7 +183,7 @@ impl WhitePoint for D65Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75Degree10;
 impl WhitePoint for D75Degree10 {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.94416), T::one(), from_f64(1.2064))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(from_f64(0.94416), from_f64(1.0), from_f64(1.2064))
     }
 }

--- a/palette/tests/pointer_dataset/pointer_data.rs
+++ b/palette/tests/pointer_dataset/pointer_data.rs
@@ -14,25 +14,22 @@ Note: The xyz and yxy conversions do not use the updated conversion formula. So 
 use approx::assert_relative_eq;
 use csv;
 use lazy_static::lazy_static;
-use num_traits::{NumCast, ToPrimitive};
 use serde_derive::Deserialize;
 
 use palette::convert::IntoColorUnclamped;
-use palette::float::Float;
 use palette::white_point::WhitePoint;
-use palette::{FloatComponent, Lab, Lch, Xyz};
+use palette::{FromF64, Lab, Lch, Xyz};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PointerWP;
 impl WhitePoint for PointerWP {
-    fn get_xyz<Wp: WhitePoint, T: FloatComponent>() -> Xyz<Wp, T> {
-        Xyz::with_wp(flt(0.980722647624), T::one(), flt(1.182254189827))
+    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+        Xyz::with_wp(
+            FromF64::from_f64(0.980722647624),
+            FromF64::from_f64(1.0),
+            FromF64::from_f64(1.182254189827),
+        )
     }
-}
-
-/// A convenience function to convert a constant number to Float Type
-fn flt<T: Float, P: ToPrimitive>(prim: P) -> T {
-    NumCast::from(prim).unwrap()
 }
 
 #[derive(Deserialize, PartialEq)]

--- a/palette_derive/src/meta/type_item_attributes.rs
+++ b/palette_derive/src/meta/type_item_attributes.rs
@@ -14,6 +14,7 @@ pub struct TypeItemAttributes {
     pub component: Option<Type>,
     pub white_point: Option<Type>,
     pub rgb_standard: Option<Type>,
+    pub luma_standard: Option<Type>,
 }
 
 impl AttributeArgumentParser for TypeItemAttributes {
@@ -49,7 +50,7 @@ impl AttributeArgumentParser for TypeItemAttributes {
                 if let Err(span) = result {
                     return Err(::syn::parse::Error::new(
                         span,
-                        "expected `skip` to have a list of color type names, like `skip(Xyz, Luma, Rgb)`",
+                        "expected `skip_derives` to have a list of color type names, like `skip_derives(Xyz, Luma, Rgb)`",
                     ));
                 }
             }
@@ -119,6 +120,29 @@ impl AttributeArgumentParser for TypeItemAttributes {
                     return Err(::syn::parse::Error::new(
                         argument.span(),
                         "`rgb_standard` appears more than once",
+                    ));
+                }
+            }
+            Some("luma_standard") => {
+                if self.luma_standard.is_none() {
+                    let result = if let Meta::NameValue(MetaNameValue {
+                        lit: Lit::Str(ty), ..
+                    }) = argument
+                    {
+                        self.luma_standard = Some(ty.parse()?);
+                        Ok(())
+                    } else {
+                        Err(argument.span())
+                    };
+
+                    if let Err(span) = result {
+                        let message = "expected `luma_standard` to be a type or type parameter in a string, like `luma_standard = \"T\"`";
+                        return Err(::syn::parse::Error::new(span, message));
+                    }
+                } else {
+                    return Err(::syn::parse::Error::new(
+                        argument.span(),
+                        "`luma_standard` appears more than once",
                     ));
                 }
             }


### PR DESCRIPTION
I removed all trait bound on color type definitions and made them more relaxed in some places. This should also enable `const fn` in some places! I guess the unfortunate (or fortunate?) effect of this is that it highlighted some shortcomings in the current set if traits. Particularly that the `Component` + `FloatComponent` combo doesn't exactly reflect how the type parameters are used and comes with a lot of assumptions. In other words, there's more trait fixing than I thought.

## Breaking Change

Some forced trait bounds were changed in ways that will be breaking. Particularly on `WhitePoint`.
