### PR TITLE
Make color constructors const and remove or replace all with_wp

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -146,8 +146,8 @@ where
     color.mix(&new_color, amount)
 }
 
-let new_hsl = transform_color(&Hsl::new(0.00, 0.70, 0.20), 0.8);
-let new_hsv = transform_color(&Hsv::new(0.00, 0.82, 0.34), 0.8);
+let new_hsl = transform_color(&Hsl::new_srgb(0.00, 0.70, 0.20), 0.8);
+let new_hsv = transform_color(&Hsv::new_srgb(0.00, 0.82, 0.34), 0.8);
 ```
 
 This image shows the transition from the color to `new_color` in HSL and HSV:

--- a/palette/build/named.rs
+++ b/palette/build/named.rs
@@ -42,7 +42,15 @@ pub fn build_colors(writer: &mut File) {
             .unwrap_or_else(|| panic!("couldn't get blue for {}", name));
 
         writeln!(writer, "\n///<div style=\"display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: {0};\"></div>", name).unwrap();
-        writeln!(writer, "pub const {}: crate::rgb::Srgb<u8> = crate::rgb::Srgb {{ red: {}, green: {}, blue: {}, standard: ::core::marker::PhantomData }};", name.to_uppercase(), red, green, blue).unwrap();
+        writeln!(
+            writer,
+            "pub const {}: crate::rgb::Srgb<u8> = crate::rgb::Srgb::new({}, {}, {});",
+            name.to_uppercase(),
+            red,
+            green,
+            blue
+        )
+        .unwrap();
 
         entries.push((name.to_owned(), name.to_uppercase()));
     }
@@ -104,7 +112,16 @@ pub fn build_gradients(writer: &mut File) {
                 .next()
                 .and_then(|r| r.trim().parse().ok())
                 .unwrap_or_else(|| panic!("couldn't get the {}th blue-value for {}", i, name));
-            write!(writer, "({:.10},{}{{red: {}, green: {}, blue: {}, standard: ::core::marker::PhantomData}}),", (i as f32/number_of_colors as f32), color_type, red, green, blue).unwrap();
+            write!(
+                writer,
+                "({:.10},{}::new({}, {}, {})),",
+                (i as f32 / number_of_colors as f32),
+                color_type,
+                red,
+                green,
+                blue
+            )
+            .unwrap();
         }
         writeln!(writer, "], ::core::marker::PhantomData);").unwrap();
     }

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -66,7 +66,7 @@ fn color_operations_1() {
     }
 
     // Write example image
-    let hsl_color = Hsl::new(0.00, 0.70, 0.20);
+    let hsl_color = Hsl::new_srgb(0.00, 0.70, 0.20);
     let hsl_color_at = |amount| {
         use palette::FromColor;
 
@@ -74,7 +74,7 @@ fn color_operations_1() {
         palette::Srgb::from_color(color).into_format()
     };
 
-    let hsv_color = Hsv::new(0.00, 0.82, 0.34);
+    let hsv_color = Hsv::new_srgb(0.00, 0.82, 0.34);
     let hsv_color_at = |amount| {
         use palette::FromColor;
 

--- a/palette/src/chromatic_adaptation.rs
+++ b/palette/src/chromatic_adaptation.rs
@@ -15,7 +15,7 @@
 //! use palette::chromatic_adaptation::AdaptInto;
 //!
 //!
-//! let a = Xyz::<A, f32>::with_wp(0.315756, 0.162732, 0.015905);
+//! let a = Xyz::<A, f32>::new(0.315756, 0.162732, 0.015905);
 //!
 //! //Will convert Xyz<A, f32> to Xyz<C, f32> using Bradford chromatic adaptation
 //! let c: Xyz<C, f32> = a.adapt_into();
@@ -254,11 +254,11 @@ mod test {
 
     #[test]
     fn chromatic_adaptation_from_a_to_c() {
-        let input_a = Xyz::<A, f32>::with_wp(0.315756, 0.162732, 0.015905);
+        let input_a = Xyz::<A, f32>::new(0.315756, 0.162732, 0.015905);
 
-        let expected_bradford = Xyz::<C, f32>::with_wp(0.257963, 0.139776, 0.058825);
-        let expected_vonkries = Xyz::<C, f32>::with_wp(0.268446, 0.159139, 0.052843);
-        let expected_xyz_scaling = Xyz::<C, f32>::with_wp(0.281868, 0.162732, 0.052844);
+        let expected_bradford = Xyz::<C, f32>::new(0.257963, 0.139776, 0.058825);
+        let expected_vonkries = Xyz::<C, f32>::new(0.268446, 0.159139, 0.052843);
+        let expected_xyz_scaling = Xyz::<C, f32>::new(0.281868, 0.162732, 0.052844);
 
         let computed_bradford: Xyz<C, f32> = Xyz::adapt_from(input_a);
         assert_relative_eq!(expected_bradford, computed_bradford, epsilon = 0.0001);
@@ -272,11 +272,11 @@ mod test {
 
     #[test]
     fn chromatic_adaptation_into_a_to_c() {
-        let input_a = Xyz::<A, f32>::with_wp(0.315756, 0.162732, 0.015905);
+        let input_a = Xyz::<A, f32>::new(0.315756, 0.162732, 0.015905);
 
-        let expected_bradford = Xyz::<C, f32>::with_wp(0.257963, 0.139776, 0.058825);
-        let expected_vonkries = Xyz::<C, f32>::with_wp(0.268446, 0.159139, 0.052843);
-        let expected_xyz_scaling = Xyz::<C, f32>::with_wp(0.281868, 0.162732, 0.052844);
+        let expected_bradford = Xyz::<C, f32>::new(0.257963, 0.139776, 0.058825);
+        let expected_vonkries = Xyz::<C, f32>::new(0.268446, 0.159139, 0.052843);
+        let expected_xyz_scaling = Xyz::<C, f32>::new(0.281868, 0.162732, 0.052844);
 
         let computed_bradford: Xyz<C, f32> = input_a.adapt_into();
         assert_relative_eq!(expected_bradford, computed_bradford, epsilon = 0.0001);

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -583,7 +583,7 @@ mod tests {
 
     impl<S: RgbSpace> FromColorUnclamped<WithXyz<S>> for Xyz<S::WhitePoint, f64> {
         fn from_color_unclamped(_color: WithXyz<S>) -> Xyz<S::WhitePoint, f64> {
-            Xyz::with_wp(0.0, 1.0, 0.0)
+            Xyz::new(0.0, 1.0, 0.0)
         }
     }
 
@@ -640,7 +640,7 @@ mod tests {
 
     impl<T: FloatComponent> FromColorUnclamped<WithoutXyz<T>> for Lch<crate::white_point::E, T> {
         fn from_color_unclamped(_color: WithoutXyz<T>) -> Lch<crate::white_point::E, T> {
-            Lch::with_wp(T::one(), T::zero(), T::zero())
+            Lch::new(T::one(), T::zero(), T::zero())
         }
     }
 

--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -14,13 +14,13 @@ pub struct Srgb;
 
 impl Primaries for Srgb {
     fn red<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
-        Yxy::with_wp(from_f64(0.6400), from_f64(0.3300), from_f64(0.212656))
+        Yxy::new(from_f64(0.6400), from_f64(0.3300), from_f64(0.212656))
     }
     fn green<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
-        Yxy::with_wp(from_f64(0.3000), from_f64(0.6000), from_f64(0.715158))
+        Yxy::new(from_f64(0.3000), from_f64(0.6000), from_f64(0.715158))
     }
     fn blue<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
-        Yxy::with_wp(from_f64(0.1500), from_f64(0.0600), from_f64(0.072186))
+        Yxy::new(from_f64(0.1500), from_f64(0.0600), from_f64(0.072186))
     }
 }
 

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -28,8 +28,8 @@ macro_rules! make_hues {
         impl<T> $name<T> {
             /// Create a new hue from degrees.
             #[inline]
-            pub fn from_degrees(degrees: T) -> $name<T> {
-                $name(degrees)
+            pub const fn from_degrees(degrees: T) -> Self {
+                Self(degrees)
             }
 
             /// Get the internal representation, without normalizing it.
@@ -42,8 +42,8 @@ macro_rules! make_hues {
         impl<T: Float + FromF64> $name<T> {
             /// Create a new hue from radians, instead of degrees.
             #[inline]
-            pub fn from_radians(radians: T) -> $name<T> {
-                $name(radians.to_degrees())
+            pub fn from_radians(radians: T) -> Self {
+                Self(radians.to_degrees())
             }
 
             /// Get the hue as degrees, in the range `(-180, 180]`.

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -77,21 +77,9 @@ where
     }
 }
 
-impl<T> Lab<D65, T> {
-    /// CIE L\*a\*b\* with white point D65.
-    pub fn new(l: T, a: T, b: T) -> Lab<D65, T> {
-        Lab {
-            l,
-            a,
-            b,
-            white_point: PhantomData,
-        }
-    }
-}
-
 impl<Wp, T> Lab<Wp, T> {
-    /// CIE L\*a\*b\*.
-    pub fn with_wp(l: T, a: T, b: T) -> Lab<Wp, T> {
+    /// Create a CIE L\*a\*b\* color.
+    pub const fn new(l: T, a: T, b: T) -> Lab<Wp, T> {
         Lab {
             l,
             a,
@@ -107,7 +95,7 @@ impl<Wp, T> Lab<Wp, T> {
 
     /// Convert from a `(L\*, a\*, b\*)` tuple.
     pub fn from_components((l, a, b): (T, T, T)) -> Self {
-        Self::with_wp(l, a, b)
+        Self::new(l, a, b)
     }
 }
 
@@ -147,22 +135,11 @@ where
 }
 
 ///<span id="Laba"></span>[`Laba`](crate::Laba) implementations.
-impl<T, A> Alpha<Lab<D65, T>, A> {
-    /// CIE L\*a\*b\* and transparency and white point D65.
-    pub fn new(l: T, a: T, b: T, alpha: A) -> Self {
+impl<Wp, T, A> Alpha<Lab<Wp, T>, A> {
+    /// Create a CIE L\*a\*b\* with transparency.
+    pub const fn new(l: T, a: T, b: T, alpha: A) -> Self {
         Alpha {
             color: Lab::new(l, a, b),
-            alpha,
-        }
-    }
-}
-
-///<span id="Laba"></span>[`Laba`](crate::Laba) implementations.
-impl<Wp, T, A> Alpha<Lab<Wp, T>, A> {
-    /// CIE L\*a\*b\* and transparency.
-    pub fn with_wp(l: T, a: T, b: T, alpha: A) -> Self {
-        Alpha {
-            color: Lab::with_wp(l, a, b),
             alpha,
         }
     }
@@ -174,7 +151,7 @@ impl<Wp, T, A> Alpha<Lab<Wp, T>, A> {
 
     /// Convert from a `(L\*, a\*, b\*, alpha)` tuple.
     pub fn from_components((l, a, b, alpha): (T, T, T, A)) -> Self {
-        Self::with_wp(l, a, b, alpha)
+        Self::new(l, a, b, alpha)
     }
 }
 
@@ -407,7 +384,7 @@ where
     T: Zero,
 {
     fn default() -> Lab<Wp, T> {
-        Lab::with_wp(T::zero(), T::zero(), T::zero())
+        Lab::new(T::zero(), T::zero(), T::zero())
     }
 }
 
@@ -599,7 +576,7 @@ mod test {
     #[cfg(feature = "serializing")]
     #[test]
     fn serialize() {
-        let serialized = ::serde_json::to_string(&Lab::new(0.3, 0.8, 0.1)).unwrap();
+        let serialized = ::serde_json::to_string(&Lab::<D65>::new(0.3, 0.8, 0.1)).unwrap();
 
         assert_eq!(serialized, r#"{"l":0.3,"a":0.8,"b":0.1}"#);
     }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -534,7 +534,7 @@ pub trait Shade: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsl, Shade};
     ///
-    /// let color = Hsl::new(0.0, 1.0, 0.5);
+    /// let color = Hsl::new_srgb(0.0, 1.0, 0.5);
     /// assert_relative_eq!(color.lighten(0.5).lightness, 0.75);
     /// ```
     fn lighten(&self, factor: Self::Scalar) -> Self;
@@ -545,7 +545,7 @@ pub trait Shade: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsl, Shade};
     ///
-    /// let color = Hsl::new(0.0, 1.0, 0.4);
+    /// let color = Hsl::new_srgb(0.0, 1.0, 0.4);
     /// assert_relative_eq!(color.lighten_fixed(0.2).lightness, 0.6);
     /// ```
     fn lighten_fixed(&self, amount: Self::Scalar) -> Self;
@@ -557,7 +557,7 @@ pub trait Shade: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsv, Shade};
     ///
-    /// let color = Hsv::new(0.0, 1.0, 0.5);
+    /// let color = Hsv::new_srgb(0.0, 1.0, 0.5);
     /// assert_relative_eq!(color.darken(0.5).value, 0.25);
     /// ```
     fn darken(&self, factor: Self::Scalar) -> Self {
@@ -570,7 +570,7 @@ pub trait Shade: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsv, Shade};
     ///
-    /// let color = Hsv::new(0.0, 1.0, 0.4);
+    /// let color = Hsv::new_srgb(0.0, 1.0, 0.4);
     /// assert_relative_eq!(color.darken_fixed(0.2).value, 0.2);
     /// ```
     fn darken_fixed(&self, amount: Self::Scalar) -> Self {
@@ -648,7 +648,7 @@ pub trait Hue: GetHue {
 /// use approx::assert_relative_eq;
 /// use palette::{Hsv, Saturate};
 ///
-/// let a = Hsv::new(0.0, 0.5, 1.0);
+/// let a = Hsv::new_srgb(0.0, 0.5, 1.0);
 ///
 /// assert_relative_eq!(a.saturate(0.5).saturation, 0.75);
 /// assert_relative_eq!(a.desaturate_fixed(0.5).saturation, 0.0);
@@ -665,7 +665,7 @@ pub trait Saturate: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsl, Saturate};
     ///
-    /// let color = Hsl::new(0.0, 0.5, 0.5);
+    /// let color = Hsl::new_srgb(0.0, 0.5, 0.5);
     /// assert_relative_eq!(color.saturate(0.5).saturation, 0.75);
     /// ```
     fn saturate(&self, factor: Self::Scalar) -> Self;
@@ -677,7 +677,7 @@ pub trait Saturate: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsl, Saturate};
     ///
-    /// let color = Hsl::new(0.0, 0.4, 0.5);
+    /// let color = Hsl::new_srgb(0.0, 0.4, 0.5);
     /// assert_relative_eq!(color.saturate_fixed(0.2).saturation, 0.6);
     /// ```
     fn saturate_fixed(&self, amount: Self::Scalar) -> Self;
@@ -689,7 +689,7 @@ pub trait Saturate: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsv, Saturate};
     ///
-    /// let color = Hsv::new(0.0, 0.5, 0.5);
+    /// let color = Hsv::new_srgb(0.0, 0.5, 0.5);
     /// assert_relative_eq!(color.desaturate(0.5).saturation, 0.25);
     /// ```
     fn desaturate(&self, factor: Self::Scalar) -> Self {
@@ -703,7 +703,7 @@ pub trait Saturate: Sized {
     /// use approx::assert_relative_eq;
     /// use palette::{Hsv, Saturate};
     ///
-    /// let color = Hsv::new(0.0, 0.4, 0.5);
+    /// let color = Hsv::new_srgb(0.0, 0.4, 0.5);
     /// assert_relative_eq!(color.desaturate_fixed(0.2).saturation, 0.2);
     /// ```
     fn desaturate_fixed(&self, amount: Self::Scalar) -> Self {

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -68,7 +68,7 @@ impl<S, T: Clone> Clone for Luma<S, T> {
 
 impl<S, T> Luma<S, T> {
     /// Create a luminance color.
-    pub fn new(luma: T) -> Luma<S, T> {
+    pub const fn new(luma: T) -> Luma<S, T> {
         Luma {
             luma,
             standard: PhantomData,
@@ -179,7 +179,7 @@ impl<S, T> Eq for Luma<S, T> where T: Eq {}
 ///<span id="Lumaa"></span>[`Lumaa`](crate::luma::Lumaa) implementations.
 impl<S, T, A> Alpha<Luma<S, T>, A> {
     /// Create a luminance color with transparency.
-    pub fn new(luma: T, alpha: A) -> Self {
+    pub const fn new(luma: T, alpha: A) -> Self {
         Alpha {
             color: Luma::new(luma),
             alpha,

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -78,21 +78,9 @@ where
     }
 }
 
-impl<T> Luv<D65, T> {
-    /// CIE L\*u\*v\* with white point D65.
-    pub fn new(l: T, u: T, v: T) -> Luv<D65, T> {
-        Luv {
-            l,
-            u,
-            v,
-            white_point: PhantomData,
-        }
-    }
-}
-
 impl<Wp, T> Luv<Wp, T> {
-    /// CIE L\*u\*v\*.
-    pub fn with_wp(l: T, u: T, v: T) -> Luv<Wp, T> {
+    /// Create a CIE L\*u\*v\* color.
+    pub const fn new(l: T, u: T, v: T) -> Self {
         Luv {
             l,
             u,
@@ -108,7 +96,7 @@ impl<Wp, T> Luv<Wp, T> {
 
     /// Convert from a `(L\*, u\*, v\*)` tuple.
     pub fn from_components((l, u, v): (T, T, T)) -> Self {
-        Self::with_wp(l, u, v)
+        Self::new(l, u, v)
     }
 }
 
@@ -148,22 +136,11 @@ where
 }
 
 ///<span id="Luva"></span>[`Luva`](crate::Luva) implementations.
-impl<T, A> Alpha<Luv<D65, T>, A> {
-    /// CIE L\*u\*v\* and transparency and white point D65.
-    pub fn new(l: T, u: T, v: T, alpha: A) -> Self {
+impl<Wp, T, A> Alpha<Luv<Wp, T>, A> {
+    /// Create a CIE L\*u\*v\* color with transparency.
+    pub const fn new(l: T, u: T, v: T, alpha: A) -> Self {
         Alpha {
             color: Luv::new(l, u, v),
-            alpha,
-        }
-    }
-}
-
-///<span id="Luva"></span>[`Luva`](crate::Luva) implementations.
-impl<Wp, T, A> Alpha<Luv<Wp, T>, A> {
-    /// CIE L\*u\*v\* and transparency.
-    pub fn with_wp(l: T, u: T, v: T, alpha: A) -> Self {
-        Alpha {
-            color: Luv::with_wp(l, u, v),
             alpha,
         }
     }
@@ -175,7 +152,7 @@ impl<Wp, T, A> Alpha<Luv<Wp, T>, A> {
 
     /// Convert from u `(L\*, u\*, v\*, alpha)` tuple.
     pub fn from_components((l, u, v, alpha): (T, T, T, A)) -> Self {
-        Self::with_wp(l, u, v, alpha)
+        Self::new(l, u, v, alpha)
     }
 }
 
@@ -192,7 +169,7 @@ where
     fn from_color_unclamped(color: Lchuv<Wp, T>) -> Self {
         let (sin_hue, cos_hue) = color.hue.to_radians().sin_cos();
         let chroma = color.chroma.max(T::zero());
-        Luv::with_wp(color.l, chroma * cos_hue, chroma * sin_hue)
+        Luv::new(color.l, chroma * cos_hue, chroma * sin_hue)
     }
 }
 
@@ -210,7 +187,7 @@ where
 
         let prime_denom = color.x + from_f64(15.0) * color.y + from_f64(3.0) * color.z;
         if prime_denom == from_f64(0.0) {
-            return Luv::with_wp(T::zero(), T::zero(), T::zero());
+            return Luv::new(T::zero(), T::zero(), T::zero());
         }
         let prime_denom_recip = prime_denom.recip();
         let prime_ref_denom_recip = (w.x + from_f64(15.0) * w.y + from_f64(3.0) * w.z).recip();
@@ -381,7 +358,7 @@ where
     T: Zero,
 {
     fn default() -> Luv<Wp, T> {
-        Luv::with_wp(T::zero(), T::zero(), T::zero())
+        Luv::new(T::zero(), T::zero(), T::zero())
     }
 }
 
@@ -559,7 +536,7 @@ mod test {
     /// implemented.
     #[test]
     fn test_arithmetic() {
-        let luv = Luv::new(120.0, 40.0, 30.0);
+        let luv = Luv::<D65>::new(120.0, 40.0, 30.0);
         let luv2 = Luv::new(200.0, 30.0, 40.0);
         let mut _luv3 = luv + luv2;
         _luv3 += luv2;
@@ -588,7 +565,7 @@ mod test {
     #[cfg(feature = "serializing")]
     #[test]
     fn serialize() {
-        let serialized = ::serde_json::to_string(&Luv::new(80.0, 20.0, 30.0)).unwrap();
+        let serialized = ::serde_json::to_string(&Luv::<D65>::new(80.0, 20.0, 30.0)).unwrap();
 
         assert_eq!(serialized, r#"{"l":80.0,"u":20.0,"v":30.0}"#);
     }

--- a/palette/src/matrix.rs
+++ b/palette/src/matrix.rs
@@ -176,7 +176,7 @@ mod test {
     use crate::chromatic_adaptation::AdaptInto;
     use crate::encoding::{Linear, Srgb};
     use crate::rgb::Rgb;
-    use crate::white_point::D50;
+    use crate::white_point::{D50, D65};
     use crate::Xyz;
 
     #[test]
@@ -194,9 +194,9 @@ mod test {
     #[test]
     fn matrix_multiply_xyz() {
         let inp1 = [0.1, 0.2, 0.3, 0.3, 0.2, 0.1, 0.2, 0.1, 0.3];
-        let inp2 = Xyz::new(0.4, 0.6, 0.8);
+        let inp2 = Xyz::<D65>::new(0.4, 0.6, 0.8);
 
-        let expected = Xyz::new(0.4, 0.32, 0.38);
+        let expected = Xyz::<D65>::new(0.4, 0.32, 0.38);
 
         let computed = multiply_xyz(&inp1, &inp2);
         assert_relative_eq!(expected, computed)

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -151,7 +151,7 @@ where
 
 impl<T> Oklab<T> {
     /// Create an Oklab color.
-    pub fn new(l: T, a: T, b: T) -> Self {
+    pub const fn new(l: T, a: T, b: T) -> Self {
         Self { l, a, b }
     }
 
@@ -203,8 +203,8 @@ where
 
 ///<span id="Oklaba"></span>[`Oklaba`](crate::Oklaba) implementations.
 impl<T, A> Alpha<Oklab<T>, A> {
-    /// Oklab and transparency.
-    pub fn new(l: T, a: T, b: T, alpha: A) -> Self {
+    /// Create an Oklab color with transparency.
+    pub const fn new(l: T, a: T, b: T, alpha: A) -> Self {
         Alpha {
             color: Oklab::new(l, a, b),
             alpha,
@@ -238,13 +238,13 @@ where
 
         let Xyz {
             x: l, y: m, z: s, ..
-        } = multiply_xyz::<_, D65, _>(&m1, &color);
+        } = multiply_xyz::<D65, D65, T>(&m1, &color);
 
         let l_m_s_ = Xyz::new(l.cbrt(), m.cbrt(), s.cbrt());
 
         let Xyz {
             x: l, y: a, z: b, ..
-        } = multiply_xyz::<_, D65, _>(&m2, &l_m_s_);
+        } = multiply_xyz::<D65, D65, T>(&m2, &l_m_s_);
 
         Self::new(l, a, b)
     }

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -139,12 +139,14 @@ where
 
 impl<T> Oklch<T> {
     /// Create an Oklch color.
-    pub fn new<H: Into<OklabHue<T>>>(l: T, chroma: T, hue: H) -> Oklch<T> {
-        Oklch {
-            l,
-            chroma,
-            hue: hue.into(),
-        }
+    pub fn new<H: Into<OklabHue<T>>>(l: T, chroma: T, hue: H) -> Self {
+        Self::new_const(l, chroma, hue.into())
+    }
+
+    /// Create an Oklch color. This is the same as `Oklch::new` without the
+    /// generic hue type. It's temporary until `const fn` supports traits.
+    pub const fn new_const(l: T, chroma: T, hue: OklabHue<T>) -> Self {
+        Oklch { l, chroma, hue }
     }
 
     /// Convert to a `(L, C, h)` tuple.
@@ -185,10 +187,17 @@ where
 
 ///<span id="Oklcha"></span>[`Oklcha`](crate::Oklcha) implementations.
 impl<T, A> Alpha<Oklch<T>, A> {
-    /// Oklch and transparency.
+    /// Create an Oklch color with transparency.
     pub fn new<H: Into<OklabHue<T>>>(l: T, chroma: T, hue: H, alpha: A) -> Self {
+        Self::new_const(l, chroma, hue.into(), alpha)
+    }
+
+    /// Create an Oklch color with transparency. This is the same as
+    /// `Oklcha::new` without the generic hue type. It's temporary until `const
+    /// fn` supports traits.
+    pub const fn new_const(l: T, chroma: T, hue: OklabHue<T>, alpha: A) -> Self {
         Alpha {
-            color: Oklch::new(l, chroma, hue),
+            color: Oklch::new_const(l, chroma, hue),
             alpha,
         }
     }

--- a/palette/src/random_sampling/cone.rs
+++ b/palette/src/random_sampling/cone.rs
@@ -141,16 +141,16 @@ mod test {
     fn sample_max_min() {
         let a = sample_hsv(RgbHue::from(0.0), 0.0, 0.0);
         let b = sample_hsv(RgbHue::from(360.0), 1.0, 1.0);
-        assert_relative_eq!(Hsv::new(0.0, 0.0, 0.0), a);
-        assert_relative_eq!(Hsv::new(360.0, 1.0, 1.0), b);
+        assert_relative_eq!(Hsv::new_srgb(0.0, 0.0, 0.0), a);
+        assert_relative_eq!(Hsv::new_srgb(360.0, 1.0, 1.0), b);
         let a = sample_hsl(RgbHue::from(0.0), 0.0, 0.0);
         let b = sample_hsl(RgbHue::from(360.0), 1.0, 1.0);
-        assert_relative_eq!(Hsl::new(0.0, 0.0, 0.0), a);
-        assert_relative_eq!(Hsl::new(360.0, 1.0, 1.0), b);
+        assert_relative_eq!(Hsl::new_srgb(0.0, 0.0, 0.0), a);
+        assert_relative_eq!(Hsl::new_srgb(360.0, 1.0, 1.0), b);
         let a = sample_hsluv(LuvHue::from(0.0), 0.0, 0.0);
         let b = sample_hsluv(LuvHue::from(360.0), 1.0, 1.0);
-        assert_relative_eq!(Hsluv::new(0.0, 0.0, 0.0), a);
-        assert_relative_eq!(Hsluv::new(360.0, 100.0, 100.0), b);
+        assert_relative_eq!(Hsluv::<D65>::new(0.0, 0.0, 0.0), a);
+        assert_relative_eq!(Hsluv::<D65>::new(360.0, 100.0, 100.0), b);
     }
 
     #[cfg(feature = "random")]

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -87,7 +87,7 @@ impl<S, T: Clone> Clone for Rgb<S, T> {
 
 impl<S, T> Rgb<S, T> {
     /// Create an RGB color.
-    pub fn new(red: T, green: T, blue: T) -> Rgb<S, T> {
+    pub const fn new(red: T, green: T, blue: T) -> Rgb<S, T> {
         Rgb {
             red,
             green,
@@ -265,7 +265,7 @@ where
 /// <span id="Rgba"></span>[`Rgba`](crate::rgb::Rgba) implementations.
 impl<S, T, A> Alpha<Rgb<S, T>, A> {
     /// Non-linear RGB.
-    pub fn new(red: T, green: T, blue: T, alpha: A) -> Self {
+    pub const fn new(red: T, green: T, blue: T, alpha: A) -> Self {
         Alpha {
             color: Rgb::new(red, green, blue),
             alpha,

--- a/palette/src/white_point.rs
+++ b/palette/src/white_point.rs
@@ -33,7 +33,7 @@ pub trait WhitePoint: 'static {
 pub struct A;
 impl WhitePoint for A {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(1.09850), from_f64(1.0), from_f64(0.35585))
+        Xyz::new(from_f64(1.09850), from_f64(1.0), from_f64(0.35585))
     }
 }
 /// CIE standard illuminant B
@@ -44,7 +44,7 @@ impl WhitePoint for A {
 pub struct B;
 impl WhitePoint for B {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.99072), from_f64(1.0), from_f64(0.85223))
+        Xyz::new(from_f64(0.99072), from_f64(1.0), from_f64(0.85223))
     }
 }
 /// CIE standard illuminant C
@@ -55,7 +55,7 @@ impl WhitePoint for B {
 pub struct C;
 impl WhitePoint for C {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.98074), from_f64(1.0), from_f64(1.18232))
+        Xyz::new(from_f64(0.98074), from_f64(1.0), from_f64(1.18232))
     }
 }
 /// CIE D series standard illuminant - D50
@@ -66,7 +66,7 @@ impl WhitePoint for C {
 pub struct D50;
 impl WhitePoint for D50 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.96422), from_f64(1.0), from_f64(0.82521))
+        Xyz::new(from_f64(0.96422), from_f64(1.0), from_f64(0.82521))
     }
 }
 /// CIE D series standard illuminant - D55
@@ -77,7 +77,7 @@ impl WhitePoint for D50 {
 pub struct D55;
 impl WhitePoint for D55 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.95682), from_f64(1.0), from_f64(0.92149))
+        Xyz::new(from_f64(0.95682), from_f64(1.0), from_f64(0.92149))
     }
 }
 /// CIE D series standard illuminant - D65
@@ -88,7 +88,7 @@ impl WhitePoint for D55 {
 pub struct D65;
 impl WhitePoint for D65 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.95047), from_f64(1.0), from_f64(1.08883))
+        Xyz::new(from_f64(0.95047), from_f64(1.0), from_f64(1.08883))
     }
 }
 /// CIE D series standard illuminant - D75
@@ -99,7 +99,7 @@ impl WhitePoint for D65 {
 pub struct D75;
 impl WhitePoint for D75 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.94972), from_f64(1.0), from_f64(1.22638))
+        Xyz::new(from_f64(0.94972), from_f64(1.0), from_f64(1.22638))
     }
 }
 /// CIE standard illuminant E
@@ -110,7 +110,7 @@ impl WhitePoint for D75 {
 pub struct E;
 impl WhitePoint for E {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(1.0), from_f64(1.0), from_f64(1.0))
+        Xyz::new(from_f64(1.0), from_f64(1.0), from_f64(1.0))
     }
 }
 /// CIE fluorescent illuminant series - F2
@@ -120,7 +120,7 @@ impl WhitePoint for E {
 pub struct F2;
 impl WhitePoint for F2 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.99186), from_f64(1.0), from_f64(0.67393))
+        Xyz::new(from_f64(0.99186), from_f64(1.0), from_f64(0.67393))
     }
 }
 /// CIE fluorescent illuminant series - F7
@@ -130,7 +130,7 @@ impl WhitePoint for F2 {
 pub struct F7;
 impl WhitePoint for F7 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.95041), from_f64(1.0), from_f64(1.08747))
+        Xyz::new(from_f64(0.95041), from_f64(1.0), from_f64(1.08747))
     }
 }
 /// CIE fluorescent illuminant series - F11
@@ -140,7 +140,7 @@ impl WhitePoint for F7 {
 pub struct F11;
 impl WhitePoint for F11 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(1.00962), from_f64(1.0), from_f64(0.64350))
+        Xyz::new(from_f64(1.00962), from_f64(1.0), from_f64(0.64350))
     }
 }
 /// CIE D series standard illuminant - D50
@@ -151,7 +151,7 @@ impl WhitePoint for F11 {
 pub struct D50Degree10;
 impl WhitePoint for D50Degree10 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.9672), from_f64(1.0), from_f64(0.8143))
+        Xyz::new(from_f64(0.9672), from_f64(1.0), from_f64(0.8143))
     }
 }
 /// CIE D series standard illuminant - D55
@@ -162,7 +162,7 @@ impl WhitePoint for D50Degree10 {
 pub struct D55Degree10;
 impl WhitePoint for D55Degree10 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.958), from_f64(1.0), from_f64(0.9093))
+        Xyz::new(from_f64(0.958), from_f64(1.0), from_f64(0.9093))
     }
 }
 /// CIE D series standard illuminant - D65
@@ -173,7 +173,7 @@ impl WhitePoint for D55Degree10 {
 pub struct D65Degree10;
 impl WhitePoint for D65Degree10 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.9481), from_f64(1.0), from_f64(1.073))
+        Xyz::new(from_f64(0.9481), from_f64(1.0), from_f64(1.073))
     }
 }
 /// CIE D series standard illuminant - D75
@@ -184,6 +184,6 @@ impl WhitePoint for D65Degree10 {
 pub struct D75Degree10;
 impl WhitePoint for D75Degree10 {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(from_f64(0.94416), from_f64(1.0), from_f64(1.2064))
+        Xyz::new(from_f64(0.94416), from_f64(1.0), from_f64(1.2064))
     }
 }

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -75,21 +75,9 @@ where
     }
 }
 
-impl<T> Yxy<D65, T> {
-    /// CIE Yxy with white point D65.
-    pub fn new(x: T, y: T, luma: T) -> Yxy<D65, T> {
-        Yxy {
-            x,
-            y,
-            luma,
-            white_point: PhantomData,
-        }
-    }
-}
-
 impl<Wp, T> Yxy<Wp, T> {
-    /// CIE Yxy.
-    pub fn with_wp(x: T, y: T, luma: T) -> Yxy<Wp, T> {
+    /// Create a CIE Yxy color.
+    pub const fn new(x: T, y: T, luma: T) -> Yxy<Wp, T> {
         Yxy {
             x,
             y,
@@ -105,7 +93,7 @@ impl<Wp, T> Yxy<Wp, T> {
 
     /// Convert from a `(x, y, luma)`, a.k.a. `(x, y, Y)` tuple.
     pub fn from_components((x, y, luma): (T, T, T)) -> Self {
-        Self::with_wp(x, y, luma)
+        Self::new(x, y, luma)
     }
 }
 
@@ -145,21 +133,11 @@ where
 }
 
 ///<span id="Yxya"></span>[`Yxya`](crate::Yxya) implementations.
-impl<T, A> Alpha<Yxy<D65, T>, A> {
-    /// CIE Yxy and transparency with white point D65.
-    pub fn new(x: T, y: T, luma: T, alpha: A) -> Self {
+impl<Wp, T, A> Alpha<Yxy<Wp, T>, A> {
+    /// Create a CIE Yxy color with transparency.
+    pub const fn new(x: T, y: T, luma: T, alpha: A) -> Self {
         Alpha {
             color: Yxy::new(x, y, luma),
-            alpha,
-        }
-    }
-}
-///<span id="Yxya"></span>[`Yxya`](crate::Yxya) implementations.
-impl<Wp, T, A> Alpha<Yxy<Wp, T>, A> {
-    /// CIE Yxy and transparency.
-    pub fn with_wp(x: T, y: T, luma: T, alpha: A) -> Self {
-        Alpha {
-            color: Yxy::with_wp(x, y, luma),
             alpha,
         }
     }
@@ -171,7 +149,7 @@ impl<Wp, T, A> Alpha<Yxy<Wp, T>, A> {
 
     /// Convert from a `(x, y, luma)`, a.k.a. `(x, y, Y)` tuple.
     pub fn from_components((x, y, luma, alpha): (T, T, T, A)) -> Self {
-        Self::with_wp(x, y, luma, alpha)
+        Self::new(x, y, luma, alpha)
     }
 }
 
@@ -491,7 +469,7 @@ mod test {
 
     #[test]
     fn luma() {
-        let a = Yxy::from_color(LinLuma::new(0.5));
+        let a = Yxy::<D65>::from_color(LinLuma::new(0.5));
         let b = Yxy::new(0.312727, 0.329023, 0.5);
         assert_relative_eq!(a, b, epsilon = 0.000001);
     }
@@ -547,7 +525,7 @@ mod test {
     #[cfg(feature = "serializing")]
     #[test]
     fn serialize() {
-        let serialized = ::serde_json::to_string(&Yxy::new(0.3, 0.8, 0.1)).unwrap();
+        let serialized = ::serde_json::to_string(&Yxy::<D65>::new(0.3, 0.8, 0.1)).unwrap();
 
         assert_eq!(serialized, r#"{"x":0.3,"y":0.8,"luma":0.1}"#);
     }

--- a/palette/tests/color_checker_data/babel.rs
+++ b/palette/tests/color_checker_data/babel.rs
@@ -26,9 +26,9 @@ pub struct BabelData {
 impl From<ColorCheckerRaw> for BabelData {
     fn from(src: ColorCheckerRaw) -> BabelData {
         BabelData {
-            yxy: Yxy::with_wp(src.yxy_x, src.yxy_y, src.yxy_luma),
-            xyz: Xyz::with_wp(src.xyz_x, src.xyz_y, src.xyz_z),
-            lab: Lab::with_wp(src.lab_l, src.lab_a, src.lab_b),
+            yxy: Yxy::new(src.yxy_x, src.yxy_y, src.yxy_luma),
+            xyz: Xyz::new(src.xyz_x, src.xyz_y, src.xyz_z),
+            lab: Lab::new(src.lab_l, src.lab_a, src.lab_b),
         }
     }
 }

--- a/palette/tests/color_checker_data/color_checker.rs
+++ b/palette/tests/color_checker_data/color_checker.rs
@@ -26,9 +26,9 @@ pub struct ColorCheckerData {
 impl From<ColorCheckerRaw> for ColorCheckerData {
     fn from(src: ColorCheckerRaw) -> ColorCheckerData {
         ColorCheckerData {
-            yxy: Yxy::with_wp(src.yxy_x, src.yxy_y, src.yxy_luma),
-            xyz: Xyz::with_wp(src.xyz_x, src.xyz_y, src.xyz_z),
-            lab: Lab::with_wp(src.lab_l, src.lab_a, src.lab_b),
+            yxy: Yxy::new(src.yxy_x, src.yxy_y, src.yxy_luma),
+            xyz: Xyz::new(src.xyz_x, src.xyz_y, src.xyz_z),
+            lab: Lab::new(src.lab_l, src.lab_a, src.lab_b),
         }
     }
 }

--- a/palette/tests/convert/data_color_mine.rs
+++ b/palette/tests/convert/data_color_mine.rs
@@ -91,9 +91,9 @@ where
             lch: Lch::new(src.lch_l_unscaled, src.lch_c_unscaled, src.lch_h_normalized),
             rgb: Srgb::new(src.rgb_r, src.rgb_g, src.rgb_b),
             linear_rgb: Srgb::new(src.rgb_r, src.rgb_g, src.rgb_b).into_linear(),
-            hsl: Hsl::new(src.hsl_h, src.hsl_s, src.hsl_l),
-            hsv: Hsv::new(src.hsv_h, src.hsv_s, src.hsv_v),
-            hwb: Hwb::new(src.hwb_h, src.hwb_w, src.hwb_b),
+            hsl: Hsl::new_srgb(src.hsl_h, src.hsl_s, src.hsl_l),
+            hsv: Hsv::new_srgb(src.hsv_h, src.hsv_s, src.hsv_v),
+            hwb: Hwb::new_srgb(src.hwb_h, src.hwb_w, src.hwb_b),
         }
     }
 }

--- a/palette/tests/convert/lab_lch.rs
+++ b/palette/tests/convert/lab_lch.rs
@@ -1,11 +1,12 @@
 use approx::assert_relative_eq;
 
 use palette::convert::IntoColorUnclamped;
+use palette::white_point::D65;
 use palette::{Lab, Lch};
 
 #[test]
 fn lab_lch_green() {
-    let lab = Lab::new(46.23, -66.176, 63.872);
+    let lab = Lab::<D65>::new(46.23, -66.176, 63.872);
     let lch = Lch::new(46.23, 91.972, 136.015);
     let expect_lab = lch.into_color_unclamped();
     let expect_lch = lab.into_color_unclamped();
@@ -16,7 +17,7 @@ fn lab_lch_green() {
 
 #[test]
 fn lab_lch_magenta() {
-    let lab = Lab::new(60.320, 98.254, -60.843);
+    let lab = Lab::<D65>::new(60.320, 98.254, -60.843);
     let lch = Lch::new(60.320, 115.567, 328.233);
 
     let expect_lab = lch.into_color_unclamped();
@@ -28,7 +29,7 @@ fn lab_lch_magenta() {
 
 #[test]
 fn lab_lch_blue() {
-    let lab = Lab::new(32.303, 79.197, -107.864);
+    let lab = Lab::<D65>::new(32.303, 79.197, -107.864);
     let lch = Lch::new(32.303, 133.816, 306.287);
 
     let expect_lab = lch.into_color_unclamped();

--- a/palette/tests/pointer_dataset/pointer_data.rs
+++ b/palette/tests/pointer_dataset/pointer_data.rs
@@ -24,7 +24,7 @@ use palette::{FromF64, Lab, Lch, Xyz};
 pub struct PointerWP;
 impl WhitePoint for PointerWP {
     fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::with_wp(
+        Xyz::new(
             FromF64::from_f64(0.980722647624),
             FromF64::from_f64(1.0),
             FromF64::from_f64(1.182254189827),
@@ -54,8 +54,8 @@ struct PointerData {
 impl From<PointerDataRaw> for PointerData {
     fn from(src: PointerDataRaw) -> PointerData {
         PointerData {
-            lch: Lch::with_wp(src.lch_l, src.lch_c, src.lch_h),
-            lab: Lab::with_wp(src.lab_l, src.lab_a, src.lab_b),
+            lch: Lch::new(src.lch_l, src.lch_c, src.lch_h),
+            lab: Lab::new(src.lab_l, src.lab_a, src.lab_b),
         }
     }
 }


### PR DESCRIPTION
I went through the color constructors and made them `const fn` (or made a `const fn` version of them). The named colors are using them now!

I did also change the naming so that `new` is always producing a fully generic type and names like `new_srgb` can be used for specialized constructors. It's easier to discover via searching or auto complete if the name contains "new". I removed `with_wp` while doing this, except in `Hsv`, `Hsl` and `Hwb` where I figured it would be good to still have an sRGB specialization. They are more likely to be "entry points" than most other types.

## Closed Issues

* Closes #134

## Breaking Change

The renamed and removed constructors will cause some breakage. Type inference will also be affected and may require additional type hints.