### PR TITLE
Add an Any white point

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -287,7 +287,7 @@ impl FromColorUnclamped<Color> for Color {
 // Convert from any kind of f32 sRGB.
 impl<S> FromColorUnclamped<Rgb<S, f32>> for Color
 where
-    S: RgbStandard<Space = encoding::Srgb>,
+    S: RgbStandard<f32, Space = encoding::Srgb>,
 {
     fn from_color_unclamped(color: Rgb<S, f32>) -> Color {
         let srgb = Srgb::from_color_unclamped(color);
@@ -298,7 +298,7 @@ where
 // Convert into any kind of f32 sRGB.
 impl<S> FromColorUnclamped<Color> for Rgb<S, f32>
 where
-    S: RgbStandard<Space = encoding::Srgb>,
+    S: RgbStandard<f32, Space = encoding::Srgb>,
 {
     fn from_color_unclamped(color: Color) -> Self {
         let srgb = Srgb::new(color.r, color.g, color.b);

--- a/palette/benches/matrix.rs
+++ b/palette/benches/matrix.rs
@@ -5,23 +5,23 @@ use palette::matrix::{
     matrix_inverse, multiply_3x3, multiply_rgb_to_xyz, multiply_xyz, multiply_xyz_to_rgb,
     rgb_to_xyz_matrix,
 };
-use palette::white_point::{WhitePoint, D50, D65};
+use palette::white_point::{WhitePoint, D65};
 use palette::{LinSrgb, Xyz};
 
 fn matrix(c: &mut Criterion) {
     let mut group = c.benchmark_group("Matrix functions");
 
     let inp1 = [0.1, 0.2, 0.3, 0.3, 0.2, 0.1, 0.2, 0.1, 0.3];
-    let inp2: Xyz<D65, _> = Xyz::new(0.4, 0.6, 0.8);
+    let inp2 = Xyz::new(0.4, 0.6, 0.8);
     let inp3 = [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
     let inp4 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
     let inverse: [f64; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
     let color = LinSrgb::new(0.2, 0.8, 0.4);
     let mat3 = rgb_to_xyz_matrix::<encoding::Srgb, f64>();
-    let wp: Xyz<D65, f64> = D65::get_xyz();
+    let wp: Xyz<D65, f64> = D65::get_xyz().with_white_point();
 
     group.bench_function("multiply_xyz", |b| {
-        b.iter(|| multiply_xyz::<D65, D50, _>(black_box(&inp1), black_box(&inp2)))
+        b.iter(|| multiply_xyz::<_>(black_box(&inp1), black_box(&inp2)))
     });
     group.bench_function("multiply_xyz_to_rgb", |b| {
         b.iter(|| multiply_xyz_to_rgb::<encoding::Srgb, _>(black_box(&inp1), black_box(&wp)))

--- a/palette/src/encoding/gamma.rs
+++ b/palette/src/encoding/gamma.rs
@@ -23,12 +23,20 @@ use crate::{from_f64, FromF64};
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Gamma<S, N: Number = F2p2>(PhantomData<(S, N)>);
 
-impl<S: RgbSpace, N: Number> RgbStandard for Gamma<S, N> {
-    type Space = S;
+impl<T, Sp, N> RgbStandard<T> for Gamma<Sp, N>
+where
+    Sp: RgbSpace<T>,
+    N: Number,
+{
+    type Space = Sp;
     type TransferFn = GammaFn<N>;
 }
 
-impl<Wp: WhitePoint, N: Number> LumaStandard for Gamma<Wp, N> {
+impl<T, Wp, N> LumaStandard<T> for Gamma<Wp, N>
+where
+    Wp: WhitePoint<T>,
+    N: Number,
+{
     type WhitePoint = Wp;
     type TransferFn = GammaFn<N>;
 }

--- a/palette/src/encoding/linear.rs
+++ b/palette/src/encoding/linear.rs
@@ -12,12 +12,18 @@ use crate::white_point::WhitePoint;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Linear<S>(PhantomData<S>);
 
-impl<S: RgbSpace> RgbStandard for Linear<S> {
-    type Space = S;
+impl<T, Sp> RgbStandard<T> for Linear<Sp>
+where
+    Sp: RgbSpace<T>,
+{
+    type Space = Sp;
     type TransferFn = LinearFn;
 }
 
-impl<Wp: WhitePoint> LumaStandard for Linear<Wp> {
+impl<T, Wp> LumaStandard<T> for Linear<Wp>
+where
+    Wp: WhitePoint<T>,
+{
     type WhitePoint = Wp;
     type TransferFn = LinearFn;
 }

--- a/palette/src/encoding/pixel.rs
+++ b/palette/src/encoding/pixel.rs
@@ -74,12 +74,11 @@ mod raw;
 /// use std::marker::PhantomData;
 ///
 /// use palette::{Pixel, RgbHue};
-/// use palette::rgb::RgbStandard;
 /// use palette::encoding::Srgb;
 ///
 /// #[derive(PartialEq, Debug, Pixel)]
 /// #[repr(C)]
-/// struct MyCoolColor<S: RgbStandard> {
+/// struct MyCoolColor<S> {
 ///     #[palette(unsafe_zero_sized)]
 ///     standard: PhantomData<S>,
 ///     // RgbHue is a wrapper with `#[repr(C)]`, so it can safely

--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -4,37 +4,36 @@ use crate::encoding::TransferFn;
 use crate::float::Float;
 use crate::luma::LumaStandard;
 use crate::rgb::{Primaries, RgbSpace, RgbStandard};
-use crate::white_point::{WhitePoint, D65};
-use crate::{from_f64, FromF64};
-use crate::{FloatComponent, Yxy};
+use crate::white_point::{Any, D65};
+use crate::{from_f64, FromF64, Yxy};
 
 /// The sRGB color space.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Srgb;
 
-impl Primaries for Srgb {
-    fn red<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
+impl<T: FromF64> Primaries<T> for Srgb {
+    fn red() -> Yxy<Any, T> {
         Yxy::new(from_f64(0.6400), from_f64(0.3300), from_f64(0.212656))
     }
-    fn green<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
+    fn green() -> Yxy<Any, T> {
         Yxy::new(from_f64(0.3000), from_f64(0.6000), from_f64(0.715158))
     }
-    fn blue<Wp: WhitePoint, T: FloatComponent>() -> Yxy<Wp, T> {
+    fn blue() -> Yxy<Any, T> {
         Yxy::new(from_f64(0.1500), from_f64(0.0600), from_f64(0.072186))
     }
 }
 
-impl RgbSpace for Srgb {
+impl<T: FromF64> RgbSpace<T> for Srgb {
     type Primaries = Srgb;
     type WhitePoint = D65;
 }
 
-impl RgbStandard for Srgb {
+impl<T: FromF64> RgbStandard<T> for Srgb {
     type Space = Srgb;
     type TransferFn = Srgb;
 }
 
-impl LumaStandard for Srgb {
+impl<T: FromF64> LumaStandard<T> for Srgb {
     type WhitePoint = D65;
     type TransferFn = Srgb;
 }

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -122,7 +122,7 @@ impl<S, T> Hsl<S, T> {
     }
 
     #[inline]
-    fn reinterpret_as<St: RgbStandard>(self) -> Hsl<St, T> {
+    fn reinterpret_as<St: RgbStandard<T>>(self) -> Hsl<St, T> {
         Hsl {
             hue: self.hue,
             saturation: self.saturation,
@@ -230,9 +230,9 @@ impl<S, T, A> Alpha<Hsl<S, T>, A> {
 impl<S1, S2, T> FromColorUnclamped<Hsl<S1, T>> for Hsl<S2, T>
 where
     T: FloatComponent,
-    S1: RgbStandard,
-    S2: RgbStandard,
-    S1::Space: RgbSpace<WhitePoint = <S2::Space as RgbSpace>::WhitePoint>,
+    S1: RgbStandard<T>,
+    S2: RgbStandard<T>,
+    S1::Space: RgbSpace<T, WhitePoint = <S2::Space as RgbSpace<T>>::WhitePoint>,
 {
     fn from_color_unclamped(hsl: Hsl<S1, T>) -> Self {
         if TypeId::of::<S1>() == TypeId::of::<S2>() {
@@ -588,7 +588,7 @@ where
 impl<S, T> RelativeContrast for Hsl<S, T>
 where
     T: FloatComponent,
-    S: RgbStandard,
+    S: RgbStandard<T>,
 {
     type Scalar = T;
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -404,7 +404,7 @@ where
 impl<Wp, T> RelativeContrast for Hsluv<Wp, T>
 where
     T: FloatComponent,
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
 {
     type Scalar = T;
 
@@ -422,7 +422,6 @@ where
 pub struct UniformHsluv<Wp, T>
 where
     T: Float + FromF64 + SampleUniform,
-    Wp: WhitePoint,
 {
     hue: crate::hues::UniformLuvHue<T>,
     u1: Uniform<T>,
@@ -434,7 +433,6 @@ where
 impl<Wp, T> SampleUniform for Hsluv<Wp, T>
 where
     T: Float + FromF64 + SampleUniform,
-    Wp: WhitePoint,
 {
     type Sampler = UniformHsluv<Wp, T>;
 }
@@ -443,7 +441,6 @@ where
 impl<Wp, T> UniformSampler for UniformHsluv<Wp, T>
 where
     T: Float + FromF64 + SampleUniform,
-    Wp: WhitePoint,
 {
     type X = Hsluv<Wp, T>;
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -124,7 +124,7 @@ impl<S, T> Hsv<S, T> {
     }
 
     #[inline]
-    fn reinterpret_as<St: RgbStandard>(self) -> Hsv<St, T> {
+    fn reinterpret_as<St: RgbStandard<T>>(self) -> Hsv<St, T> {
         Hsv {
             hue: self.hue,
             saturation: self.saturation,
@@ -230,9 +230,9 @@ impl<S, T, A> Alpha<Hsv<S, T>, A> {
 impl<S1, S2, T> FromColorUnclamped<Hsv<S1, T>> for Hsv<S2, T>
 where
     T: FloatComponent,
-    S1: RgbStandard,
-    S2: RgbStandard,
-    S1::Space: RgbSpace<WhitePoint = <S2::Space as RgbSpace>::WhitePoint>,
+    S1: RgbStandard<T>,
+    S2: RgbStandard<T>,
+    S1::Space: RgbSpace<T, WhitePoint = <S2::Space as RgbSpace<T>>::WhitePoint>,
 {
     fn from_color_unclamped(hsv: Hsv<S1, T>) -> Self {
         if TypeId::of::<S1>() == TypeId::of::<S2>() {
@@ -603,7 +603,7 @@ where
 impl<S, T> RelativeContrast for Hsv<S, T>
 where
     T: FloatComponent,
-    S: RgbStandard,
+    S: RgbStandard<T>,
 {
     type Scalar = T;
 

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -125,7 +125,7 @@ impl<S, T> Hwb<S, T> {
     }
 
     #[inline]
-    fn reinterpret_as<St: RgbStandard>(self) -> Hwb<St, T> {
+    fn reinterpret_as<St: RgbStandard<T>>(self) -> Hwb<St, T> {
         Hwb {
             hue: self.hue,
             whiteness: self.whiteness,
@@ -231,9 +231,9 @@ impl<S, T, A> Alpha<Hwb<S, T>, A> {
 
 impl<S1, S2, T> FromColorUnclamped<Hwb<S1, T>> for Hwb<S2, T>
 where
-    S1: RgbStandard,
-    S2: RgbStandard,
-    S1::Space: RgbSpace<WhitePoint = <S2::Space as RgbSpace>::WhitePoint>,
+    S1: RgbStandard<T>,
+    S2: RgbStandard<T>,
+    S1::Space: RgbSpace<T, WhitePoint = <S2::Space as RgbSpace<T>>::WhitePoint>,
     T: FloatComponent,
 {
     fn from_color_unclamped(hwb: Hwb<S1, T>) -> Self {
@@ -542,7 +542,7 @@ where
 impl<S, T> RelativeContrast for Hwb<S, T>
 where
     T: FloatComponent,
-    S: RgbStandard,
+    S: RgbStandard<T>,
 {
     type Scalar = T;
 

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -163,7 +163,7 @@ impl<Wp, T> FromColorUnclamped<Lab<Wp, T>> for Lab<Wp, T> {
 
 impl<Wp, T> FromColorUnclamped<Xyz<Wp, T>> for Lab<Wp, T>
 where
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
     T: FloatComponent,
 {
     fn from_color_unclamped(color: Xyz<Wp, T>) -> Self {
@@ -172,7 +172,7 @@ where
             mut y,
             mut z,
             ..
-        } = color / Wp::get_xyz();
+        } = color / Wp::get_xyz().with_white_point();
 
         fn convert<T: FloatComponent>(c: T) -> T {
             let epsilon = from_f64::<T>(6.0 / 29.0).powi(3);
@@ -355,25 +355,24 @@ where
 
 impl<Wp, T> ComponentWise for Lab<Wp, T>
 where
-    T: FloatComponent,
-    Wp: WhitePoint,
+    T: Clone,
 {
     type Scalar = T;
 
     fn component_wise<F: FnMut(T, T) -> T>(&self, other: &Lab<Wp, T>, mut f: F) -> Lab<Wp, T> {
         Lab {
-            l: f(self.l, other.l),
-            a: f(self.a, other.a),
-            b: f(self.b, other.b),
+            l: f(self.l.clone(), other.l.clone()),
+            a: f(self.a.clone(), other.a.clone()),
+            b: f(self.b.clone(), other.b.clone()),
             white_point: PhantomData,
         }
     }
 
     fn component_wise_self<F: FnMut(T) -> T>(&self, mut f: F) -> Lab<Wp, T> {
         Lab {
-            l: f(self.l),
-            a: f(self.a),
-            b: f(self.b),
+            l: f(self.l.clone()),
+            a: f(self.a.clone()),
+            b: f(self.b.clone()),
             white_point: PhantomData,
         }
     }
@@ -413,7 +412,7 @@ where
 
 impl<Wp, T> RelativeContrast for Lab<Wp, T>
 where
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
     T: FloatComponent,
 {
     type Scalar = T;

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -433,7 +433,7 @@ where
 
 impl<Wp, T> RelativeContrast for Lch<Wp, T>
 where
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
     T: FloatComponent,
 {
     type Scalar = T;

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -397,7 +397,7 @@ where
 
 impl<Wp, T> RelativeContrast for Lchuv<Wp, T>
 where
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
     T: FloatComponent,
 {
     type Scalar = T;

--- a/palette/src/luma.rs
+++ b/palette/src/luma.rs
@@ -25,15 +25,19 @@ pub type GammaLuma<T = f32> = Luma<Gamma<D65>, T>;
 pub type GammaLumaa<T = f32> = Lumaa<Gamma<D65>, T>;
 
 /// A white point and a transfer function.
-pub trait LumaStandard: 'static {
+pub trait LumaStandard<T>: 'static {
     /// The white point of the color space.
-    type WhitePoint: WhitePoint;
+    type WhitePoint: WhitePoint<T>;
 
     /// The transfer function for the luminance component.
     type TransferFn: TransferFn;
 }
 
-impl<Wp: WhitePoint, T: TransferFn> LumaStandard for (Wp, T) {
+impl<T, Wp, Tf> LumaStandard<T> for (Wp, Tf)
+where
+    Wp: WhitePoint<T>,
+    Tf: TransferFn,
+{
     type WhitePoint = Wp;
-    type TransferFn = T;
+    type TransferFn = Tf;
 }

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -108,8 +108,8 @@ impl<S, T> Luma<S, T> {
 
     fn reinterpret_as<S2>(self) -> Luma<S2, T>
     where
-        S: LumaStandard,
-        S2: LumaStandard<WhitePoint = S::WhitePoint>,
+        S: LumaStandard<T>,
+        S2: LumaStandard<T, WhitePoint = S::WhitePoint>,
     {
         Luma {
             luma: self.luma,
@@ -136,7 +136,7 @@ where
 impl<S, T> Luma<S, T>
 where
     T: FloatComponent,
-    S: LumaStandard,
+    S: LumaStandard<T>,
 {
     /// Convert the color to linear luminance.
     pub fn into_linear(self) -> Luma<Linear<S::WhitePoint>, T> {
@@ -149,16 +149,20 @@ where
     }
 
     /// Convert the color to a different encoding.
-    pub fn into_encoding<St: LumaStandard<WhitePoint = S::WhitePoint>>(self) -> Luma<St, T> {
+    pub fn into_encoding<St>(self) -> Luma<St, T>
+    where
+        St: LumaStandard<T, WhitePoint = S::WhitePoint>,
+    {
         Luma::new(St::TransferFn::from_linear(S::TransferFn::into_linear(
             self.luma,
         )))
     }
 
     /// Convert luminance from a different encoding.
-    pub fn from_encoding<St: LumaStandard<WhitePoint = S::WhitePoint>>(
-        color: Luma<St, T>,
-    ) -> Luma<S, T> {
+    pub fn from_encoding<St>(color: Luma<St, T>) -> Luma<S, T>
+    where
+        St: LumaStandard<T, WhitePoint = S::WhitePoint>,
+    {
         Luma::new(S::TransferFn::from_linear(St::TransferFn::into_linear(
             color.luma,
         )))
@@ -223,7 +227,7 @@ impl<S, T, A> Alpha<Luma<S, T>, A> {
 impl<S, T, A> Alpha<Luma<S, T>, A>
 where
     T: FloatComponent,
-    S: LumaStandard,
+    S: LumaStandard<T>,
 {
     /// Convert the color to linear luminance with transparency.
     pub fn into_linear(self) -> Alpha<Luma<Linear<S::WhitePoint>, T>, A> {
@@ -239,9 +243,10 @@ where
     }
 
     /// Convert the color to a different encoding with transparency.
-    pub fn into_encoding<St: LumaStandard<WhitePoint = S::WhitePoint>>(
-        self,
-    ) -> Alpha<Luma<St, T>, A> {
+    pub fn into_encoding<St>(self) -> Alpha<Luma<St, T>, A>
+    where
+        St: LumaStandard<T, WhitePoint = S::WhitePoint>,
+    {
         Alpha::<Luma<St, T>, A>::new(
             St::TransferFn::from_linear(S::TransferFn::into_linear(self.luma)),
             self.alpha,
@@ -249,9 +254,10 @@ where
     }
 
     /// Convert luminance from a different encoding with transparency.
-    pub fn from_encoding<St: LumaStandard<WhitePoint = S::WhitePoint>>(
-        color: Alpha<Luma<St, T>, A>,
-    ) -> Alpha<Luma<S, T>, A> {
+    pub fn from_encoding<St>(color: Alpha<Luma<St, T>, A>) -> Alpha<Luma<S, T>, A>
+    where
+        St: LumaStandard<T, WhitePoint = S::WhitePoint>,
+    {
         Alpha::<Luma<S, T>, A>::new(
             S::TransferFn::from_linear(St::TransferFn::into_linear(color.luma)),
             color.alpha,
@@ -261,8 +267,8 @@ where
 
 impl<S1, S2, T> FromColorUnclamped<Luma<S2, T>> for Luma<S1, T>
 where
-    S1: LumaStandard,
-    S2: LumaStandard<WhitePoint = S1::WhitePoint>,
+    S1: LumaStandard<T>,
+    S2: LumaStandard<T, WhitePoint = S1::WhitePoint>,
     T: FloatComponent,
 {
     fn from_color_unclamped(color: Luma<S2, T>) -> Self {
@@ -276,7 +282,7 @@ where
 
 impl<S, T> FromColorUnclamped<Xyz<S::WhitePoint, T>> for Luma<S, T>
 where
-    S: LumaStandard,
+    S: LumaStandard<T>,
     T: FloatComponent,
 {
     fn from_color_unclamped(color: Xyz<S::WhitePoint, T>) -> Self {
@@ -289,7 +295,7 @@ where
 
 impl<S, T> FromColorUnclamped<Yxy<S::WhitePoint, T>> for Luma<S, T>
 where
-    S: LumaStandard,
+    S: LumaStandard<T>,
     T: FloatComponent,
 {
     fn from_color_unclamped(color: Yxy<S::WhitePoint, T>) -> Self {
@@ -346,7 +352,7 @@ where
 impl<S, T> Mix for Luma<S, T>
 where
     T: FloatComponent,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Scalar = T;
 
@@ -363,7 +369,7 @@ where
 impl<S, T> Shade for Luma<S, T>
 where
     T: FloatComponent,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Scalar = T;
 
@@ -393,7 +399,7 @@ where
 impl<S, T> Blend for Luma<S, T>
 where
     T: FloatComponent,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Color = Luma<S, T>;
 
@@ -443,7 +449,7 @@ where
 impl<S, T> Add<Luma<S, T>> for Luma<S, T>
 where
     T: Add,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Add>::Output>;
 
@@ -458,7 +464,7 @@ where
 impl<S, T> Add<T> for Luma<S, T>
 where
     T: Add,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Add>::Output>;
 
@@ -473,7 +479,7 @@ where
 impl<S, T> AddAssign<Luma<S, T>> for Luma<S, T>
 where
     T: AddAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn add_assign(&mut self, other: Luma<S, T>) {
         self.luma += other.luma;
@@ -483,7 +489,7 @@ where
 impl<S, T> AddAssign<T> for Luma<S, T>
 where
     T: AddAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn add_assign(&mut self, c: T) {
         self.luma += c;
@@ -493,7 +499,7 @@ where
 impl<S, T> Sub<Luma<S, T>> for Luma<S, T>
 where
     T: Sub,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Sub>::Output>;
 
@@ -508,7 +514,7 @@ where
 impl<S, T> Sub<T> for Luma<S, T>
 where
     T: Sub,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Sub>::Output>;
 
@@ -523,7 +529,7 @@ where
 impl<S, T> SubAssign<Luma<S, T>> for Luma<S, T>
 where
     T: SubAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn sub_assign(&mut self, other: Luma<S, T>) {
         self.luma -= other.luma;
@@ -533,7 +539,7 @@ where
 impl<S, T> SubAssign<T> for Luma<S, T>
 where
     T: SubAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn sub_assign(&mut self, c: T) {
         self.luma -= c;
@@ -543,7 +549,7 @@ where
 impl<S, T> Mul<Luma<S, T>> for Luma<S, T>
 where
     T: Mul,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Mul>::Output>;
 
@@ -558,7 +564,7 @@ where
 impl<S, T> Mul<T> for Luma<S, T>
 where
     T: Mul,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Mul>::Output>;
 
@@ -573,7 +579,7 @@ where
 impl<S, T> MulAssign<Luma<S, T>> for Luma<S, T>
 where
     T: MulAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn mul_assign(&mut self, other: Luma<S, T>) {
         self.luma *= other.luma;
@@ -583,7 +589,7 @@ where
 impl<S, T> MulAssign<T> for Luma<S, T>
 where
     T: MulAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn mul_assign(&mut self, c: T) {
         self.luma *= c;
@@ -593,7 +599,7 @@ where
 impl<S, T> Div<Luma<S, T>> for Luma<S, T>
 where
     T: Div,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Div>::Output>;
 
@@ -608,7 +614,7 @@ where
 impl<S, T> Div<T> for Luma<S, T>
 where
     T: Div,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     type Output = Luma<S, <T as Div>::Output>;
 
@@ -623,7 +629,7 @@ where
 impl<S, T> DivAssign<Luma<S, T>> for Luma<S, T>
 where
     T: DivAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn div_assign(&mut self, other: Luma<S, T>) {
         self.luma /= other.luma;
@@ -633,7 +639,7 @@ where
 impl<S, T> DivAssign<T> for Luma<S, T>
 where
     T: DivAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
+    S: LumaStandard<T, TransferFn = LinearFn>,
 {
     fn div_assign(&mut self, c: T) {
         self.luma /= c;
@@ -750,7 +756,7 @@ where
 impl<S, T> RelativeContrast for Luma<S, T>
 where
     T: FloatComponent,
-    S: LumaStandard,
+    S: LumaStandard<T>,
 {
     type Scalar = T;
 

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -175,12 +175,12 @@ where
 
 impl<Wp, T> FromColorUnclamped<Xyz<Wp, T>> for Luv<Wp, T>
 where
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
     T: FloatComponent,
 {
     fn from_color_unclamped(color: Xyz<Wp, T>) -> Self {
         let from_f64 = T::from_f64;
-        let w: Xyz<Wp, T> = Wp::get_xyz();
+        let w = Wp::get_xyz();
 
         let kappa = from_f64(29.0 / 3.0).powi(3);
         let epsilon = from_f64(6.0 / 29.0).powi(3);
@@ -387,7 +387,7 @@ where
 
 impl<Wp, T> RelativeContrast for Luv<Wp, T>
 where
-    Wp: WhitePoint,
+    Wp: WhitePoint<T>,
     T: FloatComponent,
 {
     type Scalar = T;

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -179,8 +179,9 @@ macro_rules! test_uniform_distribution {
                 }
 
                 $({
-                    let min = $component_min;
-                    let range = $component_max - min;
+                    let min: f32 = $component_min;
+                    let max: f32 = $component_max;
+                    let range = max - min;
                     let normalized = (color.$component - min) / range;
                     $component[((normalized * BINS as f32) as usize).min(BINS - 1)] += 1;
                 })+
@@ -212,8 +213,9 @@ macro_rules! test_uniform_distribution {
                 }
 
                 $({
-                    let min = $component_min;
-                    let range = $component_max - min;
+                    let min: f32 = $component_min;
+                    let max: f32 = $component_max;
+                    let range = max - min;
                     let normalized = (color.$component - min) / range;
                     $component[((normalized * BINS as f32) as usize).min(BINS - 1)] += 1;
                 })+
@@ -245,8 +247,9 @@ macro_rules! test_uniform_distribution {
                 }
 
                 $({
-                    let min = $component_min;
-                    let range = $component_max - min;
+                    let min: f32 = $component_min;
+                    let max: f32 = $component_max;
+                    let range = max - min;
                     let normalized = (color.$component - min) / range;
                     $component[((normalized * BINS as f32) as usize).min(BINS - 1)] += 1;
                 })+

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -238,13 +238,13 @@ where
 
         let Xyz {
             x: l, y: m, z: s, ..
-        } = multiply_xyz::<D65, D65, T>(&m1, &color);
+        } = multiply_xyz(&m1, &color.with_white_point());
 
         let l_m_s_ = Xyz::new(l.cbrt(), m.cbrt(), s.cbrt());
 
         let Xyz {
             x: l, y: a, z: b, ..
-        } = multiply_xyz::<D65, D65, T>(&m2, &l_m_s_);
+        } = multiply_xyz(&m2, &l_m_s_);
 
         Self::new(l, a, b)
     }

--- a/palette/src/white_point.rs
+++ b/palette/src/white_point.rs
@@ -8,6 +8,14 @@
 
 use crate::{from_f64, FromF64, Xyz};
 
+/// Represents an unspecified reference white point.
+///
+/// Some color spaces (such as `Xyz` and `Yxy`) or operations don't necessarily
+/// need a known intended white point. `Any` may be used as a placeholder type
+/// in those situations.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Any;
+
 /// WhitePoint defines the Xyz color co-ordinates for a given white point.
 ///
 /// A white point (often referred to as reference white or target white in
@@ -18,9 +26,9 @@ use crate::{from_f64, FromF64, Xyz};
 /// Custom white points can be easily defined on an empty struct with the
 /// tristimulus values and can be used in place of the ones defined in this
 /// library.
-pub trait WhitePoint: 'static {
+pub trait WhitePoint<T>: 'static {
     /// Get the Xyz chromaticity co-ordinates for the white point.
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T>;
+    fn get_xyz() -> Xyz<Any, T>;
 }
 
 /// CIE standard illuminant A
@@ -31,8 +39,8 @@ pub trait WhitePoint: 'static {
 /// CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct A;
-impl WhitePoint for A {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for A {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(1.09850), from_f64(1.0), from_f64(0.35585))
     }
 }
@@ -42,8 +50,8 @@ impl WhitePoint for A {
 /// temperature (CCT) of 4874 K Uses the CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct B;
-impl WhitePoint for B {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for B {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.99072), from_f64(1.0), from_f64(0.85223))
     }
 }
@@ -53,8 +61,8 @@ impl WhitePoint for B {
 /// 6774 K Uses the CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct C;
-impl WhitePoint for C {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for C {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.98074), from_f64(1.0), from_f64(1.18232))
     }
 }
@@ -64,8 +72,8 @@ impl WhitePoint for C {
 /// 5000K for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50;
-impl WhitePoint for D50 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D50 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.96422), from_f64(1.0), from_f64(0.82521))
     }
 }
@@ -75,8 +83,8 @@ impl WhitePoint for D50 {
 /// 5500K for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55;
-impl WhitePoint for D55 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D55 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.95682), from_f64(1.0), from_f64(0.92149))
     }
 }
@@ -86,8 +94,8 @@ impl WhitePoint for D55 {
 /// for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65;
-impl WhitePoint for D65 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D65 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.95047), from_f64(1.0), from_f64(1.08883))
     }
 }
@@ -97,8 +105,8 @@ impl WhitePoint for D65 {
 /// 7500K for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75;
-impl WhitePoint for D75 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D75 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.94972), from_f64(1.0), from_f64(1.22638))
     }
 }
@@ -108,8 +116,8 @@ impl WhitePoint for D75 {
 /// Uses the CIE 1932 2° Standard Observer
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct E;
-impl WhitePoint for E {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for E {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(1.0), from_f64(1.0), from_f64(1.0))
     }
 }
@@ -118,8 +126,8 @@ impl WhitePoint for E {
 /// F2 represents a semi-broadband fluorescent lamp for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F2;
-impl WhitePoint for F2 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for F2 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.99186), from_f64(1.0), from_f64(0.67393))
     }
 }
@@ -128,8 +136,8 @@ impl WhitePoint for F2 {
 /// F7 represents a broadband fluorescent lamp for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F7;
-impl WhitePoint for F7 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for F7 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.95041), from_f64(1.0), from_f64(1.08747))
     }
 }
@@ -138,8 +146,8 @@ impl WhitePoint for F7 {
 /// F11 represents a narrowband fluorescent lamp for 2° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F11;
-impl WhitePoint for F11 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for F11 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(1.00962), from_f64(1.0), from_f64(0.64350))
     }
 }
@@ -149,8 +157,8 @@ impl WhitePoint for F11 {
 /// 5000K for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50Degree10;
-impl WhitePoint for D50Degree10 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D50Degree10 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.9672), from_f64(1.0), from_f64(0.8143))
     }
 }
@@ -160,8 +168,8 @@ impl WhitePoint for D50Degree10 {
 /// 5500K for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55Degree10;
-impl WhitePoint for D55Degree10 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D55Degree10 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.958), from_f64(1.0), from_f64(0.9093))
     }
 }
@@ -171,8 +179,8 @@ impl WhitePoint for D55Degree10 {
 /// for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65Degree10;
-impl WhitePoint for D65Degree10 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D65Degree10 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.9481), from_f64(1.0), from_f64(1.073))
     }
 }
@@ -182,8 +190,8 @@ impl WhitePoint for D65Degree10 {
 /// 7500K for 10° Standard Observer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75Degree10;
-impl WhitePoint for D75Degree10 {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
+impl<T: FromF64> WhitePoint<T> for D75Degree10 {
+    fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.94416), from_f64(1.0), from_f64(1.2064))
     }
 }

--- a/palette/tests/pointer_dataset/pointer_data.rs
+++ b/palette/tests/pointer_dataset/pointer_data.rs
@@ -17,18 +17,14 @@ use lazy_static::lazy_static;
 use serde_derive::Deserialize;
 
 use palette::convert::IntoColorUnclamped;
-use palette::white_point::WhitePoint;
-use palette::{FromF64, Lab, Lch, Xyz};
+use palette::white_point::{Any, WhitePoint};
+use palette::{Lab, Lch, Xyz};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PointerWP;
-impl WhitePoint for PointerWP {
-    fn get_xyz<Wp, T: FromF64>() -> Xyz<Wp, T> {
-        Xyz::new(
-            FromF64::from_f64(0.980722647624),
-            FromF64::from_f64(1.0),
-            FromF64::from_f64(1.182254189827),
-        )
+impl WhitePoint<f64> for PointerWP {
+    fn get_xyz() -> Xyz<Any, f64> {
+        Xyz::new(0.980722647624, 1.0, 1.182254189827)
     }
 }
 


### PR DESCRIPTION
This adds `white_point::Any`, which represents an unspecified white point. That makes it possible to remove a number of white point type parameters where they didn't matter or weren't used, other than to fill a hole in `Xyz` or `Yxy` types. This simplifies a lot of traits, removes ambiguity and presumably also reduces the amount of generated code.

## Closed Issues

* Closes #194 

## Breaking Change

* Some places that would receive or return specific `Xyz` or `Yxy` types have been changed to use the `Any` white point. It's easy to cast between white points with the new `with_white_point` method.
* `WhitePoint` and `Primaries` have been changed to be parametric over the number type, changing them to`WhitePoint<T>` and `Primaries<T>`.
* `RgbSpace`, `RgbStandard` and `LumaStandard` have also been changed to `RgbSpace<T>`, `RgbStandard<T>` and `LumaStandard<T>` to be able to pass the type parameter on to `WhitePoint` and `Primaries`. Removing the trait bounds from the associated types would instead have required trait bounds in `impl`s.
