### PR TITLE
Make most operator traits take their input by value and change `TransferFn` to `TransferFn<T>`

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -137,7 +137,7 @@ use palette::{Hue, Shade, Mix, Hsl, Hsv};
 
 fn transform_color<C>(color: C, amount: f32) -> C
 where
-    C: Hue + Shade<Scalar=f32> + Mix<Scalar=f32> + Clone,
+    C: Hue + Shade<Scalar=f32> + Mix<Scalar=f32> + Copy,
     f32: Into<C::Hue>,
 {
     let new_color = color.shift_hue(170.0).lighten(1.0);

--- a/palette/README.md
+++ b/palette/README.md
@@ -317,17 +317,13 @@ impl Clamp for Color {
             && zero_to_one.contains(&self.a)
     }
 
-    fn clamp(&self) -> Self {
+    fn clamp(self) -> Self {
         Color {
             r: self.r.min(1.0).max(0.0),
             g: self.g.min(1.0).max(0.0),
             b: self.b.min(1.0).max(0.0),
             a: self.a.min(1.0).max(0.0),
         }
-    }
-
-    fn clamp_self(&mut self) {
-        *self = self.clamp();
     }
 }
 

--- a/palette/README.md
+++ b/palette/README.md
@@ -135,7 +135,7 @@ Palette comes with a number of color operations built in, such as saturate/desat
 ```rust
 use palette::{Hue, Shade, Mix, Hsl, Hsv};
 
-fn transform_color<C>(color: &C, amount: f32) -> C
+fn transform_color<C>(color: C, amount: f32) -> C
 where
     C: Hue + Shade<Scalar=f32> + Mix<Scalar=f32> + Clone,
     f32: Into<C::Hue>,
@@ -143,11 +143,11 @@ where
     let new_color = color.shift_hue(170.0).lighten(1.0);
 
     // Interpolate between the old and new color.
-    color.mix(&new_color, amount)
+    color.mix(new_color, amount)
 }
 
-let new_hsl = transform_color(&Hsl::new_srgb(0.00, 0.70, 0.20), 0.8);
-let new_hsv = transform_color(&Hsv::new_srgb(0.00, 0.82, 0.34), 0.8);
+let new_hsl = transform_color(Hsl::new_srgb(0.00, 0.70, 0.20), 0.8);
+let new_hsv = transform_color(Hsv::new_srgb(0.00, 0.82, 0.34), 0.8);
 ```
 
 This image shows the transition from the color to `new_color` in HSL and HSV:

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -54,7 +54,7 @@ fn pixels_and_buffers() {
 fn color_operations_1() {
     use palette::{Hsl, Hsv, Hue, Mix, Shade};
 
-    fn transform_color<C>(color: &C, amount: f32) -> C
+    fn transform_color<C>(color: C, amount: f32) -> C
     where
         C: Hue + Shade<Scalar = f32> + Mix<Scalar = f32> + Clone,
         f32: Into<C::Hue>,
@@ -62,7 +62,7 @@ fn color_operations_1() {
         let new_color = color.shift_hue(170.0).lighten(1.0);
 
         // Interpolate between the old and new color.
-        color.mix(&new_color, amount)
+        color.mix(new_color, amount)
     }
 
     // Write example image
@@ -70,7 +70,7 @@ fn color_operations_1() {
     let hsl_color_at = |amount| {
         use palette::FromColor;
 
-        let color = transform_color(&hsl_color, amount);
+        let color = transform_color(hsl_color, amount);
         palette::Srgb::from_color(color).into_format()
     };
 
@@ -78,7 +78,7 @@ fn color_operations_1() {
     let hsv_color_at = |amount| {
         use palette::FromColor;
 
-        let color = transform_color(&hsv_color, amount);
+        let color = transform_color(hsv_color, amount);
         palette::Srgb::from_color(color).into_format()
     };
 

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -56,7 +56,7 @@ fn color_operations_1() {
 
     fn transform_color<C>(color: C, amount: f32) -> C
     where
-        C: Hue + Shade<Scalar = f32> + Mix<Scalar = f32> + Clone,
+        C: Hue + Shade<Scalar = f32> + Mix<Scalar = f32> + Copy,
         f32: Into<C::Hue>,
     {
         let new_color = color.shift_hue(170.0).lighten(1.0);

--- a/palette/src/alpha.rs
+++ b/palette/src/alpha.rs
@@ -96,6 +96,7 @@ pub trait WithAlpha<A>: Sized {
     /// let transparent = transparent.with_alpha(0.8f32);
     /// assert_eq!(transparent.alpha, 0.8);
     /// ```
+    #[must_use]
     fn with_alpha(self, alpha: A) -> Self::WithAlpha;
 
     /// Removes the transparency from the color. If `Self::Color` has
@@ -111,6 +112,7 @@ pub trait WithAlpha<A>: Sized {
     /// let color = transparent.without_alpha();
     /// assert_eq!(transparent.color, color);
     /// ```
+    #[must_use]
     fn without_alpha(self) -> Self::Color;
 
     /// Splits the color into separate color and transparency values.
@@ -130,6 +132,7 @@ pub trait WithAlpha<A>: Sized {
     /// assert_eq!(transparent.color, color);
     /// assert_eq!(transparent.alpha, alpha);
     /// ```
+    #[must_use]
     fn split(self) -> (Self::Color, A);
 
     /// Transforms the color into a fully opaque color with a transparency
@@ -143,6 +146,8 @@ pub trait WithAlpha<A>: Sized {
     /// let opaque: Srgba<u8> = color.opaque();
     /// assert_eq!(opaque.alpha, 255);
     /// ```
+    #[must_use]
+    #[inline]
     fn opaque(self) -> Self::WithAlpha
     where
         A: Component,
@@ -161,6 +166,8 @@ pub trait WithAlpha<A>: Sized {
     /// let transparent: Srgba<u8> = color.transparent();
     /// assert_eq!(transparent.alpha, 0);
     /// ```
+    #[must_use]
+    #[inline]
     fn transparent(self) -> Self::WithAlpha
     where
         A: Zero,

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -179,20 +179,17 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
 }
 
 impl<C: Clamp, T: Component> Clamp for Alpha<C, T> {
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.color.is_within_bounds() && self.alpha >= T::zero() && self.alpha <= T::max_intensity()
     }
 
-    fn clamp(&self) -> Alpha<C, T> {
+    #[inline]
+    fn clamp(self) -> Self {
         Alpha {
             color: self.color.clamp(),
             alpha: clamp(self.alpha, T::zero(), T::max_intensity()),
         }
-    }
-
-    fn clamp_self(&mut self) {
-        self.color.clamp_self();
-        self.alpha = clamp(self.alpha, T::zero(), T::max_intensity());
     }
 }
 

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -107,14 +107,18 @@ impl<C, T> DerefMut for Alpha<C, T> {
     }
 }
 
-impl<C: Mix> Mix for Alpha<C, C::Scalar> {
+impl<C> Mix for Alpha<C, C::Scalar>
+where
+    C: Mix,
+{
     type Scalar = C::Scalar;
 
-    fn mix(&self, other: &Alpha<C, C::Scalar>, factor: C::Scalar) -> Alpha<C, C::Scalar> {
-        Alpha {
-            color: self.color.mix(&other.color, factor),
-            alpha: self.alpha + factor * (other.alpha - self.alpha),
-        }
+    #[inline]
+    fn mix(mut self, other: Alpha<C, C::Scalar>, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+        self.color = self.color.mix(other.color, factor);
+        self.alpha = self.alpha + factor * (other.alpha - self.alpha);
+
+        self
     }
 }
 

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -151,17 +151,17 @@ impl<C: GetHue, T> GetHue for Alpha<C, T> {
 }
 
 impl<C: Hue, T: Clone> Hue for Alpha<C, T> {
-    fn with_hue<H: Into<C::Hue>>(&self, hue: H) -> Alpha<C, T> {
+    fn with_hue<H: Into<C::Hue>>(self, hue: H) -> Alpha<C, T> {
         Alpha {
             color: self.color.with_hue(hue),
-            alpha: self.alpha.clone(),
+            alpha: self.alpha,
         }
     }
 
-    fn shift_hue<H: Into<C::Hue>>(&self, amount: H) -> Alpha<C, T> {
+    fn shift_hue<H: Into<C::Hue>>(self, amount: H) -> Alpha<C, T> {
         Alpha {
             color: self.color.shift_hue(amount),
-            alpha: self.alpha.clone(),
+            alpha: self.alpha,
         }
     }
 }

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -125,14 +125,16 @@ where
 impl<C: Shade> Shade for Alpha<C, C::Scalar> {
     type Scalar = C::Scalar;
 
-    fn lighten(&self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+    #[inline]
+    fn lighten(self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
             color: self.color.lighten(factor),
             alpha: self.alpha,
         }
     }
 
-    fn lighten_fixed(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+    #[inline]
+    fn lighten_fixed(self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
             color: self.color.lighten_fixed(amount),
             alpha: self.alpha,

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -169,14 +169,16 @@ impl<C: Hue, T: Clone> Hue for Alpha<C, T> {
 impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
     type Scalar = C::Scalar;
 
-    fn saturate(&self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+    #[inline]
+    fn saturate(self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
             color: self.color.saturate(factor),
             alpha: self.alpha,
         }
     }
 
-    fn saturate_fixed(&self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+    #[inline]
+    fn saturate_fixed(self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
         Alpha {
             color: self.color.saturate_fixed(amount),
             alpha: self.alpha,

--- a/palette/src/blend.rs
+++ b/palette/src/blend.rs
@@ -56,6 +56,7 @@ where
     C::Scalar: Float,
 {
     /// Apply this blend function to a pair of colors.
+    #[must_use]
     fn apply_to(
         self,
         source: PreAlpha<C, C::Scalar>,
@@ -69,6 +70,7 @@ where
     C::Scalar: Float,
     F: FnOnce(PreAlpha<C, C::Scalar>, PreAlpha<C, C::Scalar>) -> PreAlpha<C, C::Scalar>,
 {
+    #[inline]
     fn apply_to(
         self,
         source: PreAlpha<C, C::Scalar>,

--- a/palette/src/blend/blend.rs
+++ b/palette/src/blend/blend.rs
@@ -20,9 +20,11 @@ where
     type Color: Blend<Color = Self::Color> + ComponentWise;
 
     /// Convert the color to premultiplied alpha.
+    #[must_use]
     fn into_premultiplied(self) -> PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>;
 
     /// Convert the color from premultiplied alpha.
+    #[must_use]
     fn from_premultiplied(
         color: PreAlpha<Self::Color, <Self::Color as ComponentWise>::Scalar>,
     ) -> Self;
@@ -48,6 +50,8 @@ where
     /// let b = LinSrgba::new(0.6, 0.3, 0.5, 0.1);
     /// let c = a.blend(b, blend_mode);
     /// ```
+    #[must_use]
+    #[inline]
     fn blend<F>(self, destination: Self, blend_function: F) -> Self
     where
         F: BlendFunction<Self::Color>,
@@ -59,6 +63,8 @@ where
 
     /// Place `self` over `other`. This is the good old common alpha
     /// composition equation.
+    #[must_use]
+    #[inline]
     fn over(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -78,6 +84,8 @@ where
 
     /// Results in the parts of `self` that overlaps the visible parts of
     /// `other`.
+    #[must_use]
+    #[inline]
     fn inside(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -95,6 +103,8 @@ where
 
     /// Results in the parts of `self` that lies outside the visible parts of
     /// `other`.
+    #[must_use]
+    #[inline]
     fn outside(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -111,6 +121,8 @@ where
     }
 
     /// Place `self` over only the visible parts of `other`.
+    #[must_use]
+    #[inline]
     fn atop(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -129,6 +141,8 @@ where
     }
 
     /// Results in either `self` or `other`, where they do not overlap.
+    #[must_use]
+    #[inline]
     fn xor(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -153,6 +167,8 @@ where
 
     /// Add `self` and `other`. This uses the alpha component to regulate the
     /// effect, so it's not just plain component wise addition.
+    #[must_use]
+    #[inline]
     fn plus(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -170,6 +186,8 @@ where
 
     /// Multiply `self` with `other`. This uses the alpha component to regulate
     /// the effect, so it's not just plain component wise multiplication.
+    #[must_use]
+    #[inline]
     fn multiply(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -188,6 +206,8 @@ where
     }
 
     /// Make a color which is at least as light as `self` or `other`.
+    #[must_use]
+    #[inline]
     fn screen(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -205,6 +225,8 @@ where
 
     /// Multiply `self` or `other` if other is dark, or screen them if `other`
     /// is light. This results in an S curve.
+    #[must_use]
+    #[inline]
     fn overlay(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -230,6 +252,8 @@ where
     }
 
     /// Return the darkest parts of `self` and `other`.
+    #[must_use]
+    #[inline]
     fn darken(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -248,6 +272,8 @@ where
     }
 
     /// Return the lightest parts of `self` and `other`.
+    #[must_use]
+    #[inline]
     fn lighten(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -267,6 +293,8 @@ where
 
     /// Lighten `other` to reflect `self`. Results in `other` if `self` is
     /// black.
+    #[must_use]
+    #[inline]
     fn dodge(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -294,6 +322,8 @@ where
 
     /// Darken `other` to reflect `self`. Results in `other` if `self` is
     /// white.
+    #[must_use]
+    #[inline]
     fn burn(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -322,6 +352,8 @@ where
     /// Multiply `self` or `other` if other is dark, or screen them if `self`
     /// is light. This is similar to `overlay`, but depends on `self` instead
     /// of `other`.
+    #[must_use]
+    #[inline]
     fn hard_light(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -349,6 +381,8 @@ where
     /// Lighten `other` if `self` is light, or darken `other` as if it's burned
     /// if `self` is dark. The effect is increased if the components of `self`
     /// is further from 0.5.
+    #[must_use]
+    #[inline]
     fn soft_light(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -392,6 +426,8 @@ where
 
     /// Return the absolute difference between `self` and `other`. It's
     /// basically `abs(self - other)`, but regulated by the alpha component.
+    #[must_use]
+    #[inline]
     fn difference(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();
@@ -413,6 +449,8 @@ where
     /// Similar to `difference`, but appears to result in a lower contrast.
     /// `other` is inverted if `self` is white, and preserved if `self` is
     /// black.
+    #[must_use]
+    #[inline]
     fn exclusion(self, other: Self) -> Self {
         let one = <Self::Color as ComponentWise>::Scalar::one();
         let zero = <Self::Color as ComponentWise>::Scalar::zero();

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -110,14 +110,18 @@ where
     }
 }
 
-impl<C: Mix> Mix for PreAlpha<C, C::Scalar> {
+impl<C> Mix for PreAlpha<C, C::Scalar>
+where
+    C: Mix,
+{
     type Scalar = C::Scalar;
 
-    fn mix(&self, other: &PreAlpha<C, C::Scalar>, factor: C::Scalar) -> PreAlpha<C, C::Scalar> {
-        PreAlpha {
-            color: self.color.mix(&other.color, factor),
-            alpha: self.alpha + factor * (other.alpha - self.alpha),
-        }
+    #[inline]
+    fn mix(mut self, other: PreAlpha<C, C::Scalar>, factor: C::Scalar) -> PreAlpha<C, C::Scalar> {
+        self.color = self.color.mix(other.color, factor);
+        self.alpha = self.alpha + factor * (other.alpha - self.alpha);
+
+        self
     }
 }
 

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -62,6 +62,7 @@ where
     C: ComponentWise<Scalar = T>,
     T: Float,
 {
+    #[inline]
     fn from(color: Alpha<C, T>) -> PreAlpha<C, T> {
         let alpha = clamp(color.alpha, T::zero(), T::one());
 
@@ -77,6 +78,7 @@ where
     C: ComponentWise<Scalar = T>,
     T: Float,
 {
+    #[inline]
     fn from(color: PreAlpha<C, T>) -> Alpha<C, T> {
         let alpha = clamp(color.alpha, T::zero(), T::one());
 

--- a/palette/src/chromatic_adaptation.rs
+++ b/palette/src/chromatic_adaptation.rs
@@ -55,10 +55,12 @@ where
     T: FloatComponent,
 {
     /// Get the cone response functions for the chromatic adaptation method
+    #[must_use]
     fn get_cone_response(&self) -> ConeResponseMatrices<T>;
 
     /// Generates a 3x3 transformation matrix to convert color from one
     /// reference white point to another with the given cone_response
+    #[must_use]
     fn generate_transform_matrix(
         &self,
         source_wp: Xyz<Any, T>,
@@ -91,6 +93,7 @@ where
     T: FloatComponent,
 {
     #[rustfmt::skip]
+    #[inline]
     fn get_cone_response(&self) -> ConeResponseMatrices<T> {
         match *self {
              Method::Bradford => {
@@ -150,12 +153,15 @@ where
     Dwp: WhitePoint<T>,
 {
     /// Convert the source color to the destination color using the bradford
-    /// method by default
+    /// method by default.
+    #[must_use]
+    #[inline]
     fn adapt_from(color: S) -> Self {
         Self::adapt_from_using(color, Method::Bradford)
     }
     /// Convert the source color to the destination color using the specified
-    /// method
+    /// method.
+    #[must_use]
     fn adapt_from_using<M: TransformMatrix<T>>(color: S, method: M) -> Self;
 }
 
@@ -167,6 +173,7 @@ where
     S: IntoColorUnclamped<Xyz<Swp, T>>,
     D: FromColorUnclamped<Xyz<Dwp, T>>,
 {
+    #[inline]
     fn adapt_from_using<M: TransformMatrix<T>>(color: S, method: M) -> D {
         let src_xyz = color.into_color_unclamped().with_white_point();
         let transform_matrix = method.generate_transform_matrix(Swp::get_xyz(), Dwp::get_xyz());
@@ -186,12 +193,15 @@ where
     Dwp: WhitePoint<T>,
 {
     /// Convert the source color to the destination color using the bradford
-    /// method by default
+    /// method by default.
+    #[must_use]
+    #[inline]
     fn adapt_into(self) -> D {
         self.adapt_into_using(Method::Bradford)
     }
     /// Convert the source color to the destination color using the specified
-    /// method
+    /// method.
+    #[must_use]
     fn adapt_into_using<M: TransformMatrix<T>>(self, method: M) -> D;
 }
 
@@ -202,6 +212,7 @@ where
     Dwp: WhitePoint<T>,
     D: AdaptFrom<S, Swp, Dwp, T>,
 {
+    #[inline]
     fn adapt_into_using<M: TransformMatrix<T>>(self, method: M) -> D {
         D::adapt_from_using(self, method)
     }

--- a/palette/src/color_difference.rs
+++ b/palette/src/color_difference.rs
@@ -3,10 +3,11 @@ use crate::from_f64;
 
 /// A trait for calculating the color difference between two colors.
 pub trait ColorDifference {
-    /// The type of the calculated color difference
+    /// The type of the calculated color difference.
     type Scalar: FloatComponent;
 
-    /// Return the difference or distance between two colors
+    /// Return the difference or distance between two colors.
+    #[must_use]
     fn get_color_difference(&self, other: &Self) -> Self::Scalar;
 }
 

--- a/palette/src/color_difference.rs
+++ b/palette/src/color_difference.rs
@@ -1,18 +1,17 @@
-use crate::component::FloatComponent;
-use crate::from_f64;
+use crate::{convert::IntoColorUnclamped, float::Float, from_f64, FromF64, Lab, Lch};
 
 /// A trait for calculating the color difference between two colors.
 pub trait ColorDifference {
     /// The type of the calculated color difference.
-    type Scalar: FloatComponent;
+    type Scalar;
 
     /// Return the difference or distance between two colors.
     #[must_use]
-    fn get_color_difference(&self, other: &Self) -> Self::Scalar;
+    fn get_color_difference(self, other: Self) -> Self::Scalar;
 }
 
 /// Container of components necessary to calculate CIEDE color difference
-pub struct LabColorDiff<T: FloatComponent> {
+pub struct LabColorDiff<T> {
     /// Lab color lightness
     pub l: T,
     /// Lab color a* value
@@ -23,12 +22,44 @@ pub struct LabColorDiff<T: FloatComponent> {
     pub chroma: T,
 }
 
+impl<Wp, T> From<Lab<Wp, T>> for LabColorDiff<T>
+where
+    T: Float,
+{
+    #[inline]
+    fn from(color: Lab<Wp, T>) -> Self {
+        // Color difference calculation requires Lab and chroma components. This
+        // function handles the conversion into those components which are then
+        // passed to `get_ciede_difference()` where calculation is completed.
+        LabColorDiff {
+            l: color.l,
+            a: color.a,
+            b: color.b,
+            chroma: (color.a * color.a + color.b * color.b).sqrt(),
+        }
+    }
+}
+
+impl<Wp, T> From<Lch<Wp, T>> for LabColorDiff<T>
+where
+    T: Clone,
+    Lch<Wp, T>: IntoColorUnclamped<Lab<Wp, T>>,
+{
+    #[inline]
+    fn from(color: Lch<Wp, T>) -> Self {
+        let chroma = color.chroma.clone();
+        let Lab { l, a, b, .. } = color.into_color_unclamped();
+
+        LabColorDiff { l, a, b, chroma }
+    }
+}
+
 /// Calculate the CIEDE2000 color difference for two colors in Lab color space.
 /// There is a "just noticeable difference" between two colors when the delta E
 /// is roughly greater than 1. Thus, the color difference is more suited for
 /// calculating small distances between colors as opposed to large differences.
 #[rustfmt::skip]
-pub fn get_ciede_difference<T: FloatComponent>(this: &LabColorDiff<T>, other: &LabColorDiff<T>) -> T {
+pub fn get_ciede_difference<T: Float + FromF64>(this: LabColorDiff<T>, other: LabColorDiff<T>) -> T {
     let c_bar = (this.chroma + other.chroma) / from_f64(2.0);
     let c_bar_pow_seven = c_bar * c_bar * c_bar * c_bar * c_bar * c_bar * c_bar;
     let twenty_five_pow_seven = from_f64(6103515625.0);

--- a/palette/src/component.rs
+++ b/palette/src/component.rs
@@ -8,6 +8,7 @@ pub trait Component: Copy + Zero + PartialOrd {
     /// The highest displayable value this component type can reach. Higher
     /// values are allowed, but they may be lowered to this before
     /// converting to another format.
+    #[must_use]
     fn max_intensity() -> Self;
 }
 
@@ -57,6 +58,7 @@ impl_uint_components!(u8, u16, u32, u64, u128);
 pub trait FromComponent<T: Component> {
     /// Converts `other` into `Self`, while performing the appropriate scaling,
     /// rounding and clamping.
+    #[must_use]
     fn from_component(other: T) -> Self;
 }
 
@@ -80,6 +82,7 @@ impl<T: Component, U: IntoComponent<T> + Component> FromComponent<U> for T {
 pub trait IntoComponent<T: Component> {
     /// Converts `self` into `T`, while performing the appropriate scaling,
     /// rounding and clamping.
+    #[must_use]
     fn into_component(self) -> T;
 }
 

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -478,7 +478,7 @@ where
     fn from_color(t: T) -> Self {
         let mut this = Self::from_color_unclamped(t);
         if !this.is_within_bounds() {
-            this.clamp_self();
+            this = this.clamp();
         }
         this
     }
@@ -563,11 +563,9 @@ mod tests {
             true
         }
 
-        fn clamp(&self) -> Self {
-            *self
+        fn clamp(self) -> Self {
+            self
         }
-
-        fn clamp_self(&mut self) {}
     }
 
     impl<S1, S2> FromColorUnclamped<WithXyz<S2>> for WithXyz<S1>
@@ -624,11 +622,9 @@ mod tests {
             true
         }
 
-        fn clamp(&self) -> Self {
-            *self
+        fn clamp(self) -> Self {
+            self
         }
-
-        fn clamp_self(&mut self) {}
     }
 
     impl<T: FloatComponent> FromColorUnclamped<WithoutXyz<T>> for WithoutXyz<T> {

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -331,6 +331,7 @@ pub trait IntoColor<T>: Sized {
     /// let rgb: Srgb = Lch::new(50.0, 100.0, -175.0).into_color();
     /// assert!(rgb.is_within_bounds());
     /// ```
+    #[must_use]
     fn into_color(self) -> T;
 }
 
@@ -349,6 +350,7 @@ pub trait IntoColorUnclamped<T>: Sized {
     ///let rgb: Srgb = Lch::new(50.0, 100.0, -175.0).into_color_unclamped();
     ///assert!(!rgb.is_within_bounds());
     ///```
+    #[must_use]
     fn into_color_unclamped(self) -> T;
 }
 
@@ -374,6 +376,7 @@ pub trait TryIntoColor<T>: Sized {
     ///     }
     /// };
     /// ```
+    #[must_use]
     fn try_into_color(self) -> Result<T, OutOfBounds<T>>;
 }
 
@@ -411,6 +414,7 @@ pub trait FromColor<T>: Sized {
     /// let rgb = Srgb::from_color(Lch::new(50.0, 100.0, -175.0));
     /// assert!(rgb.is_within_bounds());
     /// ```
+    #[must_use]
     fn from_color(t: T) -> Self;
 }
 
@@ -432,6 +436,7 @@ pub trait FromColorUnclamped<T>: Sized {
     /// let rgb = Srgb::from_color_unclamped(Lch::new(50.0, 100.0, -175.0));
     /// assert!(!rgb.is_within_bounds());
     /// ```
+    #[must_use]
     fn from_color_unclamped(val: T) -> Self;
 }
 
@@ -461,6 +466,7 @@ pub trait TryFromColor<T>: Sized {
     ///     }
     /// };
     /// ```
+    #[must_use]
     fn try_from_color(t: T) -> Result<Self, OutOfBounds<Self>>;
 }
 
@@ -662,160 +668,160 @@ mod tests {
     #[test]
     fn from_with_xyz() {
         let color: WithXyz<crate::encoding::Srgb> = WithXyz(Default::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(color);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(color);
 
         let xyz: Xyz<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(xyz);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(xyz);
 
         let yxy: Yxy<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(yxy);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(yxy);
 
         let lab: Lab<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(lab);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(lab);
 
         let lch: Lch<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(lch);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(lch);
 
         let luv: Hsl<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(luv);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(luv);
 
         let rgb: Rgb<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(rgb);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(rgb);
 
         let hsl: Hsl<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(hsl);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hsl);
 
         let hsluv: Hsluv<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(hsluv);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hsluv);
 
         let hsv: Hsv<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(hsv);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hsv);
 
         let hwb: Hwb<_, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(hwb);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hwb);
 
         let luma: Luma<crate::encoding::Srgb, f64> = Default::default();
-        WithXyz::<crate::encoding::Srgb>::from_color(luma);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(luma);
     }
 
     #[test]
     fn from_with_xyz_alpha() {
         let color: Alpha<WithXyz<crate::encoding::Srgb>, u8> =
             Alpha::from(WithXyz(Default::default()));
-        WithXyz::<crate::encoding::Srgb>::from_color(color);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(color);
 
         let xyz: Alpha<Xyz<_, f64>, u8> = Alpha::from(Xyz::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(xyz);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(xyz);
 
         let yxy: Alpha<Yxy<_, f64>, u8> = Alpha::from(Yxy::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(yxy);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(yxy);
 
         let lab: Alpha<Lab<_, f64>, u8> = Alpha::from(Lab::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(lab);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(lab);
 
         let lch: Alpha<Lch<_, f64>, u8> = Alpha::from(Lch::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(lch);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(lch);
 
         let luv: Alpha<Luv<_, f64>, u8> = Alpha::from(Luv::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(luv);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(luv);
 
         let rgb: Alpha<Rgb<_, f64>, u8> = Alpha::from(Rgb::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(rgb);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(rgb);
 
         let hsl: Alpha<Hsl<_, f64>, u8> = Alpha::from(Hsl::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(hsl);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hsl);
 
         let hsluv: Alpha<Hsluv<_, f64>, u8> = Alpha::from(Hsluv::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(hsluv);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hsluv);
 
         let hsv: Alpha<Hsv<_, f64>, u8> = Alpha::from(Hsv::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(hsv);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hsv);
 
         let hwb: Alpha<Hwb<_, f64>, u8> = Alpha::from(Hwb::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(hwb);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(hwb);
 
         let luma: Alpha<Luma<crate::encoding::Srgb, f64>, u8> =
             Alpha::from(Luma::<crate::encoding::Srgb, f64>::default());
-        WithXyz::<crate::encoding::Srgb>::from_color(luma);
+        let _ = WithXyz::<crate::encoding::Srgb>::from_color(luma);
     }
 
     #[test]
     fn from_with_xyz_into_alpha() {
         let color: WithXyz<crate::encoding::Srgb> = WithXyz(Default::default());
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(color);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(color);
 
         let xyz: Xyz<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(xyz);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(xyz);
 
         let yxy: Yxy<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(yxy);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(yxy);
 
         let lab: Lab<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lab);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lab);
 
         let lch: Lch<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lch);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lch);
 
         let luv: Hsl<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luv);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luv);
 
         let rgb: Rgb<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(rgb);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(rgb);
 
         let hsl: Hsl<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsl);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsl);
 
         let hsluv: Hsluv<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsluv);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsluv);
 
         let hsv: Hsv<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsv);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsv);
 
         let hwb: Hwb<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hwb);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hwb);
 
         let luma: Luma<crate::encoding::Srgb, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luma);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luma);
     }
 
     #[test]
     fn from_with_xyz_alpha_into_alpha() {
         let color: Alpha<WithXyz<crate::encoding::Srgb>, u8> =
             Alpha::from(WithXyz(Default::default()));
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(color);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(color);
 
         let xyz: Xyz<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(xyz);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(xyz);
 
         let yxy: Yxy<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(yxy);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(yxy);
 
         let lab: Lab<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lab);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lab);
 
         let lch: Lch<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lch);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(lch);
 
         let luv: Luv<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luv);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luv);
 
         let rgb: Rgb<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(rgb);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(rgb);
 
         let hsl: Hsl<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsl);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsl);
 
         let hsluv: Hsluv<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsluv);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsluv);
 
         let hsv: Hsv<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsv);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hsv);
 
         let hwb: Hwb<_, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hwb);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(hwb);
 
         let luma: Luma<crate::encoding::Srgb, f64> = Default::default();
-        Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luma);
+        let _ = Alpha::<WithXyz<crate::encoding::Srgb>, u8>::from_color(luma);
     }
 
     #[test]
@@ -895,40 +901,40 @@ mod tests {
     #[test]
     fn from_without_xyz() {
         let color: WithoutXyz<f64> = WithoutXyz(Default::default());
-        WithoutXyz::<f64>::from_color(color);
+        let _ = WithoutXyz::<f64>::from_color(color);
 
         let xyz: Xyz<crate::white_point::E, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(xyz);
+        let _ = WithoutXyz::<f64>::from_color(xyz);
 
         let yxy: Yxy<crate::white_point::E, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(yxy);
+        let _ = WithoutXyz::<f64>::from_color(yxy);
 
         let lab: Lab<crate::white_point::E, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(lab);
+        let _ = WithoutXyz::<f64>::from_color(lab);
 
         let lch: Lch<crate::white_point::E, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(lch);
+        let _ = WithoutXyz::<f64>::from_color(lch);
 
         let luv: Luv<crate::white_point::E, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(luv);
+        let _ = WithoutXyz::<f64>::from_color(luv);
 
         let rgb: Rgb<_, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(rgb);
+        let _ = WithoutXyz::<f64>::from_color(rgb);
 
         let hsl: Hsl<_, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(hsl);
+        let _ = WithoutXyz::<f64>::from_color(hsl);
 
         let hsluv: Hsluv<_, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(hsluv);
+        let _ = WithoutXyz::<f64>::from_color(hsluv);
 
         let hsv: Hsv<_, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(hsv);
+        let _ = WithoutXyz::<f64>::from_color(hsv);
 
         let hwb: Hwb<_, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(hwb);
+        let _ = WithoutXyz::<f64>::from_color(hwb);
 
         let luma: Luma<Linear<crate::white_point::E>, f64> = Default::default();
-        WithoutXyz::<f64>::from_color(luma);
+        let _ = WithoutXyz::<f64>::from_color(luma);
     }
 
     #[test]

--- a/palette/src/encoding.rs
+++ b/palette/src/encoding.rs
@@ -15,8 +15,10 @@ pub mod srgb;
 /// A transfer function to and from linear space.
 pub trait TransferFn: 'static {
     /// Convert the color component `x` from linear space.
+    #[must_use]
     fn from_linear<T: Float + FromF64>(x: T) -> T;
 
     /// Convert the color component `x` into linear space.
+    #[must_use]
     fn into_linear<T: Float + FromF64>(x: T) -> T;
 }

--- a/palette/src/encoding.rs
+++ b/palette/src/encoding.rs
@@ -1,8 +1,5 @@
 //! Various encoding traits, types and standards.
 
-use crate::float::Float;
-use crate::FromF64;
-
 pub use self::gamma::{F2p2, Gamma};
 pub use self::linear::Linear;
 pub use self::srgb::Srgb;
@@ -13,12 +10,12 @@ pub mod pixel;
 pub mod srgb;
 
 /// A transfer function to and from linear space.
-pub trait TransferFn: 'static {
+pub trait TransferFn<T>: 'static {
     /// Convert the color component `x` from linear space.
     #[must_use]
-    fn from_linear<T: Float + FromF64>(x: T) -> T;
+    fn from_linear(x: T) -> T;
 
     /// Convert the color component `x` into linear space.
     #[must_use]
-    fn into_linear<T: Float + FromF64>(x: T) -> T;
+    fn into_linear(x: T) -> T;
 }

--- a/palette/src/encoding/gamma.rs
+++ b/palette/src/encoding/gamma.rs
@@ -25,6 +25,7 @@ pub struct Gamma<S, N: Number = F2p2>(PhantomData<(S, N)>);
 
 impl<T, Sp, N> RgbStandard<T> for Gamma<Sp, N>
 where
+    T: Float + FromF64,
     Sp: RgbSpace<T>,
     N: Number,
 {
@@ -34,6 +35,7 @@ where
 
 impl<T, Wp, N> LumaStandard<T> for Gamma<Wp, N>
 where
+    T: Float + FromF64,
     Wp: WhitePoint<T>,
     N: Number,
 {
@@ -48,14 +50,18 @@ where
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct GammaFn<N: Number = F2p2>(PhantomData<N>);
 
-impl<N: Number> TransferFn for GammaFn<N> {
+impl<T, N> TransferFn<T> for GammaFn<N>
+where
+    T: Float + FromF64,
+    N: Number,
+{
     #[inline]
-    fn into_linear<T: Float + FromF64>(x: T) -> T {
+    fn into_linear(x: T) -> T {
         x.powf(T::one() / from_f64(N::VALUE))
     }
 
     #[inline]
-    fn from_linear<T: Float + FromF64>(x: T) -> T {
+    fn from_linear(x: T) -> T {
         x.powf(from_f64(N::VALUE))
     }
 }

--- a/palette/src/encoding/gamma.rs
+++ b/palette/src/encoding/gamma.rs
@@ -49,10 +49,12 @@ where
 pub struct GammaFn<N: Number = F2p2>(PhantomData<N>);
 
 impl<N: Number> TransferFn for GammaFn<N> {
+    #[inline]
     fn into_linear<T: Float + FromF64>(x: T) -> T {
         x.powf(T::one() / from_f64(N::VALUE))
     }
 
+    #[inline]
     fn from_linear<T: Float + FromF64>(x: T) -> T {
         x.powf(from_f64(N::VALUE))
     }

--- a/palette/src/encoding/linear.rs
+++ b/palette/src/encoding/linear.rs
@@ -3,7 +3,6 @@
 use core::marker::PhantomData;
 
 use crate::encoding::TransferFn;
-use crate::float::Float;
 use crate::luma::LumaStandard;
 use crate::rgb::{RgbSpace, RgbStandard};
 use crate::white_point::WhitePoint;
@@ -32,14 +31,14 @@ where
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LinearFn;
 
-impl TransferFn for LinearFn {
+impl<T> TransferFn<T> for LinearFn {
     #[inline(always)]
-    fn into_linear<T: Float>(x: T) -> T {
+    fn into_linear(x: T) -> T {
         x
     }
 
     #[inline(always)]
-    fn from_linear<T: Float>(x: T) -> T {
+    fn from_linear(x: T) -> T {
         x
     }
 }

--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -23,23 +23,35 @@ impl<T: FromF64> Primaries<T> for Srgb {
     }
 }
 
-impl<T: FromF64> RgbSpace<T> for Srgb {
+impl<T> RgbSpace<T> for Srgb
+where
+    T: FromF64,
+{
     type Primaries = Srgb;
     type WhitePoint = D65;
 }
 
-impl<T: FromF64> RgbStandard<T> for Srgb {
+impl<T> RgbStandard<T> for Srgb
+where
+    T: FromF64 + Float,
+{
     type Space = Srgb;
     type TransferFn = Srgb;
 }
 
-impl<T: FromF64> LumaStandard<T> for Srgb {
+impl<T> LumaStandard<T> for Srgb
+where
+    T: FromF64 + Float,
+{
     type WhitePoint = D65;
     type TransferFn = Srgb;
 }
 
-impl TransferFn for Srgb {
-    fn into_linear<T: Float + FromF64>(x: T) -> T {
+impl<T> TransferFn<T> for Srgb
+where
+    T: Float + FromF64,
+{
+    fn into_linear(x: T) -> T {
         // Recip call shows performance benefits in benchmarks for this function
         if x <= from_f64(0.04045) {
             x * from_f64::<T>(12.92).recip()
@@ -48,7 +60,7 @@ impl TransferFn for Srgb {
         }
     }
 
-    fn from_linear<T: Float + FromF64>(x: T) -> T {
+    fn from_linear(x: T) -> T {
         if x <= from_f64(0.0031308) {
             x * from_f64(12.92)
         } else {

--- a/palette/src/gradient.rs
+++ b/palette/src/gradient.rs
@@ -90,7 +90,7 @@ where
 
         let factor = (i - min) / (max - min);
 
-        min_color.mix(max_color, factor)
+        min_color.clone().mix(max_color.clone(), factor)
     }
 
     /// Create a gradient of colors with custom spacing and domain. There must

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -463,7 +463,8 @@ where
 {
     type Scalar = T;
 
-    fn saturate(&self, factor: T) -> Hsl<S, T> {
+    #[inline]
+    fn saturate(self, factor: T) -> Hsl<S, T> {
         let difference = if factor >= T::zero() {
             T::max_intensity() - self.saturation
         } else {
@@ -480,7 +481,8 @@ where
         }
     }
 
-    fn saturate_fixed(&self, amount: T) -> Hsl<S, T> {
+    #[inline]
+    fn saturate_fixed(self, amount: T) -> Hsl<S, T> {
         Hsl {
             hue: self.hue,
             saturation: (self.saturation + T::max_intensity() * amount).max(T::zero()),

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -354,20 +354,19 @@ where
     T: Component,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.saturation >= T::zero() && self.saturation <= T::max_intensity() &&
         self.lightness >= T::zero() && self.lightness <= T::max_intensity()
     }
 
-    fn clamp(&self) -> Hsl<S, T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.saturation = clamp(self.saturation, T::zero(), T::max_intensity());
-        self.lightness = clamp(self.lightness, T::zero(), T::max_intensity());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            self.hue,
+            clamp(self.saturation, T::zero(), T::max_intensity()),
+            clamp(self.lightness, T::zero(), T::max_intensity()),
+        )
     }
 }
 

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -376,7 +376,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Hsl<S, T>, factor: T) -> Hsl<S, T> {
+    #[inline]
+    fn mix(self, other: Hsl<S, T>, factor: T) -> Hsl<S, T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
 

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -590,11 +590,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -396,7 +396,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Hsl<S, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Hsl<S, T> {
         let difference = if factor >= T::zero() {
             T::max_intensity() - self.lightness
         } else {
@@ -413,7 +414,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Hsl<S, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Hsl<S, T> {
         Hsl {
             hue: self.hue,
             saturation: self.saturation,

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -444,22 +444,16 @@ impl<S, T> Hue for Hsl<S, T>
 where
     T: Zero + PartialOrd + Add<Output = T> + Clone,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Hsl<S, T> {
-        Hsl {
-            hue: hue.into(),
-            saturation: self.saturation.clone(),
-            lightness: self.lightness.clone(),
-            standard: PhantomData,
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Hsl<S, T> {
-        Hsl {
-            hue: self.hue.clone() + amount.into(),
-            saturation: self.saturation.clone(),
-            lightness: self.lightness.clone(),
-            standard: PhantomData,
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -245,7 +245,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Hsluv<Wp, T>, factor: T) -> Hsluv<Wp, T> {
+    #[inline]
+    fn mix(self, other: Hsluv<Wp, T>, factor: T) -> Hsluv<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -216,27 +216,26 @@ impl<Wp, T, A> From<Alpha<Hsluv<Wp, T>, A>> for (LuvHue<T>, T, T, A) {
 
 impl<Wp, T> Clamp for Hsluv<Wp, T>
 where
-    T: Zero + FromF64 + PartialOrd + Clone,
+    T: Zero + FromF64 + PartialOrd,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.saturation >= Self::min_saturation() && self.saturation <= Self::max_saturation() &&
         self.l >= Self::min_l() && self.l <= Self::max_l()
     }
 
-    fn clamp(&self) -> Hsluv<Wp, T> {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.saturation = clamp(
-            self.saturation.clone(),
-            Self::min_saturation(),
-            Self::max_saturation(),
-        );
-        self.l = clamp(self.l.clone(), Self::min_l(), Self::max_l());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            self.hue,
+            clamp(
+                self.saturation,
+                Self::min_saturation(),
+                Self::max_saturation(),
+            ),
+            clamp(self.l, Self::min_l(), Self::max_l()),
+        )
     }
 }
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -406,11 +406,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -265,7 +265,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Hsluv<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Hsluv<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -282,7 +283,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Hsluv<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Hsluv<Wp, T> {
         Hsluv {
             hue: self.hue,
             saturation: self.saturation,

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -332,7 +332,8 @@ where
 {
     type Scalar = T;
 
-    fn saturate(&self, factor: T) -> Hsluv<Wp, T> {
+    #[inline]
+    fn saturate(self, factor: T) -> Hsluv<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_saturation() - self.saturation
         } else {
@@ -353,7 +354,8 @@ where
         }
     }
 
-    fn saturate_fixed(&self, amount: T) -> Hsluv<Wp, T> {
+    #[inline]
+    fn saturate_fixed(self, amount: T) -> Hsluv<Wp, T> {
         Hsluv {
             hue: self.hue,
             saturation: clamp(

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -313,22 +313,16 @@ impl<Wp, T> Hue for Hsluv<Wp, T>
 where
     T: Zero + PartialOrd + Clone,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Hsluv<Wp, T> {
-        Hsluv {
-            hue: hue.into(),
-            saturation: self.saturation.clone(),
-            l: self.l.clone(),
-            white_point: PhantomData,
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Hsluv<Wp, T> {
-        Hsluv {
-            hue: self.hue.clone() + amount.into(),
-            saturation: self.saturation.clone(),
-            l: self.l.clone(),
-            white_point: PhantomData,
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -459,22 +459,16 @@ impl<S, T> Hue for Hsv<S, T>
 where
     T: Zero + PartialOrd + Clone,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Hsv<S, T> {
-        Hsv {
-            hue: hue.into(),
-            saturation: self.saturation.clone(),
-            value: self.value.clone(),
-            standard: PhantomData,
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Hsv<S, T> {
-        Hsv {
-            hue: self.hue.clone() + amount.into(),
-            saturation: self.saturation.clone(),
-            value: self.value.clone(),
-            standard: PhantomData,
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -478,7 +478,8 @@ where
 {
     type Scalar = T;
 
-    fn saturate(&self, factor: T) -> Hsv<S, T> {
+    #[inline]
+    fn saturate(self, factor: T) -> Hsv<S, T> {
         let difference = if factor >= T::zero() {
             T::max_intensity() - self.saturation
         } else {
@@ -495,7 +496,8 @@ where
         }
     }
 
-    fn saturate_fixed(&self, amount: T) -> Hsv<S, T> {
+    #[inline]
+    fn saturate_fixed(self, amount: T) -> Hsv<S, T> {
         Hsv {
             hue: self.hue,
             saturation: (self.saturation + T::max_intensity() * amount).max(T::zero()),

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -391,7 +391,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Hsv<S, T>, factor: T) -> Hsv<S, T> {
+    #[inline]
+    fn mix(self, other: Hsv<S, T>, factor: T) -> Hsv<S, T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -365,24 +365,23 @@ where
     T: Component,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.saturation >= Self::min_saturation() && self.saturation <= Self::max_saturation() &&
         self.value >= Self::min_value() && self.value <= Self::max_value()
     }
 
-    fn clamp(&self) -> Hsv<S, T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.saturation = clamp(
-            self.saturation,
-            Self::min_saturation(),
-            Self::max_saturation(),
-        );
-        self.value = clamp(self.value, Self::min_value(), Self::max_value());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            self.hue,
+            clamp(
+                self.saturation,
+                Self::min_saturation(),
+                Self::max_saturation(),
+            ),
+            clamp(self.value, Self::min_value(), Self::max_value()),
+        )
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -411,7 +411,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Hsv<S, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Hsv<S, T> {
         let difference = if factor >= T::zero() {
             Self::max_value() - self.value
         } else {
@@ -428,7 +429,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Hsv<S, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Hsv<S, T> {
         Hsv {
             hue: self.hue,
             saturation: self.saturation,

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -605,9 +605,10 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -534,11 +534,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -318,7 +318,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Hwb<S, T>, factor: T) -> Hwb<S, T> {
+    #[inline]
+    fn mix(self, other: Hwb<S, T>, factor: T) -> Hwb<S, T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
 

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -392,22 +392,16 @@ impl<S, T> Hue for Hwb<S, T>
 where
     T: Component,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Hwb<S, T> {
-        Hwb {
-            hue: hue.into(),
-            whiteness: self.whiteness,
-            blackness: self.blackness,
-            standard: PhantomData,
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Hwb<S, T> {
-        Hwb {
-            hue: self.hue + amount.into(),
-            whiteness: self.whiteness,
-            blackness: self.blackness,
-            standard: PhantomData,
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -338,7 +338,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Hwb<S, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Hwb<S, T> {
         let difference_whiteness = if factor >= T::zero() {
             T::max_intensity() - self.whiteness
         } else {
@@ -361,7 +362,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Hwb<S, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Hwb<S, T> {
         Hwb {
             hue: self.hue,
             whiteness: (self.whiteness + T::max_intensity() * amount).max(T::zero()),

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -15,8 +15,8 @@ use crate::encoding::pixel::RawPixel;
 use crate::encoding::Srgb;
 use crate::rgb::{RgbSpace, RgbStandard};
 use crate::{
-    clamp, contrast_ratio, Alpha, Clamp, Component, FloatComponent, GetHue, Hsv, Hue, Mix, Pixel,
-    RelativeContrast, RgbHue, Shade, Xyz,
+    clamp, clamp_min, contrast_ratio, Alpha, Clamp, Component, FloatComponent, GetHue, Hsv, Hue,
+    Mix, Pixel, RelativeContrast, RgbHue, Shade, Xyz,
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
@@ -290,34 +290,25 @@ where
     T: Component + DivAssign,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.blackness >= Self::min_blackness() && self.blackness <= Self::max_blackness() &&
         self.whiteness >= Self::min_whiteness() && self.whiteness <= Self::max_blackness() &&
         self.whiteness + self.blackness <= T::max_intensity()
     }
 
-    fn clamp(&self) -> Hwb<S, T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
+    #[inline]
+    fn clamp(self) -> Self {
+        let mut whiteness = clamp_min(self.whiteness, Self::min_whiteness());
+        let mut blackness = clamp_min(self.blackness, Self::min_blackness());
 
-    fn clamp_self(&mut self) {
-        self.whiteness = if self.whiteness < Self::min_whiteness() {
-            Self::min_whiteness()
-        } else {
-            self.whiteness
-        };
-        self.blackness = if self.blackness < Self::min_blackness() {
-            Self::min_blackness()
-        } else {
-            self.blackness
-        };
         let sum = self.blackness + self.whiteness;
         if sum > T::max_intensity() {
-            self.whiteness /= sum;
-            self.blackness /= sum;
+            whiteness /= sum;
+            blackness /= sum;
         }
+
+        Self::new(self.hue, whiteness, blackness)
     }
 }
 
@@ -698,35 +689,27 @@ mod test {
     #[test]
     fn clamp_invalid() {
         let expected = Hwb::new_srgb(240.0, 0.0, 0.0);
-
-        let a = Hwb::new_srgb(240.0, -3.0, -4.0);
-        let calc_a = a.clamp();
-        assert_relative_eq!(expected, calc_a);
+        let clamped = Hwb::new_srgb(240.0, -3.0, -4.0).clamp();
+        assert_relative_eq!(expected, clamped);
     }
 
     #[test]
     fn clamp_none() {
         let expected = Hwb::new_srgb(240.0, 0.3, 0.7);
-
-        let a = Hwb::new_srgb(240.0, 0.3, 0.7);
-        let calc_a = a.clamp();
-        assert_relative_eq!(expected, calc_a);
+        let clamped = Hwb::new_srgb(240.0, 0.3, 0.7).clamp();
+        assert_relative_eq!(expected, clamped);
     }
     #[test]
     fn clamp_over_one() {
         let expected = Hwb::new_srgb(240.0, 0.2, 0.8);
-
-        let a = Hwb::new_srgb(240.0, 5.0, 20.0);
-        let calc_a = a.clamp();
-        assert_relative_eq!(expected, calc_a);
+        let clamped = Hwb::new_srgb(240.0, 5.0, 20.0).clamp();
+        assert_relative_eq!(expected, clamped);
     }
     #[test]
     fn clamp_under_one() {
         let expected = Hwb::new_srgb(240.0, 0.3, 0.1);
-
-        let a = Hwb::new_srgb(240.0, 0.3, 0.1);
-        let calc_a = a.clamp();
-        assert_relative_eq!(expected, calc_a);
+        let clamped = Hwb::new_srgb(240.0, 0.3, 0.1).clamp();
+        assert_relative_eq!(expected, clamped);
     }
 
     raw_pixel_conversion_tests!(Hwb<crate::encoding::Srgb>: hue, whiteness, blackness);

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -264,15 +264,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Lab<Wp, T>, factor: T) -> Lab<Wp, T> {
+    #[inline]
+    fn mix(self, other: Lab<Wp, T>, factor: T) -> Lab<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Lab {
-            l: self.l + factor * (other.l - self.l),
-            a: self.a + factor * (other.a - self.a),
-            b: self.b + factor * (other.b - self.b),
-            white_point: PhantomData,
-        }
+        self + (other - self) * factor
     }
 }
 

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -397,11 +397,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -277,7 +277,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Lab<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Lab<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -294,7 +295,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Lab<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Lab<Wp, T> {
         Lab {
             l: (self.l + Self::max_l() * amount).max(Self::min_l()),
             a: self.a,

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -238,25 +238,23 @@ impl<Wp, T, A> From<Alpha<Lab<Wp, T>, A>> for (T, T, T, A) {
 
 impl<Wp, T> Clamp for Lab<Wp, T>
 where
-    T: Zero + FromF64 + PartialOrd + Clone,
+    T: Zero + FromF64 + PartialOrd,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.l >= Self::min_l() && self.l <= Self::max_l() &&
         self.a >= Self::min_a() && self.a <= Self::max_a() &&
         self.b >= Self::min_b() && self.b <= Self::max_b()
     }
 
-    fn clamp(&self) -> Lab<Wp, T> {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.l = clamp(self.l.clone(), Self::min_l(), Self::max_l());
-        self.a = clamp(self.a.clone(), Self::min_a(), Self::max_a());
-        self.b = clamp(self.b.clone(), Self::min_b(), Self::max_b());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.l, Self::min_l(), Self::max_l()),
+            clamp(self.a, Self::min_a(), Self::max_a()),
+            clamp(self.b, Self::min_b(), Self::max_b()),
+        )
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -336,7 +336,8 @@ where
 {
     type Scalar = T;
 
-    fn saturate(&self, factor: T) -> Lch<Wp, T> {
+    #[inline]
+    fn saturate(self, factor: T) -> Lch<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_chroma() - self.chroma
         } else {
@@ -353,7 +354,8 @@ where
         }
     }
 
-    fn saturate_fixed(&self, amount: T) -> Lch<Wp, T> {
+    #[inline]
+    fn saturate_fixed(self, amount: T) -> Lch<Wp, T> {
         Lch {
             l: self.l,
             chroma: (self.chroma + Self::max_chroma() * amount).max(Self::min_chroma()),

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -236,7 +236,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Lch<Wp, T>, factor: T) -> Lch<Wp, T> {
+    #[inline]
+    fn mix(self, other: Lch<Wp, T>, factor: T) -> Lch<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
         Lch {

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -255,7 +255,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Lch<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Lch<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -272,7 +273,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Lch<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Lch<Wp, T> {
         Lch {
             l: (self.l + Self::max_l() * amount).max(Self::min_l()),
             chroma: self.chroma,

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -303,22 +303,16 @@ impl<Wp, T> Hue for Lch<Wp, T>
 where
     T: Float + FromF64 + PartialOrd,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Lch<Wp, T> {
-        Lch {
-            l: self.l,
-            chroma: self.chroma,
-            hue: hue.into(),
-            white_point: PhantomData,
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Lch<Wp, T> {
-        Lch {
-            l: self.l,
-            chroma: self.chroma,
-            hue: self.hue + amount.into(),
-            white_point: PhantomData,
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -402,9 +402,10 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -334,7 +334,8 @@ where
 {
     type Scalar = T;
 
-    fn saturate(&self, factor: T) -> Lchuv<Wp, T> {
+    #[inline]
+    fn saturate(self, factor: T) -> Lchuv<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_chroma() - self.chroma
         } else {
@@ -351,7 +352,8 @@ where
         }
     }
 
-    fn saturate_fixed(&self, amount: T) -> Lchuv<Wp, T> {
+    #[inline]
+    fn saturate_fixed(self, amount: T) -> Lchuv<Wp, T> {
         Lchuv {
             l: self.l,
             chroma: (self.chroma + Self::max_chroma() * amount).max(T::zero()),

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -315,22 +315,16 @@ impl<Wp, T> Hue for Lchuv<Wp, T>
 where
     T: Zero + PartialOrd + Clone,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Lchuv<Wp, T> {
-        Lchuv {
-            l: self.l.clone(),
-            chroma: self.chroma.clone(),
-            hue: hue.into(),
-            white_point: PhantomData,
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Lchuv<Wp, T> {
-        Lchuv {
-            l: self.l.clone(),
-            chroma: self.chroma.clone(),
-            hue: self.hue.clone() + amount.into(),
-            white_point: PhantomData,
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -248,7 +248,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Lchuv<Wp, T>, factor: T) -> Lchuv<Wp, T> {
+    #[inline]
+    fn mix(self, other: Lchuv<Wp, T>, factor: T) -> Lchuv<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
         Lchuv {

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -267,7 +267,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Lchuv<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Lchuv<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -284,7 +285,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Lchuv<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Lchuv<Wp, T> {
         Lchuv {
             l: (self.l + Self::max_l() * amount).max(Self::min_l()),
             chroma: self.chroma,

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -222,8 +222,9 @@ impl<Wp, T, A> From<Alpha<Lchuv<Wp, T>, A>> for (T, T, LuvHue<T>, A) {
 
 impl<Wp, T> Clamp for Lchuv<Wp, T>
 where
-    T: Zero + FromF64 + PartialOrd + Clone,
+    T: Zero + FromF64 + PartialOrd,
 {
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.l >= Self::min_l()
             && self.l <= Self::max_l()
@@ -231,15 +232,13 @@ where
             && self.chroma <= Self::max_chroma()
     }
 
-    fn clamp(&self) -> Lchuv<Wp, T> {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.l = clamp(self.l.clone(), Self::min_l(), Self::max_l());
-        self.chroma = clamp(self.chroma.clone(), Self::min_chroma(), Self::max_chroma());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.l, Self::min_l(), Self::max_l()),
+            clamp(self.chroma, Self::min_chroma(), Self::max_chroma()),
+            self.hue,
+        )
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -400,9 +400,10 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -499,9 +499,9 @@ pub trait Clamp {
 /// let a = LinSrgb::new(0.0, 0.5, 1.0);
 /// let b = LinSrgb::new(1.0, 0.5, 0.0);
 ///
-/// assert_relative_eq!(a.mix(&b, 0.0), a);
-/// assert_relative_eq!(a.mix(&b, 0.5), LinSrgb::new(0.5, 0.5, 0.5));
-/// assert_relative_eq!(a.mix(&b, 1.0), b);
+/// assert_relative_eq!(a.mix(b, 0.0), a);
+/// assert_relative_eq!(a.mix(b, 0.5), LinSrgb::new(0.5, 0.5, 0.5));
+/// assert_relative_eq!(a.mix(b, 1.0), b);
 /// ```
 pub trait Mix {
     /// The type of the mixing factor.
@@ -513,7 +513,7 @@ pub trait Mix {
     /// the same color as `self` and `1.0` will result in the same color as
     /// `other`.
     #[must_use]
-    fn mix(&self, other: &Self, factor: Self::Scalar) -> Self;
+    fn mix(self, other: Self, factor: Self::Scalar) -> Self;
 }
 
 /// The `Shade` trait allows a color to be lightened or darkened.

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -693,7 +693,7 @@ pub trait Saturate: Sized {
     /// assert_relative_eq!(color.saturate(0.5).saturation, 0.75);
     /// ```
     #[must_use]
-    fn saturate(&self, factor: Self::Scalar) -> Self;
+    fn saturate(self, factor: Self::Scalar) -> Self;
 
     /// Increase the saturation by `amount`, a value ranging from `0.0` to
     /// `1.0`.
@@ -706,7 +706,7 @@ pub trait Saturate: Sized {
     /// assert_relative_eq!(color.saturate_fixed(0.2).saturation, 0.6);
     /// ```
     #[must_use]
-    fn saturate_fixed(&self, amount: Self::Scalar) -> Self;
+    fn saturate_fixed(self, amount: Self::Scalar) -> Self;
 
     /// Scale the color towards the minimum saturation by `factor`, a value
     /// ranging from `0.0` to `1.0`.
@@ -720,7 +720,7 @@ pub trait Saturate: Sized {
     /// ```
     #[must_use]
     #[inline]
-    fn desaturate(&self, factor: Self::Scalar) -> Self {
+    fn desaturate(self, factor: Self::Scalar) -> Self {
         self.saturate(-factor)
     }
 
@@ -736,7 +736,7 @@ pub trait Saturate: Sized {
     /// ```
     #[must_use]
     #[inline]
-    fn desaturate_fixed(&self, amount: Self::Scalar) -> Self {
+    fn desaturate_fixed(self, amount: Self::Scalar) -> Self {
         self.saturate_fixed(-amount)
     }
 }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -553,7 +553,7 @@ pub trait Shade: Sized {
     /// assert_relative_eq!(color.lighten(0.5).lightness, 0.75);
     /// ```
     #[must_use]
-    fn lighten(&self, factor: Self::Scalar) -> Self;
+    fn lighten(self, factor: Self::Scalar) -> Self;
 
     /// Lighten the color by `amount`, a value ranging from `0.0` to `1.0`.
     ///
@@ -565,7 +565,7 @@ pub trait Shade: Sized {
     /// assert_relative_eq!(color.lighten_fixed(0.2).lightness, 0.6);
     /// ```
     #[must_use]
-    fn lighten_fixed(&self, amount: Self::Scalar) -> Self;
+    fn lighten_fixed(self, amount: Self::Scalar) -> Self;
 
     /// Scale the color towards the minimum lightness by `factor`, a value
     /// ranging from `0.0` to `1.0`.
@@ -579,7 +579,7 @@ pub trait Shade: Sized {
     /// ```
     #[must_use]
     #[inline]
-    fn darken(&self, factor: Self::Scalar) -> Self {
+    fn darken(self, factor: Self::Scalar) -> Self {
         self.lighten(-factor)
     }
 
@@ -594,7 +594,7 @@ pub trait Shade: Sized {
     /// ```
     #[must_use]
     #[inline]
-    fn darken_fixed(&self, amount: Self::Scalar) -> Self {
+    fn darken_fixed(self, amount: Self::Scalar) -> Self {
         self.lighten_fixed(-amount)
     }
 }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -636,11 +636,11 @@ pub trait GetHue {
 pub trait Hue: GetHue {
     /// Return a new copy of `self`, but with a specific hue.
     #[must_use]
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Self;
+    fn with_hue<H: Into<Self::Hue>>(self, hue: H) -> Self;
 
     /// Return a new copy of `self`, but with the hue shifted by `amount`.
     #[must_use]
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Self;
+    fn shift_hue<H: Into<Self::Hue>>(self, amount: H) -> Self;
 }
 
 /// A trait for colors where the saturation (or chroma) can be manipulated

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -298,13 +298,15 @@ macro_rules! assert_ranges {
                 )*
 
                 for assert_ranges!(@make_tuple (), $($clamped,)+ $($clamped_min,)* $($unclamped,)* ) in repeat(()) $(.zip($clamped))+ $(.zip($clamped_min))* $(.zip($unclamped))* {
-                    let c: $ty<$($ty_params),+> = $ty {
+                    let color: $ty<$($ty_params),+> = $ty {
                         $($clamped: $clamped.into(),)+
                         $($clamped_min: $clamped_min.into(),)*
                         $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
-                    let clamped = c.clamp();
+
+                    let clamped = color.clamp();
+
                     let expected: $ty<$($ty_params),+> = $ty {
                         $($clamped: $clamped_from.into(),)+
                         $($clamped_min: $clamped_min_from.into(),)*
@@ -312,7 +314,7 @@ macro_rules! assert_ranges {
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
 
-                    assert!(!c.is_within_bounds());
+                    assert!(!color.is_within_bounds());
                     assert_relative_eq!(clamped, expected);
                 }
 
@@ -343,16 +345,17 @@ macro_rules! assert_ranges {
                 )*
 
                 for assert_ranges!(@make_tuple (), $($clamped,)+ $($clamped_min,)* $($unclamped,)* ) in repeat(()) $(.zip($clamped))+ $(.zip($clamped_min))* $(.zip($unclamped))* {
-                    let c: $ty<$($ty_params),+> = $ty {
+                    let color: $ty<$($ty_params),+> = $ty {
                         $($clamped: $clamped.into(),)+
                         $($clamped_min: $clamped_min.into(),)*
                         $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
-                    let clamped = c.clamp();
 
-                    assert!(c.is_within_bounds());
-                    assert_relative_eq!(clamped, c);
+                    let clamped = color.clamp();
+
+                    assert!(color.is_within_bounds());
+                    assert_relative_eq!(clamped, color);
                 }
 
                 println!("ok")
@@ -382,13 +385,15 @@ macro_rules! assert_ranges {
                 )*
 
                 for assert_ranges!(@make_tuple (), $($clamped,)+ $($clamped_min,)* $($unclamped,)* ) in repeat(()) $(.zip($clamped))+ $(.zip($clamped_min))* $(.zip($unclamped))* {
-                    let c: $ty<$($ty_params),+> = $ty {
+                    let color: $ty<$($ty_params),+> = $ty {
                         $($clamped: $clamped.into(),)+
                         $($clamped_min: $clamped_min.into(),)*
                         $($unclamped: $unclamped.into(),)*
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
-                    let clamped = c.clamp();
+
+                    let clamped = color.clamp();
+
                     let expected: $ty<$($ty_params),+> = $ty {
                         $($clamped: $clamped_to.into(),)+
                         $($clamped_min: $clamped_min.into(),)*
@@ -396,7 +401,7 @@ macro_rules! assert_ranges {
                         ..$ty::default() //This prevents exhaustiveness checking
                     };
 
-                    assert!(!c.is_within_bounds());
+                    assert!(!color.is_within_bounds());
                     assert_relative_eq!(clamped, expected);
                 }
 
@@ -452,13 +457,23 @@ pub mod float;
 #[doc(hidden)]
 pub mod matrix;
 
-fn clamp<T: PartialOrd>(v: T, min: T, max: T) -> T {
-    if v < min {
+#[inline]
+fn clamp<T: PartialOrd>(value: T, min: T, max: T) -> T {
+    if value < min {
         min
-    } else if v > max {
+    } else if value > max {
         max
     } else {
-        v
+        value
+    }
+}
+
+#[inline]
+fn clamp_min<T: PartialOrd>(value: T, min: T) -> T {
+    if value < min {
+        min
+    } else {
+        value
     }
 }
 
@@ -472,10 +487,7 @@ pub trait Clamp {
     /// Return a new color where the components have been clamped to the nearest
     /// valid values.
     #[must_use]
-    fn clamp(&self) -> Self;
-
-    /// Clamp the color's components to the nearest valid values.
-    fn clamp_self(&mut self);
+    fn clamp(self) -> Self;
 }
 
 /// A trait for linear color interpolation.

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -466,10 +466,12 @@ fn clamp<T: PartialOrd>(v: T, min: T, max: T) -> T {
 pub trait Clamp {
     /// Check if the color's components are within the expected clamped range
     /// bounds.
+    #[must_use]
     fn is_within_bounds(&self) -> bool;
 
     /// Return a new color where the components have been clamped to the nearest
     /// valid values.
+    #[must_use]
     fn clamp(&self) -> Self;
 
     /// Clamp the color's components to the nearest valid values.
@@ -498,6 +500,7 @@ pub trait Mix {
     /// `factor` should be between `0.0` and `1.0`, where `0.0` will result in
     /// the same color as `self` and `1.0` will result in the same color as
     /// `other`.
+    #[must_use]
     fn mix(&self, other: &Self, factor: Self::Scalar) -> Self;
 }
 
@@ -537,6 +540,7 @@ pub trait Shade: Sized {
     /// let color = Hsl::new_srgb(0.0, 1.0, 0.5);
     /// assert_relative_eq!(color.lighten(0.5).lightness, 0.75);
     /// ```
+    #[must_use]
     fn lighten(&self, factor: Self::Scalar) -> Self;
 
     /// Lighten the color by `amount`, a value ranging from `0.0` to `1.0`.
@@ -548,6 +552,7 @@ pub trait Shade: Sized {
     /// let color = Hsl::new_srgb(0.0, 1.0, 0.4);
     /// assert_relative_eq!(color.lighten_fixed(0.2).lightness, 0.6);
     /// ```
+    #[must_use]
     fn lighten_fixed(&self, amount: Self::Scalar) -> Self;
 
     /// Scale the color towards the minimum lightness by `factor`, a value
@@ -560,6 +565,8 @@ pub trait Shade: Sized {
     /// let color = Hsv::new_srgb(0.0, 1.0, 0.5);
     /// assert_relative_eq!(color.darken(0.5).value, 0.25);
     /// ```
+    #[must_use]
+    #[inline]
     fn darken(&self, factor: Self::Scalar) -> Self {
         self.lighten(-factor)
     }
@@ -573,6 +580,8 @@ pub trait Shade: Sized {
     /// let color = Hsv::new_srgb(0.0, 1.0, 0.4);
     /// assert_relative_eq!(color.darken_fixed(0.2).value, 0.2);
     /// ```
+    #[must_use]
+    #[inline]
     fn darken_fixed(&self, amount: Self::Scalar) -> Self {
         self.lighten_fixed(-amount)
     }
@@ -607,15 +616,18 @@ pub trait GetHue {
     ///
     /// Colors in the gray scale has no well defined hue and should preferably
     /// return `None`.
+    #[must_use]
     fn get_hue(&self) -> Option<Self::Hue>;
 }
 
 /// A trait for colors where the hue can be manipulated without conversion.
 pub trait Hue: GetHue {
     /// Return a new copy of `self`, but with a specific hue.
+    #[must_use]
     fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Self;
 
     /// Return a new copy of `self`, but with the hue shifted by `amount`.
+    #[must_use]
     fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Self;
 }
 
@@ -668,6 +680,7 @@ pub trait Saturate: Sized {
     /// let color = Hsl::new_srgb(0.0, 0.5, 0.5);
     /// assert_relative_eq!(color.saturate(0.5).saturation, 0.75);
     /// ```
+    #[must_use]
     fn saturate(&self, factor: Self::Scalar) -> Self;
 
     /// Increase the saturation by `amount`, a value ranging from `0.0` to
@@ -680,6 +693,7 @@ pub trait Saturate: Sized {
     /// let color = Hsl::new_srgb(0.0, 0.4, 0.5);
     /// assert_relative_eq!(color.saturate_fixed(0.2).saturation, 0.6);
     /// ```
+    #[must_use]
     fn saturate_fixed(&self, amount: Self::Scalar) -> Self;
 
     /// Scale the color towards the minimum saturation by `factor`, a value
@@ -692,6 +706,8 @@ pub trait Saturate: Sized {
     /// let color = Hsv::new_srgb(0.0, 0.5, 0.5);
     /// assert_relative_eq!(color.desaturate(0.5).saturation, 0.25);
     /// ```
+    #[must_use]
+    #[inline]
     fn desaturate(&self, factor: Self::Scalar) -> Self {
         self.saturate(-factor)
     }
@@ -706,6 +722,8 @@ pub trait Saturate: Sized {
     /// let color = Hsv::new_srgb(0.0, 0.4, 0.5);
     /// assert_relative_eq!(color.desaturate_fixed(0.2).saturation, 0.2);
     /// ```
+    #[must_use]
+    #[inline]
     fn desaturate_fixed(&self, amount: Self::Scalar) -> Self {
         self.saturate_fixed(-amount)
     }
@@ -717,6 +735,7 @@ pub trait ComponentWise {
     type Scalar;
 
     /// Perform a binary operation on this and an other color.
+    #[must_use]
     fn component_wise<F: FnMut(Self::Scalar, Self::Scalar) -> Self::Scalar>(
         &self,
         other: &Self,
@@ -724,12 +743,14 @@ pub trait ComponentWise {
     ) -> Self;
 
     /// Perform a unary operation on this color.
+    #[must_use]
     fn component_wise_self<F: FnMut(Self::Scalar) -> Self::Scalar>(&self, f: F) -> Self;
 }
 
 /// A trait for infallible conversion from `f64`. The conversion may be lossy.
 pub trait FromF64 {
     /// Creates a value from an `f64` constant.
+    #[must_use]
     fn from_f64(c: f64) -> Self;
 }
 

--- a/palette/src/luma.rs
+++ b/palette/src/luma.rs
@@ -30,13 +30,13 @@ pub trait LumaStandard<T>: 'static {
     type WhitePoint: WhitePoint<T>;
 
     /// The transfer function for the luminance component.
-    type TransferFn: TransferFn;
+    type TransferFn: TransferFn<T>;
 }
 
 impl<T, Wp, Tf> LumaStandard<T> for (Wp, Tf)
 where
     Wp: WhitePoint<T>,
-    Tf: TransferFn,
+    Tf: TransferFn<T>,
 {
     type WhitePoint = Wp;
     type TransferFn = Tf;

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -352,13 +352,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Luma<S, T>, factor: T) -> Luma<S, T> {
+    #[inline]
+    fn mix(self, other: Luma<S, T>, factor: T) -> Luma<S, T> {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Luma {
-            luma: self.luma + factor * (other.luma - self.luma),
-            standard: PhantomData,
-        }
+        self + (other - self) * factor
     }
 }
 

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -334,18 +334,14 @@ impl<S, T> Clamp for Luma<S, T>
 where
     T: Component,
 {
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.luma >= Self::min_luma() && self.luma <= Self::max_luma()
     }
 
-    fn clamp(&self) -> Luma<S, T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.luma = clamp(self.luma, Self::min_luma(), Self::max_luma());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(clamp(self.luma, Self::min_luma(), Self::max_luma()))
     }
 }
 

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -366,7 +366,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Luma<S, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Luma<S, T> {
         let difference = if factor >= T::zero() {
             T::max_intensity() - self.luma
         } else {
@@ -381,7 +382,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Luma<S, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Luma<S, T> {
         Luma {
             luma: (self.luma + T::max_intensity() * amount).max(T::zero()),
             standard: PhantomData,

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -755,7 +755,8 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         let luma1 = self.into_linear();
         let luma2 = other.into_linear();
 

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -266,15 +266,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Luv<Wp, T>, factor: T) -> Luv<Wp, T> {
+    #[inline]
+    fn mix(self, other: Luv<Wp, T>, factor: T) -> Luv<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Luv {
-            l: self.l + factor * (other.l - self.l),
-            u: self.u + factor * (other.u - self.u),
-            v: self.v + factor * (other.v - self.v),
-            white_point: PhantomData,
-        }
+        self + (other - self) * factor
     }
 }
 

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -279,7 +279,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Luv<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Luv<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -296,7 +297,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Luv<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Luv<Wp, T> {
         Luv {
             l: (self.l + Self::max_l() * amount).max(Self::min_l()),
             u: self.u,

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -387,11 +387,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -240,25 +240,23 @@ impl<Wp, T, A> From<Alpha<Luv<Wp, T>, A>> for (T, T, T, A) {
 
 impl<Wp, T> Clamp for Luv<Wp, T>
 where
-    T: Zero + FromF64 + PartialOrd + Clone,
+    T: Zero + FromF64 + PartialOrd,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
-	self.l >= Self::min_l() && self.l <= Self::max_l() &&
-	self.u >= Self::min_u() && self.u <= Self::max_u() &&
-	self.v >= Self::min_v() && self.v <= Self::max_v()
+        self.l >= Self::min_l() && self.l <= Self::max_l() &&
+        self.u >= Self::min_u() && self.u <= Self::max_u() &&
+        self.v >= Self::min_v() && self.v <= Self::max_v()
     }
 
-    fn clamp(&self) -> Luv<Wp, T> {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.l = clamp(self.l.clone(), Self::min_l(), Self::max_l());
-        self.u = clamp(self.u.clone(), Self::min_u(), Self::max_u());
-        self.v = clamp(self.v.clone(), Self::min_v(), Self::max_v());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.l, Self::min_l(), Self::max_l()),
+            clamp(self.u, Self::min_u(), Self::max_u()),
+            clamp(self.v, Self::min_v(), Self::max_v()),
+        )
     }
 }
 

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -289,25 +289,23 @@ impl<T, A: Component> From<Alpha<Oklab<T>, A>> for (T, T, T, A) {
 
 impl<T> Clamp for Oklab<T>
 where
-    T: FromF64 + PartialOrd + Clone,
+    T: FromF64 + PartialOrd,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.l >= Self::min_l() && self.l <= Self::max_l() &&
         self.a >= Self::min_a() && self.a <= Self::max_a() &&
         self.b >= Self::min_b() && self.b <= Self::max_b()
     }
 
-    fn clamp(&self) -> Self {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.l = clamp(self.l.clone(), Self::min_l(), Self::max_l());
-        self.a = clamp(self.a.clone(), Self::min_a(), Self::max_a());
-        self.b = clamp(self.b.clone(), Self::min_b(), Self::max_b());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.l, Self::min_l(), Self::max_l()),
+            clamp(self.a, Self::min_a(), Self::max_a()),
+            clamp(self.b, Self::min_b(), Self::max_b()),
+        )
     }
 }
 

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -315,14 +315,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Self, factor: T) -> Self {
+    #[inline]
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Self::new(
-            self.l + factor * (other.l - self.l),
-            self.a + factor * (other.a - self.a),
-            self.b + factor * (other.b - self.b),
-        )
+        self + (other - self) * factor
     }
 }
 

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -415,11 +415,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -328,7 +328,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Self {
+    #[inline]
+    fn lighten(self, factor: T) -> Self {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -340,7 +341,8 @@ where
         Self::new((self.l + delta).max(Self::min_l()), self.a, self.b)
     }
 
-    fn lighten_fixed(&self, amount: T) -> Self {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Self {
         Self::new((self.l + amount).max(Self::min_l()), self.a, self.b)
     }
 }

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -268,8 +268,9 @@ impl<T, A> From<Alpha<Oklch<T>, A>> for (T, T, OklabHue<T>, A) {
 
 impl<T> Clamp for Oklch<T>
 where
-    T: Zero + FromF64 + PartialOrd + Clone,
+    T: Zero + FromF64 + PartialOrd,
 {
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.l >= Self::min_l()
             && self.l <= Self::max_l()
@@ -277,15 +278,13 @@ where
             && self.chroma <= Self::max_chroma()
     }
 
-    fn clamp(&self) -> Oklch<T> {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.l = clamp(self.l.clone(), Self::min_l(), Self::max_l());
-        self.chroma = clamp(self.chroma.clone(), Self::min_chroma(), Self::max_chroma());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.l, Self::min_l(), Self::max_l()),
+            clamp(self.chroma, Self::min_chroma(), Self::max_chroma()),
+            self.hue,
+        )
     }
 }
 

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -377,7 +377,8 @@ where
 {
     type Scalar = T;
 
-    fn saturate(&self, factor: T) -> Oklch<T> {
+    #[inline]
+    fn saturate(self, factor: T) -> Oklch<T> {
         let difference = if factor >= T::zero() {
             Self::max_chroma() - self.chroma
         } else {
@@ -393,7 +394,8 @@ where
         }
     }
 
-    fn saturate_fixed(&self, amount: T) -> Oklch<T> {
+    #[inline]
+    fn saturate_fixed(self, amount: T) -> Oklch<T> {
         Oklch {
             l: self.l,
             chroma: (self.chroma + Self::max_chroma() * amount).max(Self::min_chroma()),

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -312,7 +312,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Oklch<T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Oklch<T> {
         let difference = if factor >= T::zero() {
             Self::max_l() - self.l
         } else {
@@ -328,7 +329,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Oklch<T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Oklch<T> {
         Oklch {
             l: (self.l + Self::max_l() * amount).max(Self::min_l()),
             chroma: self.chroma,

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -294,7 +294,8 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Oklch<T>, factor: T) -> Oklch<T> {
+    #[inline]
+    fn mix(self, other: Oklch<T>, factor: T) -> Oklch<T> {
         let factor = clamp(factor, T::zero(), T::one());
         let hue_diff: T = (other.hue - self.hue).to_degrees();
         Oklch {

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -358,20 +358,16 @@ impl<T> Hue for Oklch<T>
 where
     T: Zero + PartialOrd + Clone,
 {
-    fn with_hue<H: Into<Self::Hue>>(&self, hue: H) -> Oklch<T> {
-        Oklch {
-            l: self.l.clone(),
-            chroma: self.chroma.clone(),
-            hue: hue.into(),
-        }
+    #[inline]
+    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+        self.hue = hue.into();
+        self
     }
 
-    fn shift_hue<H: Into<Self::Hue>>(&self, amount: H) -> Oklch<T> {
-        Oklch {
-            l: self.l.clone(),
-            chroma: self.chroma.clone(),
-            hue: self.hue.clone() + amount.into(),
-        }
+    #[inline]
+    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
+        self.hue = self.hue + amount.into();
+        self
     }
 }
 

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -440,9 +440,10 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/relative_contrast.rs
+++ b/palette/src/relative_contrast.rs
@@ -56,35 +56,47 @@ pub trait RelativeContrast {
     type Scalar: FromF64 + PartialOrd;
 
     /// Calculate the contrast ratio between two colors.
+    #[must_use]
     fn get_contrast_ratio(&self, other: &Self) -> Self::Scalar;
     /// Verify the contrast between two colors satisfies SC 1.4.3. Contrast
     /// is at least 4.5:1 (Level AA).
+    #[must_use]
+    #[inline]
     fn has_min_contrast_text(&self, other: &Self) -> bool {
         self.get_contrast_ratio(other) >= from_f64(4.5)
     }
     /// Verify the contrast between two colors satisfies SC 1.4.3 for large
     /// text. Contrast is at least 3:1 (Level AA).
+    #[must_use]
+    #[inline]
     fn has_min_contrast_large_text(&self, other: &Self) -> bool {
         self.get_contrast_ratio(other) >= from_f64(3.0)
     }
     /// Verify the contrast between two colors satisfies SC 1.4.6. Contrast
     /// is at least 7:1 (Level AAA).
+    #[must_use]
+    #[inline]
     fn has_enhanced_contrast_text(&self, other: &Self) -> bool {
         self.get_contrast_ratio(other) >= from_f64(7.0)
     }
     /// Verify the contrast between two colors satisfies SC 1.4.6 for large
     /// text. Contrast is at least 4.5:1 (Level AAA).
+    #[must_use]
+    #[inline]
     fn has_enhanced_contrast_large_text(&self, other: &Self) -> bool {
         self.has_min_contrast_text(other)
     }
     /// Verify the contrast between two colors satisfies SC 1.4.11 for graphical
     /// objects. Contrast is at least 3:1 (Level AA).
+    #[must_use]
+    #[inline]
     fn has_min_contrast_graphics(&self, other: &Self) -> bool {
         self.has_min_contrast_large_text(other)
     }
 }
 
 /// Calculate the ratio between two `luma` values.
+#[inline]
 pub fn contrast_ratio<T>(luma1: T, luma2: T) -> T
 where
     T: Component + FromF64 + Add<Output = T> + Div<Output = T>,

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -93,13 +93,13 @@ pub trait RgbStandard<T>: 'static {
     type Space: RgbSpace<T>;
 
     /// The transfer function for the color components.
-    type TransferFn: TransferFn;
+    type TransferFn: TransferFn<T>;
 }
 
 impl<T, Sp, Tf> RgbStandard<T> for (Sp, Tf)
 where
     Sp: RgbSpace<T>,
-    Tf: TransferFn,
+    Tf: TransferFn<T>,
 {
     type Space = Sp;
     type TransferFn = Tf;
@@ -109,7 +109,7 @@ impl<T, Pr, Wp, Tf> RgbStandard<T> for (Pr, Wp, Tf)
 where
     Pr: Primaries<T>,
     Wp: WhitePoint<T>,
-    Tf: TransferFn,
+    Tf: TransferFn<T>,
 {
     type Space = (Pr, Wp);
     type TransferFn = Tf;

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -148,6 +148,7 @@ where
     T: FloatComponent,
     U: Component + FromComponent<T>,
 {
+    #[inline]
     fn from(lin_srgb: LinSrgb<T>) -> Self {
         let non_lin = Srgb::<T>::from_linear(lin_srgb);
         non_lin.into_format()
@@ -159,6 +160,7 @@ where
     T: FloatComponent,
     U: Component + FromComponent<T>,
 {
+    #[inline]
     fn from(srgb: Srgb<T>) -> Self {
         srgb.into_linear().into_format()
     }
@@ -169,6 +171,7 @@ where
     T: FloatComponent,
     U: Component + FromComponent<T>,
 {
+    #[inline]
     fn from(lin_srgb: LinSrgb<T>) -> Self {
         let non_lin = Srgb::<T>::from_linear(lin_srgb);
         let new_fmt = Srgb::<U>::from_format(non_lin);
@@ -181,6 +184,7 @@ where
     T: FloatComponent,
     U: Component + FromComponent<T>,
 {
+    #[inline]
     fn from(lin_srgba: LinSrgba<T>) -> Self {
         let non_lin = Srgba::<T>::from_linear(lin_srgba);
         non_lin.into_format()
@@ -192,6 +196,7 @@ where
     T: FloatComponent,
     U: Component + FromComponent<T>,
 {
+    #[inline]
     fn from(srgb: Srgb<T>) -> Self {
         srgb.into_linear().into_format().into()
     }
@@ -202,6 +207,7 @@ where
     T: FloatComponent,
     U: Component + FromComponent<T>,
 {
+    #[inline]
     fn from(srgba: Srgba<T>) -> Self {
         srgba.into_linear().into_format()
     }

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -558,7 +558,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Rgb<S, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Rgb<S, T> {
         let difference_red = if factor >= T::zero() {
             T::max_intensity() - self.red
         } else {
@@ -588,7 +589,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Rgb<S, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Rgb<S, T> {
         Rgb {
             red: (self.red + T::max_intensity() * amount).max(T::zero()),
             green: (self.green + T::max_intensity() * amount).max(T::zero()),

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1139,11 +1139,12 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         use crate::FromColor;
 
-        let xyz1 = Xyz::from_color(*self);
-        let xyz2 = Xyz::from_color(*other);
+        let xyz1 = Xyz::from_color(self);
+        let xyz2 = Xyz::from_color(other);
 
         contrast_ratio(xyz1.y, xyz2.y)
     }

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -520,22 +520,20 @@ where
     T: Component,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.red >= T::zero() && self.red <= T::max_intensity() &&
         self.green >= T::zero() && self.green <= T::max_intensity() &&
         self.blue >= T::zero() && self.blue <= T::max_intensity()
     }
 
-    fn clamp(&self) -> Rgb<S, T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.red = clamp(self.red, T::zero(), T::max_intensity());
-        self.green = clamp(self.green, T::zero(), T::max_intensity());
-        self.blue = clamp(self.blue, T::zero(), T::max_intensity());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.red, T::zero(), T::max_intensity()),
+            clamp(self.green, T::zero(), T::max_intensity()),
+            clamp(self.blue, T::zero(), T::max_intensity()),
+        )
     }
 }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -544,15 +544,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Rgb<S, T>, factor: T) -> Rgb<S, T> {
+    #[inline]
+    fn mix(self, other: Rgb<S, T>, factor: T) -> Rgb<S, T> {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Rgb {
-            red: self.red + factor * (other.red - self.red),
-            green: self.green + factor * (other.green - self.green),
-            blue: self.blue + factor * (other.blue - self.blue),
-            standard: PhantomData,
-        }
+        self + (other - self) * factor
     }
 }
 

--- a/palette/src/white_point.rs
+++ b/palette/src/white_point.rs
@@ -40,6 +40,7 @@ pub trait WhitePoint<T>: 'static {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct A;
 impl<T: FromF64> WhitePoint<T> for A {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(1.09850), from_f64(1.0), from_f64(0.35585))
     }
@@ -51,6 +52,7 @@ impl<T: FromF64> WhitePoint<T> for A {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct B;
 impl<T: FromF64> WhitePoint<T> for B {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.99072), from_f64(1.0), from_f64(0.85223))
     }
@@ -62,6 +64,7 @@ impl<T: FromF64> WhitePoint<T> for B {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct C;
 impl<T: FromF64> WhitePoint<T> for C {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.98074), from_f64(1.0), from_f64(1.18232))
     }
@@ -73,6 +76,7 @@ impl<T: FromF64> WhitePoint<T> for C {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50;
 impl<T: FromF64> WhitePoint<T> for D50 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.96422), from_f64(1.0), from_f64(0.82521))
     }
@@ -84,6 +88,7 @@ impl<T: FromF64> WhitePoint<T> for D50 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55;
 impl<T: FromF64> WhitePoint<T> for D55 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.95682), from_f64(1.0), from_f64(0.92149))
     }
@@ -95,6 +100,7 @@ impl<T: FromF64> WhitePoint<T> for D55 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65;
 impl<T: FromF64> WhitePoint<T> for D65 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.95047), from_f64(1.0), from_f64(1.08883))
     }
@@ -106,6 +112,7 @@ impl<T: FromF64> WhitePoint<T> for D65 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75;
 impl<T: FromF64> WhitePoint<T> for D75 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.94972), from_f64(1.0), from_f64(1.22638))
     }
@@ -117,6 +124,7 @@ impl<T: FromF64> WhitePoint<T> for D75 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct E;
 impl<T: FromF64> WhitePoint<T> for E {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(1.0), from_f64(1.0), from_f64(1.0))
     }
@@ -127,6 +135,7 @@ impl<T: FromF64> WhitePoint<T> for E {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F2;
 impl<T: FromF64> WhitePoint<T> for F2 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.99186), from_f64(1.0), from_f64(0.67393))
     }
@@ -137,6 +146,7 @@ impl<T: FromF64> WhitePoint<T> for F2 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F7;
 impl<T: FromF64> WhitePoint<T> for F7 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.95041), from_f64(1.0), from_f64(1.08747))
     }
@@ -147,6 +157,7 @@ impl<T: FromF64> WhitePoint<T> for F7 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct F11;
 impl<T: FromF64> WhitePoint<T> for F11 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(1.00962), from_f64(1.0), from_f64(0.64350))
     }
@@ -158,6 +169,7 @@ impl<T: FromF64> WhitePoint<T> for F11 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D50Degree10;
 impl<T: FromF64> WhitePoint<T> for D50Degree10 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.9672), from_f64(1.0), from_f64(0.8143))
     }
@@ -169,6 +181,7 @@ impl<T: FromF64> WhitePoint<T> for D50Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D55Degree10;
 impl<T: FromF64> WhitePoint<T> for D55Degree10 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.958), from_f64(1.0), from_f64(0.9093))
     }
@@ -180,6 +193,7 @@ impl<T: FromF64> WhitePoint<T> for D55Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D65Degree10;
 impl<T: FromF64> WhitePoint<T> for D65Degree10 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.9481), from_f64(1.0), from_f64(1.073))
     }
@@ -191,6 +205,7 @@ impl<T: FromF64> WhitePoint<T> for D65Degree10 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct D75Degree10;
 impl<T: FromF64> WhitePoint<T> for D75Degree10 {
+    #[inline]
     fn get_xyz() -> Xyz<Any, T> {
         Xyz::new(from_f64(0.94416), from_f64(1.0), from_f64(1.2064))
     }

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -348,26 +348,24 @@ impl<Wp, T, A> From<Alpha<Xyz<Wp, T>, A>> for (T, T, T, A) {
 
 impl<Wp, T> Clamp for Xyz<Wp, T>
 where
-    T: Zero + PartialOrd + Clone,
+    T: Zero + PartialOrd,
     Wp: WhitePoint<T>,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.x >= Self::min_x() && self.x <= Self::max_x() &&
         self.y >= Self::min_y() && self.y <= Self::max_y() &&
         self.z >= Self::min_z() && self.z <= Self::max_z()
     }
 
-    fn clamp(&self) -> Xyz<Wp, T> {
-        let mut c = self.clone();
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.x = clamp(self.x.clone(), Self::min_x(), Self::max_x());
-        self.y = clamp(self.y.clone(), Self::min_y(), Self::max_y());
-        self.z = clamp(self.z.clone(), Self::min_z(), Self::max_z());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.x, Self::min_x(), Self::max_x()),
+            clamp(self.y, Self::min_y(), Self::max_y()),
+            clamp(self.z, Self::min_z(), Self::max_z()),
+        )
     }
 }
 

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -481,7 +481,8 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         contrast_ratio(self.y, other.y)
     }
 }

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -389,7 +389,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Xyz<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Xyz<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_y() - self.y
         } else {
@@ -406,7 +407,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Xyz<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Xyz<Wp, T> {
         Xyz {
             x: self.x,
             y: (self.y + Self::max_y() * amount).max(Self::min_y()),

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -375,15 +375,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Xyz<Wp, T>, factor: T) -> Xyz<Wp, T> {
+    #[inline]
+    fn mix(self, other: Xyz<Wp, T>, factor: T) -> Xyz<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Xyz {
-            x: self.x + factor * (other.x - self.x),
-            y: self.y + factor * (other.y - self.y),
-            z: self.z + factor * (other.z - self.z),
-            white_point: PhantomData,
-        }
+        self + (other - self) * factor
     }
 }
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -286,7 +286,8 @@ where
 {
     type Scalar = T;
 
-    fn lighten(&self, factor: T) -> Yxy<Wp, T> {
+    #[inline]
+    fn lighten(self, factor: T) -> Yxy<Wp, T> {
         let difference = if factor >= T::zero() {
             Self::max_luma() - self.luma
         } else {
@@ -303,7 +304,8 @@ where
         }
     }
 
-    fn lighten_fixed(&self, amount: T) -> Yxy<Wp, T> {
+    #[inline]
+    fn lighten_fixed(self, amount: T) -> Yxy<Wp, T> {
         Yxy {
             x: self.x,
             y: self.y,

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -250,22 +250,20 @@ where
     T: FloatComponent,
 {
     #[rustfmt::skip]
+    #[inline]
     fn is_within_bounds(&self) -> bool {
         self.x >= Self::min_x() && self.x <= Self::max_x() &&
         self.y >= Self::min_y() && self.y <= Self::max_y() &&
         self.luma >= Self::min_luma() && self.luma <= Self::max_luma()
     }
 
-    fn clamp(&self) -> Yxy<Wp, T> {
-        let mut c = *self;
-        c.clamp_self();
-        c
-    }
-
-    fn clamp_self(&mut self) {
-        self.x = clamp(self.x, Self::min_x(), Self::max_x());
-        self.y = clamp(self.y, Self::min_y(), Self::max_y());
-        self.luma = clamp(self.luma, Self::min_luma(), Self::max_luma());
+    #[inline]
+    fn clamp(self) -> Self {
+        Self::new(
+            clamp(self.x, Self::min_x(), Self::max_x()),
+            clamp(self.y, Self::min_y(), Self::max_y()),
+            clamp(self.luma, Self::min_luma(), Self::max_luma()),
+        )
     }
 }
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -386,7 +386,8 @@ where
 {
     type Scalar = T;
 
-    fn get_contrast_ratio(&self, other: &Self) -> T {
+    #[inline]
+    fn get_contrast_ratio(self, other: Self) -> T {
         contrast_ratio(self.luma, other.luma)
     }
 }

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -273,15 +273,10 @@ where
 {
     type Scalar = T;
 
-    fn mix(&self, other: &Yxy<Wp, T>, factor: T) -> Yxy<Wp, T> {
+    #[inline]
+    fn mix(self, other: Yxy<Wp, T>, factor: T) -> Yxy<Wp, T> {
         let factor = clamp(factor, T::zero(), T::one());
-
-        Yxy {
-            x: self.x + factor * (other.x - self.x),
-            y: self.y + factor * (other.y - self.y),
-            luma: self.luma + factor * (other.luma - self.luma),
-            white_point: PhantomData,
-        }
+        self + (other - self) * factor
     }
 }
 

--- a/palette/tests/convert/data_ciede_2000.rs
+++ b/palette/tests/convert/data_ciede_2000.rs
@@ -71,12 +71,12 @@ pub fn run_tests() {
     let data = load_data();
 
     for expected in data.iter() {
-        let result_lab = expected.c1.get_color_difference(&expected.c2);
+        let result_lab = expected.c1.get_color_difference(expected.c2);
         check_equal_lab(result_lab, expected.delta_e);
 
         let lch1: Lch<_, f64> = Lch::from_color_unclamped(expected.c1);
         let lch2: Lch<_, f64> = Lch::from_color_unclamped(expected.c2);
-        let result_lch = lch1.get_color_difference(&lch2);
+        let result_lch = lch1.get_color_difference(lch2);
         check_equal_lch(result_lch, expected.delta_e);
     }
 }


### PR DESCRIPTION
This makes all of the traits have the same convention, modeled after the `core::ops` traits, and leaves any cloning to the caller. I considered adding an `Output`type too, but that can go into a separate pass.

## Breaking Change

Almost every trait that takes parameters have changed here, so that may be breaking for non-Copy types. The `clamp_self` method is also gone.
