### PR TITLE
Split `Clamp` into smaller traits and implement for `[T]`

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -306,17 +306,8 @@ where
     }
 }
 
-// Add the required clamping and validation.
+// Add the required clamping.
 impl Clamp for Color {
-    fn is_within_bounds(&self) -> bool {
-        let zero_to_one = 0.0..=1.0;
-
-        zero_to_one.contains(&self.r)
-            && zero_to_one.contains(&self.g)
-            && zero_to_one.contains(&self.b)
-            && zero_to_one.contains(&self.a)
-    }
-
     fn clamp(self) -> Self {
         Color {
             r: self.r.min(1.0).max(0.0),

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -16,8 +16,9 @@ use crate::encoding::pixel::RawPixel;
 use crate::encoding::Srgb;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, FloatComponent, GetHue, Hsv, Hue,
-    Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, Component,
+    FloatComponent, GetHue, Hsv, Hue, IsWithinBounds, Mix, Pixel, RelativeContrast, RgbHue,
+    Saturate, Shade, Xyz,
 };
 #[cfg(feature = "random")]
 use crate::{float::Float, FromF64};
@@ -349,7 +350,7 @@ impl<S, T, A> From<Alpha<Hsl<S, T>, A>> for (RgbHue<T>, T, T, A) {
     }
 }
 
-impl<S, T> Clamp for Hsl<S, T>
+impl<S, T> IsWithinBounds for Hsl<S, T>
 where
     T: Component,
 {
@@ -359,7 +360,12 @@ where
         self.saturation >= T::zero() && self.saturation <= T::max_intensity() &&
         self.lightness >= T::zero() && self.lightness <= T::max_intensity()
     }
+}
 
+impl<S, T> Clamp for Hsl<S, T>
+where
+    T: Component,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -367,6 +373,17 @@ where
             clamp(self.saturation, T::zero(), T::max_intensity()),
             clamp(self.lightness, T::zero(), T::max_intensity()),
         )
+    }
+}
+
+impl<S, T> ClampAssign for Hsl<S, T>
+where
+    T: Component,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.saturation, T::zero(), T::max_intensity());
+        clamp_assign(&mut self.lightness, T::zero(), T::max_intensity());
     }
 }
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -20,6 +20,7 @@ use crate::{
     Alpha, Clamp, FloatComponent, FromF64, GetHue, Hue, Lchuv, LuvHue, Mix, Pixel,
     RelativeContrast, Saturate, Shade, Xyz,
 };
+use crate::{clamp_assign, ClampAssign, IsWithinBounds};
 
 /// HSLuv with an alpha component. See the [`Hsluva` implementation in
 /// `Alpha`](crate::Alpha#Hsluva).
@@ -214,7 +215,7 @@ impl<Wp, T, A> From<Alpha<Hsluv<Wp, T>, A>> for (LuvHue<T>, T, T, A) {
     }
 }
 
-impl<Wp, T> Clamp for Hsluv<Wp, T>
+impl<Wp, T> IsWithinBounds for Hsluv<Wp, T>
 where
     T: Zero + FromF64 + PartialOrd,
 {
@@ -224,7 +225,12 @@ where
         self.saturation >= Self::min_saturation() && self.saturation <= Self::max_saturation() &&
         self.l >= Self::min_l() && self.l <= Self::max_l()
     }
+}
 
+impl<Wp, T> Clamp for Hsluv<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -236,6 +242,21 @@ where
             ),
             clamp(self.l, Self::min_l(), Self::max_l()),
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Hsluv<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(
+            &mut self.saturation,
+            Self::min_saturation(),
+            Self::max_saturation(),
+        );
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -16,8 +16,9 @@ use crate::encoding::pixel::RawPixel;
 use crate::encoding::Srgb;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, FloatComponent, FromColor, GetHue,
-    Hsl, Hue, Hwb, Mix, Pixel, RelativeContrast, RgbHue, Saturate, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, Component,
+    FloatComponent, FromColor, GetHue, Hsl, Hue, Hwb, IsWithinBounds, Mix, Pixel, RelativeContrast,
+    RgbHue, Saturate, Shade, Xyz,
 };
 #[cfg(feature = "random")]
 use crate::{float::Float, FromF64};
@@ -360,7 +361,7 @@ impl<S, T, A> From<Alpha<Hsv<S, T>, A>> for (RgbHue<T>, T, T, A) {
     }
 }
 
-impl<S, T> Clamp for Hsv<S, T>
+impl<S, T> IsWithinBounds for Hsv<S, T>
 where
     T: Component,
 {
@@ -370,7 +371,12 @@ where
         self.saturation >= Self::min_saturation() && self.saturation <= Self::max_saturation() &&
         self.value >= Self::min_value() && self.value <= Self::max_value()
     }
+}
 
+impl<S, T> Clamp for Hsv<S, T>
+where
+    T: Component,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -382,6 +388,21 @@ where
             ),
             clamp(self.value, Self::min_value(), Self::max_value()),
         )
+    }
+}
+
+impl<S, T> ClampAssign for Hsv<S, T>
+where
+    T: Component,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(
+            &mut self.saturation,
+            Self::min_saturation(),
+            Self::max_saturation(),
+        );
+        clamp_assign(&mut self.value, Self::min_value(), Self::max_value());
     }
 }
 

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -9,14 +9,14 @@ use rand::distributions::{Distribution, Standard};
 #[cfg(feature = "random")]
 use rand::Rng;
 
-use crate::color_difference::get_ciede_difference;
-use crate::color_difference::ColorDifference;
+use crate::color_difference::{get_ciede_difference, ColorDifference};
 use crate::convert::FromColorUnclamped;
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, float::Float, from_f64, Alpha, Clamp, ComponentWise, FloatComponent,
-    FromF64, GetHue, LabHue, Lch, Mix, Pixel, RelativeContrast, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, float::Float, from_f64, Alpha, Clamp, ClampAssign,
+    ComponentWise, FloatComponent, FromF64, GetHue, IsWithinBounds, LabHue, Lch, Mix, Pixel,
+    RelativeContrast, Shade, Xyz,
 };
 
 /// CIE L\*a\*b\* (CIELAB) with an alpha component. See the [`Laba`
@@ -236,7 +236,7 @@ impl<Wp, T, A> From<Alpha<Lab<Wp, T>, A>> for (T, T, T, A) {
     }
 }
 
-impl<Wp, T> Clamp for Lab<Wp, T>
+impl<Wp, T> IsWithinBounds for Lab<Wp, T>
 where
     T: Zero + FromF64 + PartialOrd,
 {
@@ -247,7 +247,12 @@ where
         self.a >= Self::min_a() && self.a <= Self::max_a() &&
         self.b >= Self::min_b() && self.b <= Self::max_b()
     }
+}
 
+impl<Wp, T> Clamp for Lab<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -255,6 +260,18 @@ where
             clamp(self.a, Self::min_a(), Self::max_a()),
             clamp(self.b, Self::min_b(), Self::max_b()),
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Lab<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
+        clamp_assign(&mut self.a, Self::min_a(), Self::max_a());
+        clamp_assign(&mut self.b, Self::min_b(), Self::max_b());
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -15,8 +15,9 @@ use crate::convert::{FromColorUnclamped, IntoColorUnclamped};
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, clamp_min, contrast_ratio, from_f64, Alpha, Clamp, Float, FloatComponent, FromColor,
-    FromF64, GetHue, Hue, Lab, LabHue, Mix, Pixel, RelativeContrast, Saturate, Shade, Xyz,
+    clamp, clamp_assign, clamp_min, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp,
+    ClampAssign, Float, FloatComponent, FromColor, FromF64, GetHue, Hue, IsWithinBounds, Lab,
+    LabHue, Mix, Pixel, RelativeContrast, Saturate, Shade, Xyz,
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
@@ -211,7 +212,7 @@ impl<Wp, T, A> From<Alpha<Lch<Wp, T>, A>> for (T, T, LabHue<T>, A) {
     }
 }
 
-impl<Wp, T> Clamp for Lch<Wp, T>
+impl<Wp, T> IsWithinBounds for Lch<Wp, T>
 where
     T: Zero + FromF64 + PartialOrd,
 {
@@ -219,7 +220,12 @@ where
     fn is_within_bounds(&self) -> bool {
         self.l >= Self::min_l() && self.l <= Self::max_l() && self.chroma >= Self::min_chroma()
     }
+}
 
+impl<Wp, T> Clamp for Lch<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -227,6 +233,17 @@ where
             clamp_min(self.chroma, Self::min_chroma()),
             self.hue,
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Lch<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
+        clamp_min_assign(&mut self.chroma, Self::min_chroma());
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -14,8 +14,9 @@ use crate::encoding::pixel::RawPixel;
 use crate::luv_bounds::LuvBounds;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Clamp, FloatComponent, FromColor, FromF64, GetHue,
-    Hsluv, Hue, Luv, LuvHue, Mix, Pixel, RelativeContrast, Saturate, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, FloatComponent,
+    FromColor, FromF64, GetHue, Hsluv, Hue, IsWithinBounds, Luv, LuvHue, Mix, Pixel,
+    RelativeContrast, Saturate, Shade, Xyz,
 };
 
 /// CIE L\*C\*uv h°uv with an alpha component. See the [`Lchuva` implementation in
@@ -220,7 +221,7 @@ impl<Wp, T, A> From<Alpha<Lchuv<Wp, T>, A>> for (T, T, LuvHue<T>, A) {
     }
 }
 
-impl<Wp, T> Clamp for Lchuv<Wp, T>
+impl<Wp, T> IsWithinBounds for Lchuv<Wp, T>
 where
     T: Zero + FromF64 + PartialOrd,
 {
@@ -231,7 +232,12 @@ where
             && self.chroma >= Self::min_chroma()
             && self.chroma <= Self::max_chroma()
     }
+}
 
+impl<Wp, T> Clamp for Lchuv<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -239,6 +245,17 @@ where
             clamp(self.chroma, Self::min_chroma(), Self::max_chroma()),
             self.hue,
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Lchuv<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
+        clamp_assign(&mut self.chroma, Self::min_chroma(), Self::max_chroma());
     }
 }
 

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -19,8 +19,9 @@ use crate::encoding::pixel::RawPixel;
 use crate::encoding::{Linear, Srgb, TransferFn};
 use crate::luma::LumaStandard;
 use crate::{
-    clamp, contrast_ratio, Alpha, Blend, Clamp, Component, ComponentWise, FloatComponent,
-    FromComponent, Mix, Pixel, RelativeContrast, Shade, Xyz, Yxy,
+    clamp, clamp_assign, contrast_ratio, Alpha, Blend, Clamp, ClampAssign, Component,
+    ComponentWise, FloatComponent, FromComponent, IsWithinBounds, Mix, Pixel, RelativeContrast,
+    Shade, Xyz, Yxy,
 };
 
 /// Luminance with an alpha component. See the [`Lumaa` implementation
@@ -330,7 +331,7 @@ impl<S, T, A> From<Alpha<Luma<S, T>, A>> for (T, A) {
     }
 }
 
-impl<S, T> Clamp for Luma<S, T>
+impl<S, T> IsWithinBounds for Luma<S, T>
 where
     T: Component,
 {
@@ -338,10 +339,25 @@ where
     fn is_within_bounds(&self) -> bool {
         self.luma >= Self::min_luma() && self.luma <= Self::max_luma()
     }
+}
 
+impl<S, T> Clamp for Luma<S, T>
+where
+    T: Component,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(clamp(self.luma, Self::min_luma(), Self::max_luma()))
+    }
+}
+
+impl<S, T> ClampAssign for Luma<S, T>
+where
+    T: Component,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.luma, Self::min_luma(), Self::max_luma());
     }
 }
 

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -13,8 +13,9 @@ use crate::convert::FromColorUnclamped;
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Clamp, ComponentWise, FloatComponent, FromF64, GetHue,
-    Lchuv, LuvHue, Mix, Pixel, RelativeContrast, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, ComponentWise,
+    FloatComponent, FromF64, GetHue, IsWithinBounds, Lchuv, LuvHue, Mix, Pixel, RelativeContrast,
+    Shade, Xyz,
 };
 
 /// CIE L\*u\*v\* (CIELUV) with an alpha component. See the [`Luva`
@@ -238,7 +239,7 @@ impl<Wp, T, A> From<Alpha<Luv<Wp, T>, A>> for (T, T, T, A) {
     }
 }
 
-impl<Wp, T> Clamp for Luv<Wp, T>
+impl<Wp, T> IsWithinBounds for Luv<Wp, T>
 where
     T: Zero + FromF64 + PartialOrd,
 {
@@ -249,7 +250,12 @@ where
         self.u >= Self::min_u() && self.u <= Self::max_u() &&
         self.v >= Self::min_v() && self.v <= Self::max_v()
     }
+}
 
+impl<Wp, T> Clamp for Luv<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -257,6 +263,18 @@ where
             clamp(self.u, Self::min_u(), Self::max_u()),
             clamp(self.v, Self::min_v(), Self::max_v()),
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Luv<Wp, T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
+        clamp_assign(&mut self.u, Self::min_u(), Self::max_u());
+        clamp_assign(&mut self.v, Self::min_v(), Self::max_v());
     }
 }
 

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -14,8 +14,9 @@ use crate::encoding::pixel::RawPixel;
 use crate::matrix::multiply_xyz;
 use crate::white_point::D65;
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Clamp, Component, ComponentWise, FloatComponent,
-    FromF64, GetHue, Mat3, Mix, OklabHue, Oklch, Pixel, RelativeContrast, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, Component,
+    ComponentWise, FloatComponent, FromF64, GetHue, IsWithinBounds, Mat3, Mix, OklabHue, Oklch,
+    Pixel, RelativeContrast, Shade, Xyz,
 };
 
 #[rustfmt::skip]
@@ -287,7 +288,7 @@ impl<T, A: Component> From<Alpha<Oklab<T>, A>> for (T, T, T, A) {
     }
 }
 
-impl<T> Clamp for Oklab<T>
+impl<T> IsWithinBounds for Oklab<T>
 where
     T: FromF64 + PartialOrd,
 {
@@ -298,7 +299,12 @@ where
         self.a >= Self::min_a() && self.a <= Self::max_a() &&
         self.b >= Self::min_b() && self.b <= Self::max_b()
     }
+}
 
+impl<T> Clamp for Oklab<T>
+where
+    T: FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -306,6 +312,18 @@ where
             clamp(self.a, Self::min_a(), Self::max_a()),
             clamp(self.b, Self::min_b(), Self::max_b()),
         )
+    }
+}
+
+impl<T> ClampAssign for Oklab<T>
+where
+    T: FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
+        clamp_assign(&mut self.a, Self::min_a(), Self::max_a());
+        clamp_assign(&mut self.b, Self::min_b(), Self::max_b());
     }
 }
 

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -13,8 +13,9 @@ use crate::convert::{FromColorUnclamped, IntoColorUnclamped};
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::D65;
 use crate::{
-    clamp, contrast_ratio, from_f64, Alpha, Clamp, FloatComponent, FromColor, FromF64, GetHue, Hue,
-    Mix, Oklab, OklabHue, Pixel, RelativeContrast, Saturate, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, FloatComponent,
+    FromColor, FromF64, GetHue, Hue, IsWithinBounds, Mix, Oklab, OklabHue, Pixel, RelativeContrast,
+    Saturate, Shade, Xyz,
 };
 
 /// Oklch with an alpha component. See the [`Oklcha` implementation in
@@ -266,7 +267,7 @@ impl<T, A> From<Alpha<Oklch<T>, A>> for (T, T, OklabHue<T>, A) {
     }
 }
 
-impl<T> Clamp for Oklch<T>
+impl<T> IsWithinBounds for Oklch<T>
 where
     T: Zero + FromF64 + PartialOrd,
 {
@@ -277,7 +278,12 @@ where
             && self.chroma >= Self::min_chroma()
             && self.chroma <= Self::max_chroma()
     }
+}
 
+impl<T> Clamp for Oklch<T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -285,6 +291,17 @@ where
             clamp(self.chroma, Self::min_chroma(), Self::max_chroma()),
             self.hue,
         )
+    }
+}
+
+impl<T> ClampAssign for Oklch<T>
+where
+    T: Zero + FromF64 + PartialOrd,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.l, Self::min_l(), Self::max_l());
+        clamp_assign(&mut self.chroma, Self::min_chroma(), Self::max_chroma());
     }
 }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -24,8 +24,9 @@ use crate::luma::LumaStandard;
 use crate::matrix::{matrix_inverse, multiply_xyz_to_rgb, rgb_to_xyz_matrix};
 use crate::rgb::{Packed, RgbChannels, RgbSpace, RgbStandard, TransferFn};
 use crate::{
-    clamp, contrast_ratio, from_f64, Blend, Clamp, Component, ComponentWise, FloatComponent,
-    FromComponent, GetHue, Mix, Pixel, RelativeContrast, Shade,
+    clamp, clamp_assign, contrast_ratio, from_f64, Blend, Clamp, ClampAssign, Component,
+    ComponentWise, FloatComponent, FromComponent, GetHue, IsWithinBounds, Mix, Pixel,
+    RelativeContrast, Shade,
 };
 use crate::{Hsl, Hsv, Luma, RgbHue, Xyz};
 
@@ -515,25 +516,42 @@ where
     }
 }
 
-impl<S, T> Clamp for Rgb<S, T>
+impl<S, T> IsWithinBounds for Rgb<S, T>
 where
     T: Component,
 {
     #[rustfmt::skip]
     #[inline]
     fn is_within_bounds(&self) -> bool {
-        self.red >= T::zero() && self.red <= T::max_intensity() &&
-        self.green >= T::zero() && self.green <= T::max_intensity() &&
-        self.blue >= T::zero() && self.blue <= T::max_intensity()
+        self.red >= Self::min_red() && self.red <= Self::max_red() &&
+        self.green >= Self::min_green() && self.green <= Self::max_green() &&
+        self.blue >= Self::min_blue() && self.blue <= Self::max_blue()
     }
+}
 
+impl<S, T> Clamp for Rgb<S, T>
+where
+    T: Component,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
-            clamp(self.red, T::zero(), T::max_intensity()),
-            clamp(self.green, T::zero(), T::max_intensity()),
-            clamp(self.blue, T::zero(), T::max_intensity()),
+            clamp(self.red, Self::min_red(), Self::max_red()),
+            clamp(self.green, Self::min_green(), Self::max_green()),
+            clamp(self.blue, Self::min_blue(), Self::max_blue()),
         )
+    }
+}
+
+impl<S, T> ClampAssign for Rgb<S, T>
+where
+    T: Component,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.red, Self::min_red(), Self::max_red());
+        clamp_assign(&mut self.green, Self::min_green(), Self::max_green());
+        clamp_assign(&mut self.blue, Self::min_blue(), Self::max_blue());
     }
 }
 

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -16,8 +16,9 @@ use crate::matrix::{multiply_rgb_to_xyz, multiply_xyz, rgb_to_xyz_matrix};
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, from_f64, oklab, Alpha, Clamp, ComponentWise, FloatComponent, Lab, Luma,
-    Luv, Mix, Oklab, Oklch, Pixel, RelativeContrast, Shade, Yxy,
+    clamp, clamp_assign, contrast_ratio, from_f64, oklab, Alpha, Clamp, ClampAssign, ComponentWise,
+    FloatComponent, IsWithinBounds, Lab, Luma, Luv, Mix, Oklab, Oklch, Pixel, RelativeContrast,
+    Shade, Yxy,
 };
 
 /// CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in
@@ -346,7 +347,7 @@ impl<Wp, T, A> From<Alpha<Xyz<Wp, T>, A>> for (T, T, T, A) {
     }
 }
 
-impl<Wp, T> Clamp for Xyz<Wp, T>
+impl<Wp, T> IsWithinBounds for Xyz<Wp, T>
 where
     T: Zero + PartialOrd,
     Wp: WhitePoint<T>,
@@ -358,7 +359,13 @@ where
         self.y >= Self::min_y() && self.y <= Self::max_y() &&
         self.z >= Self::min_z() && self.z <= Self::max_z()
     }
+}
 
+impl<Wp, T> Clamp for Xyz<Wp, T>
+where
+    T: Zero + PartialOrd,
+    Wp: WhitePoint<T>,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -366,6 +373,19 @@ where
             clamp(self.y, Self::min_y(), Self::max_y()),
             clamp(self.z, Self::min_z(), Self::max_z()),
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Xyz<Wp, T>
+where
+    T: Zero + PartialOrd,
+    Wp: WhitePoint<T>,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.x, Self::min_x(), Self::max_x());
+        clamp_assign(&mut self.y, Self::min_y(), Self::max_y());
+        clamp_assign(&mut self.z, Self::min_z(), Self::max_z());
     }
 }
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -13,8 +13,8 @@ use crate::encoding::pixel::RawPixel;
 use crate::luma::LumaStandard;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
-    clamp, contrast_ratio, Alpha, Clamp, Component, ComponentWise, FloatComponent, Luma, Mix,
-    Pixel, RelativeContrast, Shade, Xyz,
+    clamp, clamp_assign, contrast_ratio, Alpha, Clamp, ClampAssign, Component, ComponentWise,
+    FloatComponent, IsWithinBounds, Luma, Mix, Pixel, RelativeContrast, Shade, Xyz,
 };
 
 /// CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation
@@ -245,9 +245,9 @@ where
     }
 }
 
-impl<Wp, T> Clamp for Yxy<Wp, T>
+impl<Wp, T> IsWithinBounds for Yxy<Wp, T>
 where
-    T: FloatComponent,
+    T: Component,
 {
     #[rustfmt::skip]
     #[inline]
@@ -256,7 +256,12 @@ where
         self.y >= Self::min_y() && self.y <= Self::max_y() &&
         self.luma >= Self::min_luma() && self.luma <= Self::max_luma()
     }
+}
 
+impl<Wp, T> Clamp for Yxy<Wp, T>
+where
+    T: Component,
+{
     #[inline]
     fn clamp(self) -> Self {
         Self::new(
@@ -264,6 +269,18 @@ where
             clamp(self.y, Self::min_y(), Self::max_y()),
             clamp(self.luma, Self::min_luma(), Self::max_luma()),
         )
+    }
+}
+
+impl<Wp, T> ClampAssign for Yxy<Wp, T>
+where
+    T: Component,
+{
+    #[inline]
+    fn clamp_assign(&mut self) {
+        clamp_assign(&mut self.x, Self::min_x(), Self::max_x());
+        clamp_assign(&mut self.y, Self::min_y(), Self::max_y());
+        clamp_assign(&mut self.luma, Self::min_luma(), Self::max_luma());
     }
 }
 


### PR DESCRIPTION
This adds back a replacement for `clamp_self`, but I'm going for the `*_assign` naming convention, and also splits `Clamp` into separate `IsWithinBounds`, `Clamp` and `ClampAssign`. This allows separate implementations for some traits that wouldn't be compatible with the other traits. For example `[T]` can't implement `Clamp` in a nice way since it requires moving `self`.

## Breaking Change

This moves the `is_within_bounds` method into `IsWithinBounds`.
