### PR TITLE
Add a MixAssign trait and remove the Float requirement from Mix

### DIFF
--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -17,8 +17,8 @@ use crate::encoding::Srgb;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, Component,
-    FloatComponent, GetHue, Hsv, Hue, IsWithinBounds, Mix, Pixel, RelativeContrast, RgbHue,
-    Saturate, Shade, Xyz,
+    FloatComponent, GetHue, Hsv, Hue, IsWithinBounds, Mix, MixAssign, Pixel, RelativeContrast,
+    RgbHue, Saturate, Shade, Xyz,
 };
 #[cfg(feature = "random")]
 use crate::{float::Float, FromF64};
@@ -394,9 +394,9 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Hsl<S, T>, factor: T) -> Hsl<S, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
 
         Hsl {
             hue: self.hue + factor * hue_diff,
@@ -404,6 +404,23 @@ where
             lightness: self.lightness + factor * (other.lightness - self.lightness),
             standard: PhantomData,
         }
+    }
+}
+
+impl<S, T> MixAssign for Hsl<S, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.hue += factor * hue_diff;
+        self.saturation += factor * (other.saturation - self.saturation);
+        self.lightness += factor * (other.lightness - self.lightness);
     }
 }
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -13,6 +13,7 @@ use crate::encoding::pixel::RawPixel;
 #[cfg(feature = "random")]
 use crate::float::Float;
 use crate::luv_bounds::LuvBounds;
+use crate::MixAssign;
 use crate::{
     clamp, contrast_ratio,
     convert::FromColorUnclamped,
@@ -267,9 +268,9 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Hsluv<Wp, T>, factor: T) -> Hsluv<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
 
         Hsluv {
             hue: self.hue + factor * hue_diff,
@@ -277,6 +278,23 @@ where
             l: self.l + factor * (other.l - self.l),
             white_point: PhantomData,
         }
+    }
+}
+
+impl<Wp, T> MixAssign for Hsluv<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.hue += factor * hue_diff;
+        self.saturation += factor * (other.saturation - self.saturation);
+        self.l += factor * (other.l - self.l);
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -17,8 +17,8 @@ use crate::encoding::Srgb;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, Component,
-    FloatComponent, FromColor, GetHue, Hsl, Hue, Hwb, IsWithinBounds, Mix, Pixel, RelativeContrast,
-    RgbHue, Saturate, Shade, Xyz,
+    FloatComponent, FromColor, GetHue, Hsl, Hue, Hwb, IsWithinBounds, Mix, MixAssign, Pixel,
+    RelativeContrast, RgbHue, Saturate, Shade, Xyz,
 };
 #[cfg(feature = "random")]
 use crate::{float::Float, FromF64};
@@ -413,9 +413,9 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Hsv<S, T>, factor: T) -> Hsv<S, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
 
         Hsv {
             hue: self.hue + factor * hue_diff,
@@ -423,6 +423,23 @@ where
             value: self.value + factor * (other.value - self.value),
             standard: PhantomData,
         }
+    }
+}
+
+impl<S, T> MixAssign for Hsv<S, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.hue += factor * hue_diff;
+        self.saturation += factor * (other.saturation - self.saturation);
+        self.value += factor * (other.value - self.value);
     }
 }
 

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -16,8 +16,8 @@ use crate::encoding::Srgb;
 use crate::rgb::{RgbSpace, RgbStandard};
 use crate::{
     clamp, clamp_min, clamp_min_assign, contrast_ratio, Alpha, Clamp, ClampAssign, Component,
-    FloatComponent, GetHue, Hsv, Hue, IsWithinBounds, Mix, Pixel, RelativeContrast, RgbHue, Shade,
-    Xyz,
+    FloatComponent, GetHue, Hsv, Hue, IsWithinBounds, Mix, MixAssign, Pixel, RelativeContrast,
+    RgbHue, Shade, Xyz,
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
@@ -342,9 +342,9 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Hwb<S, T>, factor: T) -> Hwb<S, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
 
         Hwb {
             hue: self.hue + factor * hue_diff,
@@ -352,6 +352,23 @@ where
             blackness: self.blackness + factor * (other.blackness - self.blackness),
             standard: PhantomData,
         }
+    }
+}
+
+impl<S, T> MixAssign for Hwb<S, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.hue += factor * hue_diff;
+        self.whiteness += factor * (other.whiteness - self.whiteness);
+        self.blackness += factor * (other.blackness - self.blackness);
     }
 }
 

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -13,6 +13,7 @@ use crate::color_difference::{get_ciede_difference, ColorDifference};
 use crate::convert::FromColorUnclamped;
 use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
+use crate::MixAssign;
 use crate::{
     clamp, clamp_assign, contrast_ratio, float::Float, from_f64, Alpha, Clamp, ClampAssign,
     ComponentWise, FloatComponent, FromF64, GetHue, IsWithinBounds, LabHue, Lch, Mix, Pixel,
@@ -282,9 +283,22 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Lab<Wp, T>, factor: T) -> Lab<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<Wp, T> MixAssign for Lab<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -17,7 +17,7 @@ use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, clamp_min, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp,
     ClampAssign, Float, FloatComponent, FromColor, FromF64, GetHue, Hue, IsWithinBounds, Lab,
-    LabHue, Mix, Pixel, RelativeContrast, Saturate, Shade, Xyz,
+    LabHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, Shade, Xyz,
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
@@ -254,15 +254,33 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Lch<Wp, T>, factor: T) -> Lch<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
         Lch {
             l: self.l + factor * (other.l - self.l),
             chroma: self.chroma + factor * (other.chroma - self.chroma),
             hue: self.hue + factor * hue_diff,
             white_point: PhantomData,
         }
+    }
+}
+
+impl<Wp, T> MixAssign for Lch<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.l += factor * (other.l - self.l);
+        self.chroma += factor * (other.chroma - self.chroma);
+        self.hue += factor * hue_diff;
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -15,7 +15,7 @@ use crate::luv_bounds::LuvBounds;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, FloatComponent,
-    FromColor, FromF64, GetHue, Hsluv, Hue, IsWithinBounds, Luv, LuvHue, Mix, Pixel,
+    FromColor, FromF64, GetHue, Hsluv, Hue, IsWithinBounds, Luv, LuvHue, Mix, MixAssign, Pixel,
     RelativeContrast, Saturate, Shade, Xyz,
 };
 
@@ -266,15 +266,33 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Lchuv<Wp, T>, factor: T) -> Lchuv<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
         Lchuv {
             l: self.l + factor * (other.l - self.l),
             chroma: self.chroma + factor * (other.chroma - self.chroma),
             hue: self.hue + factor * hue_diff,
             white_point: PhantomData,
         }
+    }
+}
+
+impl<Wp, T> MixAssign for Lchuv<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.l += factor * (other.l - self.l);
+        self.chroma += factor * (other.chroma - self.chroma);
+        self.hue += factor * hue_diff;
     }
 }
 

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -546,8 +546,9 @@ where
 /// An operator for restricting a color's components to their expected ranges.
 ///
 /// [`IsWithinBounds`] can be used to check if the components are within their
-/// range bounds. See also [`ClampAssign`] for a self-modifying version of
-/// `Clamp`.
+/// range bounds.
+///
+/// See also [`ClampAssign`].
 ///
 /// ```
 /// use palette::{Srgb, IsWithinBounds, Clamp};
@@ -575,7 +576,9 @@ pub trait Clamp {
 /// ranges.
 ///
 /// [`IsWithinBounds`] can be used to check if the components are within their
-/// range bounds. See also [`Clamp`] for a moving version of `ClampAssign`.
+/// range bounds.
+///
+/// See also [`Clamp`].
 ///
 /// ```
 /// use palette::{Srgb, IsWithinBounds, ClampAssign};
@@ -624,7 +627,9 @@ where
     }
 }
 
-/// A trait for linear color interpolation.
+/// Linear color interpolation of two colors.
+///
+/// See also [`MixAssign`].
 ///
 /// ```
 /// use approx::assert_relative_eq;
@@ -639,7 +644,7 @@ where
 /// ```
 pub trait Mix {
     /// The type of the mixing factor.
-    type Scalar: Float;
+    type Scalar;
 
     /// Mix the color with an other color, by `factor`.
     ///
@@ -648,6 +653,32 @@ pub trait Mix {
     /// `other`.
     #[must_use]
     fn mix(self, other: Self, factor: Self::Scalar) -> Self;
+}
+
+/// Assigning linear color interpolation of two colors.
+///
+/// See also [`Mix`].
+///
+/// ```
+/// use approx::assert_relative_eq;
+/// use palette::{LinSrgb, MixAssign};
+///
+/// let mut a = LinSrgb::new(0.0, 0.5, 1.0);
+/// let b = LinSrgb::new(1.0, 0.5, 0.0);
+///
+/// a.mix_assign(b, 0.5);
+/// assert_relative_eq!(a, LinSrgb::new(0.5, 0.5, 0.5));
+/// ```
+pub trait MixAssign {
+    /// The type of the mixing factor.
+    type Scalar;
+
+    /// Mix the color with an other color, by `factor`.
+    ///
+    /// `factor` should be between `0.0` and `1.0`, where `0.0` will result in
+    /// the same color as `self` and `1.0` will result in the same color as
+    /// `other`.
+    fn mix_assign(&mut self, other: Self, factor: Self::Scalar);
 }
 
 /// The `Shade` trait allows a color to be lightened or darkened.

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -20,8 +20,8 @@ use crate::encoding::{Linear, Srgb, TransferFn};
 use crate::luma::LumaStandard;
 use crate::{
     clamp, clamp_assign, contrast_ratio, Alpha, Blend, Clamp, ClampAssign, Component,
-    ComponentWise, FloatComponent, FromComponent, IsWithinBounds, Mix, Pixel, RelativeContrast,
-    Shade, Xyz, Yxy,
+    ComponentWise, FloatComponent, FromComponent, IsWithinBounds, Mix, MixAssign, Pixel,
+    RelativeContrast, Shade, Xyz, Yxy,
 };
 
 /// Luminance with an alpha component. See the [`Lumaa` implementation
@@ -369,9 +369,23 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Luma<S, T>, factor: T) -> Luma<S, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<S, T> MixAssign for Luma<S, T>
+where
+    T: FloatComponent + AddAssign,
+    S: LumaStandard<T, TransferFn = LinearFn>,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -14,8 +14,8 @@ use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, ComponentWise,
-    FloatComponent, FromF64, GetHue, IsWithinBounds, Lchuv, LuvHue, Mix, Pixel, RelativeContrast,
-    Shade, Xyz,
+    FloatComponent, FromF64, GetHue, IsWithinBounds, Lchuv, LuvHue, Mix, MixAssign, Pixel,
+    RelativeContrast, Shade, Xyz,
 };
 
 /// CIE L\*u\*v\* (CIELUV) with an alpha component. See the [`Luva`
@@ -285,9 +285,22 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Luv<Wp, T>, factor: T) -> Luv<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<Wp, T> MixAssign for Luv<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -15,8 +15,8 @@ use crate::matrix::multiply_xyz;
 use crate::white_point::D65;
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, Component,
-    ComponentWise, FloatComponent, FromF64, GetHue, IsWithinBounds, Mat3, Mix, OklabHue, Oklch,
-    Pixel, RelativeContrast, Shade, Xyz,
+    ComponentWise, FloatComponent, FromF64, GetHue, IsWithinBounds, Mat3, Mix, MixAssign, OklabHue,
+    Oklch, Pixel, RelativeContrast, Shade, Xyz,
 };
 
 #[rustfmt::skip]
@@ -337,6 +337,19 @@ where
     fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<T> MixAssign for Oklab<T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -14,8 +14,8 @@ use crate::encoding::pixel::RawPixel;
 use crate::white_point::D65;
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign, FloatComponent,
-    FromColor, FromF64, GetHue, Hue, IsWithinBounds, Mix, Oklab, OklabHue, Pixel, RelativeContrast,
-    Saturate, Shade, Xyz,
+    FromColor, FromF64, GetHue, Hue, IsWithinBounds, Mix, MixAssign, Oklab, OklabHue, Pixel,
+    RelativeContrast, Saturate, Shade, Xyz,
 };
 
 /// Oklch with an alpha component. See the [`Oklcha` implementation in
@@ -312,14 +312,32 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Oklch<T>, factor: T) -> Oklch<T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
-        let hue_diff: T = (other.hue - self.hue).to_degrees();
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
         Oklch {
             l: self.l + factor * (other.l - self.l),
             chroma: self.chroma + factor * (other.chroma - self.chroma),
             hue: self.hue + factor * hue_diff,
         }
+    }
+}
+
+impl<T> MixAssign for Oklch<T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        let hue_diff = (other.hue - self.hue).to_degrees();
+
+        self.l += factor * (other.l - self.l);
+        self.chroma += factor * (other.chroma - self.chroma);
+        self.hue += factor * hue_diff;
     }
 }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -25,7 +25,7 @@ use crate::matrix::{matrix_inverse, multiply_xyz_to_rgb, rgb_to_xyz_matrix};
 use crate::rgb::{Packed, RgbChannels, RgbSpace, RgbStandard, TransferFn};
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, Blend, Clamp, ClampAssign, Component,
-    ComponentWise, FloatComponent, FromComponent, GetHue, IsWithinBounds, Mix, Pixel,
+    ComponentWise, FloatComponent, FromComponent, GetHue, IsWithinBounds, Mix, MixAssign, Pixel,
     RelativeContrast, Shade,
 };
 use crate::{Hsl, Hsv, Luma, RgbHue, Xyz};
@@ -563,9 +563,23 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Rgb<S, T>, factor: T) -> Rgb<S, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<S, T> MixAssign for Rgb<S, T>
+where
+    S: RgbStandard<T, TransferFn = LinearFn>,
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -17,8 +17,8 @@ use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, contrast_ratio, from_f64, oklab, Alpha, Clamp, ClampAssign, ComponentWise,
-    FloatComponent, IsWithinBounds, Lab, Luma, Luv, Mix, Oklab, Oklch, Pixel, RelativeContrast,
-    Shade, Yxy,
+    FloatComponent, IsWithinBounds, Lab, Luma, Luv, Mix, MixAssign, Oklab, Oklch, Pixel,
+    RelativeContrast, Shade, Yxy,
 };
 
 /// CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in
@@ -396,9 +396,22 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Xyz<Wp, T>, factor: T) -> Xyz<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<Wp, T> MixAssign for Xyz<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -14,7 +14,7 @@ use crate::luma::LumaStandard;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, contrast_ratio, Alpha, Clamp, ClampAssign, Component, ComponentWise,
-    FloatComponent, IsWithinBounds, Luma, Mix, Pixel, RelativeContrast, Shade, Xyz,
+    FloatComponent, IsWithinBounds, Luma, Mix, MixAssign, Pixel, RelativeContrast, Shade, Xyz,
 };
 
 /// CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation
@@ -291,9 +291,22 @@ where
     type Scalar = T;
 
     #[inline]
-    fn mix(self, other: Yxy<Wp, T>, factor: T) -> Yxy<Wp, T> {
+    fn mix(self, other: Self, factor: T) -> Self {
         let factor = clamp(factor, T::zero(), T::one());
         self + (other - self) * factor
+    }
+}
+
+impl<Wp, T> MixAssign for Yxy<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn mix_assign(&mut self, other: Self, factor: T) {
+        let factor = clamp(factor, T::zero(), T::one());
+        *self += (other - *self) * factor;
     }
 }
 


### PR DESCRIPTION
This adds a `MixAssign` trait that allows interpolating without moving or cloning more than necessary. I have also removed the requirement that the `Scalar` implements `Float`.

## Breaking Change

Removing the `Float` requirement also removes the implication `T: Mix` -> `T::Scalar: Float`, possibly breaking some generic implementations (hence the changes in `gradinet`).
