### PR TITLE
Split `Shade` into `Lighten` and `Darken`, and add `*Assign` variants

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -133,11 +133,11 @@ This makes it possible to use Palette with any other crate that can convert thei
 Palette comes with a number of color operations built in, such as saturate/desaturate, hue shift, etc., in the form of operator traits. That means it's possible to write generic functions that perform these operation on any color space that supports them. The output will vary depending on the color space's characteristics.
 
 ```rust
-use palette::{Hue, Shade, Mix, Hsl, Hsv};
+use palette::{Hue, Lighten, Mix, Hsl, Hsv};
 
 fn transform_color<C>(color: C, amount: f32) -> C
 where
-    C: Hue + Shade<Scalar=f32> + Mix<Scalar=f32> + Copy,
+    C: Hue + Lighten<Scalar=f32> + Mix<Scalar=f32> + Copy,
     f32: Into<C::Hue>,
 {
     let new_color = color.shift_hue(170.0).lighten(1.0);

--- a/palette/examples/color_scheme.rs
+++ b/palette/examples/color_scheme.rs
@@ -1,4 +1,4 @@
-use palette::{Hue, IntoColor, Lch, LinSrgb, Pixel, Shade, Srgb};
+use palette::{Darken, Hue, IntoColor, Lch, Lighten, LinSrgb, Pixel, Srgb};
 
 use image::{GenericImage, GenericImageView, RgbImage, SubImage};
 
@@ -159,7 +159,10 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/color_scheme.png") {
         Ok(()) => println!("see 'example-data/output/color_scheme.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/color_scheme.png': {}", e),
+        Err(e) => println!(
+            "failed to write 'example-data/output/color_scheme.png': {}",
+            e
+        ),
     }
 }
 

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -52,11 +52,11 @@ fn pixels_and_buffers() {
 }
 
 fn color_operations_1() {
-    use palette::{Hsl, Hsv, Hue, Mix, Shade};
+    use palette::{Hsl, Hsv, Hue, Lighten, Mix};
 
     fn transform_color<C>(color: C, amount: f32) -> C
     where
-        C: Hue + Shade<Scalar = f32> + Mix<Scalar = f32> + Copy,
+        C: Hue + Lighten<Scalar = f32> + Mix<Scalar = f32> + Copy,
         f32: Into<C::Hue>,
     {
         let new_color = color.shift_hue(170.0).lighten(1.0);

--- a/palette/examples/shade.rs
+++ b/palette/examples/shade.rs
@@ -1,4 +1,4 @@
-use palette::{FromColor, Hsv, IntoColor, Lab, LinSrgb, Pixel, Shade, Srgb};
+use palette::{Darken, FromColor, Hsv, IntoColor, Lab, Lighten, LinSrgb, Pixel, Srgb};
 
 use image::{GenericImage, GenericImageView, RgbImage};
 

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -16,7 +16,7 @@ use crate::encoding::pixel::RawPixel;
 use crate::float::Float;
 use crate::{
     clamp, clamp_assign, Blend, Clamp, ClampAssign, Component, ComponentWise, GetHue, Hue,
-    IsWithinBounds, Mix, MixAssign, Pixel, Saturate, Shade, WithAlpha,
+    IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign, Pixel, Saturate, WithAlpha,
 };
 
 /// An alpha component wrapper for colors.
@@ -142,11 +142,11 @@ where
     }
 }
 
-impl<C: Shade> Shade for Alpha<C, C::Scalar> {
+impl<C: Lighten> Lighten for Alpha<C, C::Scalar> {
     type Scalar = C::Scalar;
 
     #[inline]
-    fn lighten(self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+    fn lighten(self, factor: C::Scalar) -> Self {
         Alpha {
             color: self.color.lighten(factor),
             alpha: self.alpha,
@@ -154,11 +154,25 @@ impl<C: Shade> Shade for Alpha<C, C::Scalar> {
     }
 
     #[inline]
-    fn lighten_fixed(self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+    fn lighten_fixed(self, amount: C::Scalar) -> Self {
         Alpha {
             color: self.color.lighten_fixed(amount),
             alpha: self.alpha,
         }
+    }
+}
+
+impl<C: LightenAssign> LightenAssign for Alpha<C, C::Scalar> {
+    type Scalar = C::Scalar;
+
+    #[inline]
+    fn lighten_assign(&mut self, factor: C::Scalar) {
+        self.color.lighten_assign(factor);
+    }
+
+    #[inline]
+    fn lighten_fixed_assign(&mut self, amount: C::Scalar) {
+        self.color.lighten_fixed_assign(amount);
     }
 }
 


### PR DESCRIPTION
I have split up `Shade` and given the traits more obvious names. I think the whole setup is nicer like this. Also added `*Assign` traits for them with implementations for `[T]`.

## Breaking Change

The `Shade` trait has been split up into `Lighten` and `Darken`, and `Scalar` is no longer implied to implement `Float`.
