### PR TITLE
Split the `Hue` trait into more specific traits

### DIFF
--- a/palette/README.md
+++ b/palette/README.md
@@ -133,12 +133,11 @@ This makes it possible to use Palette with any other crate that can convert thei
 Palette comes with a number of color operations built in, such as saturate/desaturate, hue shift, etc., in the form of operator traits. That means it's possible to write generic functions that perform these operation on any color space that supports them. The output will vary depending on the color space's characteristics.
 
 ```rust
-use palette::{Hue, Lighten, Mix, Hsl, Hsv};
+use palette::{Hsl, Hsv, Lighten, Mix, ShiftHue};
 
 fn transform_color<C>(color: C, amount: f32) -> C
 where
-    C: Hue + Lighten<Scalar=f32> + Mix<Scalar=f32> + Copy,
-    f32: Into<C::Hue>,
+    C: ShiftHue<Scalar = f32> + Lighten<Scalar = f32> + Mix<Scalar = f32> + Copy,
 {
     let new_color = color.shift_hue(170.0).lighten(1.0);
 

--- a/palette/examples/color_scheme.rs
+++ b/palette/examples/color_scheme.rs
@@ -1,4 +1,4 @@
-use palette::{Darken, Hue, IntoColor, Lch, Lighten, LinSrgb, Pixel, Srgb};
+use palette::{Darken, IntoColor, Lch, Lighten, LinSrgb, Pixel, ShiftHue, Srgb};
 
 use image::{GenericImage, GenericImageView, RgbImage, SubImage};
 

--- a/palette/examples/hue.rs
+++ b/palette/examples/hue.rs
@@ -1,4 +1,4 @@
-use palette::{FromColor, Hsl, Hue, Lch, Pixel, Srgb};
+use palette::{FromColor, Hsl, Lch, Pixel, ShiftHue, Srgb};
 
 fn main() {
     let mut image = image::open("example-data/input/fruits.png")

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -52,12 +52,11 @@ fn pixels_and_buffers() {
 }
 
 fn color_operations_1() {
-    use palette::{Hsl, Hsv, Hue, Lighten, Mix};
+    use palette::{Hsl, Hsv, Lighten, Mix, ShiftHue};
 
     fn transform_color<C>(color: C, amount: f32) -> C
     where
-        C: Hue + Lighten<Scalar = f32> + Mix<Scalar = f32> + Copy,
-        f32: Into<C::Hue>,
+        C: ShiftHue<Scalar = f32> + Lighten<Scalar = f32> + Mix<Scalar = f32> + Copy,
     {
         let new_color = color.shift_hue(170.0).lighten(1.0);
 

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -15,8 +15,9 @@ use crate::convert::{FromColorUnclamped, IntoColorUnclamped};
 use crate::encoding::pixel::RawPixel;
 use crate::float::Float;
 use crate::{
-    clamp, clamp_assign, Blend, Clamp, ClampAssign, Component, ComponentWise, GetHue, Hue,
-    IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign, Pixel, Saturate, WithAlpha,
+    clamp, clamp_assign, Blend, Clamp, ClampAssign, Component, ComponentWise, GetHue,
+    IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign, Pixel, Saturate, SetHue, ShiftHue,
+    ShiftHueAssign, WithAlpha, WithHue,
 };
 
 /// An alpha component wrapper for colors.
@@ -179,24 +180,55 @@ impl<C: LightenAssign> LightenAssign for Alpha<C, C::Scalar> {
 impl<C: GetHue, T> GetHue for Alpha<C, T> {
     type Hue = C::Hue;
 
+    #[inline]
     fn get_hue(&self) -> Option<C::Hue> {
         self.color.get_hue()
     }
 }
 
-impl<C: Hue, T: Clone> Hue for Alpha<C, T> {
-    fn with_hue<H: Into<C::Hue>>(self, hue: H) -> Alpha<C, T> {
-        Alpha {
-            color: self.color.with_hue(hue),
-            alpha: self.alpha,
-        }
+impl<C, T, H> WithHue<H> for Alpha<C, T>
+where
+    C: WithHue<H>,
+{
+    #[inline]
+    fn with_hue(mut self, hue: H) -> Self {
+        self.color = self.color.with_hue(hue);
+        self
     }
+}
 
-    fn shift_hue<H: Into<C::Hue>>(self, amount: H) -> Alpha<C, T> {
-        Alpha {
-            color: self.color.shift_hue(amount),
-            alpha: self.alpha,
-        }
+impl<C, T, H> SetHue<H> for Alpha<C, T>
+where
+    C: SetHue<H>,
+{
+    #[inline]
+    fn set_hue(&mut self, hue: H) {
+        self.color.set_hue(hue);
+    }
+}
+
+impl<C, T> ShiftHue for Alpha<C, T>
+where
+    C: ShiftHue,
+{
+    type Scalar = C::Scalar;
+
+    #[inline]
+    fn shift_hue(mut self, amount: Self::Scalar) -> Self {
+        self.color = self.color.shift_hue(amount);
+        self
+    }
+}
+
+impl<C, T> ShiftHueAssign for Alpha<C, T>
+where
+    C: ShiftHueAssign,
+{
+    type Scalar = C::Scalar;
+
+    #[inline]
+    fn shift_hue_assign(&mut self, amount: Self::Scalar) {
+        self.color.shift_hue_assign(amount);
     }
 }
 

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -17,8 +17,8 @@ use crate::encoding::Srgb;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
     clamp, clamp_assign, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign,
-    Component, FloatComponent, GetHue, Hsv, Hue, IsWithinBounds, Lighten, LightenAssign, Mix,
-    MixAssign, Pixel, RelativeContrast, RgbHue, Saturate, Xyz,
+    Component, FloatComponent, GetHue, Hsv, IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign,
+    Pixel, RelativeContrast, RgbHue, Saturate, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
 };
 #[cfg(feature = "random")]
 use crate::{float::Float, FromF64};
@@ -490,6 +490,7 @@ where
 {
     type Hue = RgbHue<T>;
 
+    #[inline]
     fn get_hue(&self) -> Option<RgbHue<T>> {
         if self.saturation <= T::zero() {
             None
@@ -499,20 +500,49 @@ where
     }
 }
 
-impl<S, T> Hue for Hsl<S, T>
+impl<S, T, H> WithHue<H> for Hsl<S, T>
 where
-    T: Zero + PartialOrd + Add<Output = T> + Clone,
+    H: Into<RgbHue<T>>,
 {
     #[inline]
-    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+    fn with_hue(mut self, hue: H) -> Self {
         self.hue = hue.into();
         self
     }
+}
+
+impl<S, T, H> SetHue<H> for Hsl<S, T>
+where
+    H: Into<RgbHue<T>>,
+{
+    #[inline]
+    fn set_hue(&mut self, hue: H) {
+        self.hue = hue.into();
+    }
+}
+
+impl<S, T> ShiftHue for Hsl<S, T>
+where
+    T: Add<Output = T>,
+{
+    type Scalar = T;
 
     #[inline]
-    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
-        self.hue = self.hue + amount.into();
+    fn shift_hue(mut self, amount: Self::Scalar) -> Self {
+        self.hue = self.hue + amount;
         self
+    }
+}
+
+impl<S, T> ShiftHueAssign for Hsl<S, T>
+where
+    T: AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn shift_hue_assign(&mut self, amount: Self::Scalar) {
+        self.hue += amount;
     }
 }
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -17,9 +17,10 @@ use crate::{
     encoding::pixel::RawPixel,
     luv_bounds::LuvBounds,
     white_point::{WhitePoint, D65},
-    Alpha, Clamp, ClampAssign, FloatComponent, FromF64, GetHue, Hue, IsWithinBounds, Lchuv,
-    Lighten, LightenAssign, LuvHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, Xyz,
+    Alpha, Clamp, ClampAssign, FloatComponent, FromF64, GetHue, IsWithinBounds, Lchuv, Lighten,
+    LightenAssign, LuvHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, WithHue, Xyz,
 };
+use crate::{SetHue, ShiftHue, ShiftHueAssign};
 
 /// HSLuv with an alpha component. See the [`Hsluva` implementation in
 /// `Alpha`](crate::Alpha#Hsluva).
@@ -362,6 +363,7 @@ where
 {
     type Hue = LuvHue<T>;
 
+    #[inline]
     fn get_hue(&self) -> Option<LuvHue<T>> {
         if self.saturation <= T::zero() {
             None
@@ -371,20 +373,49 @@ where
     }
 }
 
-impl<Wp, T> Hue for Hsluv<Wp, T>
+impl<Wp, T, H> WithHue<H> for Hsluv<Wp, T>
 where
-    T: Zero + PartialOrd + Clone,
+    H: Into<LuvHue<T>>,
 {
     #[inline]
-    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+    fn with_hue(mut self, hue: H) -> Self {
         self.hue = hue.into();
         self
     }
+}
+
+impl<Wp, T, H> SetHue<H> for Hsluv<Wp, T>
+where
+    H: Into<LuvHue<T>>,
+{
+    #[inline]
+    fn set_hue(&mut self, hue: H) {
+        self.hue = hue.into();
+    }
+}
+
+impl<Wp, T> ShiftHue for Hsluv<Wp, T>
+where
+    T: Add<Output = T>,
+{
+    type Scalar = T;
 
     #[inline]
-    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
-        self.hue = self.hue + amount.into();
+    fn shift_hue(mut self, amount: Self::Scalar) -> Self {
+        self.hue = self.hue + amount;
         self
+    }
+}
+
+impl<Wp, T> ShiftHueAssign for Hsluv<Wp, T>
+where
+    T: AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn shift_hue_assign(&mut self, amount: Self::Scalar) {
+        self.hue += amount;
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -17,8 +17,9 @@ use crate::encoding::Srgb;
 use crate::rgb::{Rgb, RgbSpace, RgbStandard};
 use crate::{
     clamp, clamp_assign, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign,
-    Component, FloatComponent, FromColor, GetHue, Hsl, Hue, Hwb, IsWithinBounds, Lighten,
-    LightenAssign, Mix, MixAssign, Pixel, RelativeContrast, RgbHue, Saturate, Xyz,
+    Component, FloatComponent, FromColor, GetHue, Hsl, Hwb, IsWithinBounds, Lighten, LightenAssign,
+    Mix, MixAssign, Pixel, RelativeContrast, RgbHue, Saturate, SetHue, ShiftHue, ShiftHueAssign,
+    WithHue, Xyz,
 };
 #[cfg(feature = "random")]
 use crate::{float::Float, FromF64};
@@ -509,6 +510,7 @@ where
 {
     type Hue = RgbHue<T>;
 
+    #[inline]
     fn get_hue(&self) -> Option<RgbHue<T>> {
         if self.saturation <= T::zero() || self.value <= T::zero() {
             None
@@ -518,20 +520,49 @@ where
     }
 }
 
-impl<S, T> Hue for Hsv<S, T>
+impl<S, T, H> WithHue<H> for Hsv<S, T>
 where
-    T: Zero + PartialOrd + Clone,
+    H: Into<RgbHue<T>>,
 {
     #[inline]
-    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+    fn with_hue(mut self, hue: H) -> Self {
         self.hue = hue.into();
         self
     }
+}
+
+impl<S, T, H> SetHue<H> for Hsv<S, T>
+where
+    H: Into<RgbHue<T>>,
+{
+    #[inline]
+    fn set_hue(&mut self, hue: H) {
+        self.hue = hue.into();
+    }
+}
+
+impl<S, T> ShiftHue for Hsv<S, T>
+where
+    T: Add<Output = T>,
+{
+    type Scalar = T;
 
     #[inline]
-    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
-        self.hue = self.hue + amount.into();
+    fn shift_hue(mut self, amount: Self::Scalar) -> Self {
+        self.hue = self.hue + amount;
         self
+    }
+}
+
+impl<S, T> ShiftHueAssign for Hsv<S, T>
+where
+    T: AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn shift_hue_assign(&mut self, amount: Self::Scalar) {
+        self.hue += amount;
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -16,8 +16,9 @@ use crate::encoding::pixel::RawPixel;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, clamp_min, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp,
-    ClampAssign, Float, FloatComponent, FromColor, FromF64, GetHue, Hue, IsWithinBounds, Lab,
-    LabHue, Lighten, LightenAssign, Mix, MixAssign, Pixel, RelativeContrast, Saturate, Xyz,
+    ClampAssign, Float, FloatComponent, FromColor, FromF64, GetHue, IsWithinBounds, Lab, LabHue,
+    Lighten, LightenAssign, Mix, MixAssign, Pixel, RelativeContrast, Saturate, SetHue, ShiftHue,
+    ShiftHueAssign, WithHue, Xyz,
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
@@ -350,6 +351,7 @@ where
 {
     type Hue = LabHue<T>;
 
+    #[inline]
     fn get_hue(&self) -> Option<LabHue<T>> {
         if self.chroma <= T::zero() {
             None
@@ -359,20 +361,49 @@ where
     }
 }
 
-impl<Wp, T> Hue for Lch<Wp, T>
+impl<Wp, T, H> WithHue<H> for Lch<Wp, T>
 where
-    T: Float + FromF64 + PartialOrd,
+    H: Into<LabHue<T>>,
 {
     #[inline]
-    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+    fn with_hue(mut self, hue: H) -> Self {
         self.hue = hue.into();
         self
     }
+}
+
+impl<Wp, T, H> SetHue<H> for Lch<Wp, T>
+where
+    H: Into<LabHue<T>>,
+{
+    #[inline]
+    fn set_hue(&mut self, hue: H) {
+        self.hue = hue.into();
+    }
+}
+
+impl<Wp, T> ShiftHue for Lch<Wp, T>
+where
+    T: Add<Output = T>,
+{
+    type Scalar = T;
 
     #[inline]
-    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
-        self.hue = self.hue + amount.into();
+    fn shift_hue(mut self, amount: Self::Scalar) -> Self {
+        self.hue = self.hue + amount;
         self
+    }
+}
+
+impl<Wp, T> ShiftHueAssign for Lch<Wp, T>
+where
+    T: AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn shift_hue_assign(&mut self, amount: Self::Scalar) {
+        self.hue += amount;
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -15,8 +15,9 @@ use crate::luv_bounds::LuvBounds;
 use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign,
-    FloatComponent, FromColor, FromF64, GetHue, Hsluv, Hue, IsWithinBounds, Lighten, LightenAssign,
-    Luv, LuvHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, Xyz,
+    FloatComponent, FromColor, FromF64, GetHue, Hsluv, IsWithinBounds, Lighten, LightenAssign, Luv,
+    LuvHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, SetHue, ShiftHue, ShiftHueAssign,
+    WithHue, Xyz,
 };
 
 /// CIE L\*C\*uv h°uv with an alpha component. See the [`Lchuva` implementation in
@@ -362,6 +363,7 @@ where
 {
     type Hue = LuvHue<T>;
 
+    #[inline]
     fn get_hue(&self) -> Option<LuvHue<T>> {
         if self.chroma <= T::zero() {
             None
@@ -371,20 +373,49 @@ where
     }
 }
 
-impl<Wp, T> Hue for Lchuv<Wp, T>
+impl<Wp, T, H> WithHue<H> for Lchuv<Wp, T>
 where
-    T: Zero + PartialOrd + Clone,
+    H: Into<LuvHue<T>>,
 {
     #[inline]
-    fn with_hue<H: Into<Self::Hue>>(mut self, hue: H) -> Self {
+    fn with_hue(mut self, hue: H) -> Self {
         self.hue = hue.into();
         self
     }
+}
+
+impl<Wp, T, H> SetHue<H> for Lchuv<Wp, T>
+where
+    H: Into<LuvHue<T>>,
+{
+    #[inline]
+    fn set_hue(&mut self, hue: H) {
+        self.hue = hue.into();
+    }
+}
+
+impl<Wp, T> ShiftHue for Lchuv<Wp, T>
+where
+    T: Add<Output = T>,
+{
+    type Scalar = T;
 
     #[inline]
-    fn shift_hue<H: Into<Self::Hue>>(mut self, amount: H) -> Self {
-        self.hue = self.hue + amount.into();
+    fn shift_hue(mut self, amount: Self::Scalar) -> Self {
+        self.hue = self.hue + amount;
         self
+    }
+}
+
+impl<Wp, T> ShiftHueAssign for Lchuv<Wp, T>
+where
+    T: AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn shift_hue_assign(&mut self, amount: Self::Scalar) {
+        self.hue += amount;
     }
 }
 


### PR DESCRIPTION
The `Hue` trait is split into more specific single-purpose traits and `*Assign` variants have been added. Although the naming is a bit different here. I didn't like the idea of having `SetHueAssign` or `WithHueAssign`, so went with the `WithHue` & `SetHue` combo. I'm thinking that's fine with traits that set fixed values, like `WithAlpha` from before.


## Breaking Change

`Hue` has been split up and renamed. Use `WithHue` or `ShiftHue` to get the methods from `Hue`. `WithHue` is also parametric over the hue type, instead of the methods having a type parameter.
