### PR TITLE
Split Saturate into Saturate and Desaturate

### DIFF
--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -16,8 +16,8 @@ use crate::encoding::pixel::RawPixel;
 use crate::float::Float;
 use crate::{
     clamp, clamp_assign, Blend, Clamp, ClampAssign, Component, ComponentWise, GetHue,
-    IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign, Pixel, Saturate, SetHue, ShiftHue,
-    ShiftHueAssign, WithAlpha, WithHue,
+    IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign, Pixel, Saturate, SaturateAssign,
+    SetHue, ShiftHue, ShiftHueAssign, WithAlpha, WithHue,
 };
 
 /// An alpha component wrapper for colors.
@@ -236,7 +236,7 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
     type Scalar = C::Scalar;
 
     #[inline]
-    fn saturate(self, factor: C::Scalar) -> Alpha<C, C::Scalar> {
+    fn saturate(self, factor: C::Scalar) -> Self {
         Alpha {
             color: self.color.saturate(factor),
             alpha: self.alpha,
@@ -244,11 +244,25 @@ impl<C: Saturate> Saturate for Alpha<C, C::Scalar> {
     }
 
     #[inline]
-    fn saturate_fixed(self, amount: C::Scalar) -> Alpha<C, C::Scalar> {
+    fn saturate_fixed(self, amount: C::Scalar) -> Self {
         Alpha {
             color: self.color.saturate_fixed(amount),
             alpha: self.alpha,
         }
+    }
+}
+
+impl<C: SaturateAssign> SaturateAssign for Alpha<C, C::Scalar> {
+    type Scalar = C::Scalar;
+
+    #[inline]
+    fn saturate_assign(&mut self, factor: C::Scalar) {
+        self.color.saturate_assign(factor);
+    }
+
+    #[inline]
+    fn saturate_fixed_assign(&mut self, amount: C::Scalar) {
+        self.color.saturate_fixed_assign(amount);
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -16,8 +16,8 @@ use crate::white_point::{WhitePoint, D65};
 use crate::{
     clamp, clamp_assign, clamp_min_assign, contrast_ratio, from_f64, Alpha, Clamp, ClampAssign,
     FloatComponent, FromColor, FromF64, GetHue, Hsluv, IsWithinBounds, Lighten, LightenAssign, Luv,
-    LuvHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, SetHue, ShiftHue, ShiftHueAssign,
-    WithHue, Xyz,
+    LuvHue, Mix, MixAssign, Pixel, RelativeContrast, Saturate, SaturateAssign, SetHue, ShiftHue,
+    ShiftHueAssign, WithHue, Xyz,
 };
 
 /// CIE L\*C\*uv h°uv with an alpha component. See the [`Lchuva` implementation in
@@ -426,7 +426,7 @@ where
     type Scalar = T;
 
     #[inline]
-    fn saturate(self, factor: T) -> Lchuv<Wp, T> {
+    fn saturate(self, factor: T) -> Self {
         let difference = if factor >= T::zero() {
             Self::max_chroma() - self.chroma
         } else {
@@ -444,13 +444,38 @@ where
     }
 
     #[inline]
-    fn saturate_fixed(self, amount: T) -> Lchuv<Wp, T> {
+    fn saturate_fixed(self, amount: T) -> Self {
         Lchuv {
             l: self.l,
             chroma: (self.chroma + Self::max_chroma() * amount).max(T::zero()),
             hue: self.hue,
             white_point: PhantomData,
         }
+    }
+}
+
+impl<Wp, T> SaturateAssign for Lchuv<Wp, T>
+where
+    T: FloatComponent + AddAssign,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn saturate_assign(&mut self, factor: T) {
+        let difference = if factor >= T::zero() {
+            Self::max_chroma() - self.chroma
+        } else {
+            self.chroma
+        };
+
+        self.chroma += difference.max(T::zero()) * factor;
+        clamp_min_assign(&mut self.chroma, Self::min_chroma());
+    }
+
+    #[inline]
+    fn saturate_fixed_assign(&mut self, amount: T) {
+        self.chroma += Self::max_chroma() * amount;
+        clamp_min_assign(&mut self.chroma, Self::min_chroma());
     }
 }
 


### PR DESCRIPTION
The `Saturate` trait is split to give us a separate `Desaturate` trait, and `*Assign` variants are added. Just like how `Shade` was changed. I did also notice a small bug in how `DarkenAssign` was blanket implemented.

## Breaking Change

`desaturate` and `desaturate_fixed` have been moved into a `Desaturate` trait. `Saturate` does also not require/imply `Sized`, and `Saturate::Scalar` does no longer require/imply `Float`.