### PR TITLE
Implement SIMD support and add `wide` integration

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,8 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-      - uses: boa-dev/criterion-compare-action@master
+      - uses: boa-dev/criterion-compare-action@v3.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branchName: ${{ github.base_ref }}
+          features: "wide"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
     "rust-analyzer.cargo.features": [
         "random",
         "serializing",
-        "bytemuck"
+        "bytemuck",
+        "wide"
     ],
     "rust-analyzer.assist.importEnforceGranularity": true,
     "rust-analyzer.assist.importGranularity": "crate",

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -62,6 +62,11 @@ optional = true
 version = "1"
 optional = true
 
+[dependencies.wide]
+version = "0.7.3"
+optional = true
+default-features = false
+
 [dev-dependencies]
 csv = "1"
 lazy_static = "1"

--- a/palette/README.md
+++ b/palette/README.md
@@ -51,6 +51,7 @@ These features are disabled by default:
 * `"random"` - Enables generating random colors using [`rand`].
 * `"libm"` - Uses the [`libm`] floating point math library (for when the `std` feature is disabled).
 * `"bytemuck"` - Enables casting between plain data types using [`bytemuck`].
+* `"wide"` - Enables support for using SIMD types from [`wide`].
 
 ### Using palette in an embedded environment
 
@@ -351,3 +352,4 @@ at your option.
 [`rand`]: https://crates.io/crates/rand
 [`libm`]: https://crates.io/crates/libm
 [`bytemuck`]: https://crates.io/crates/bytemuck
+[`wide`]: https://crates.io/crates/wide

--- a/palette/benches/matrix.rs
+++ b/palette/benches/matrix.rs
@@ -13,13 +13,14 @@ fn matrix(c: &mut Criterion) {
 
     let inp1 = [0.1, 0.2, 0.3, 0.3, 0.2, 0.1, 0.2, 0.1, 0.3];
     let inp2 = Xyz::new(0.4, 0.6, 0.8);
-    let inp3 = [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
+    let inp3 = [1.0f32, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
     let inp4 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
-    let inverse: [f64; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
-    let color = LinSrgb::new(0.2f64, 0.8, 0.4);
-    let mat3 = rgb_to_xyz_matrix::<encoding::Srgb, f64>();
-    let wp: Xyz<D65, f64> = D65::get_xyz().with_white_point();
+    let inverse: [f32; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
+    let color = LinSrgb::new(0.2f32, 0.8, 0.4);
+    let mat3 = rgb_to_xyz_matrix::<encoding::Srgb, f32>();
+    let wp: Xyz<D65, f32> = D65::get_xyz().with_white_point();
 
+    group.throughput(criterion::Throughput::Elements(1));
     group.bench_function("multiply_xyz", |b| {
         b.iter(|| multiply_xyz::<_>(black_box(inp1), black_box(inp2)))
     });
@@ -36,7 +37,7 @@ fn matrix(c: &mut Criterion) {
         b.iter(|| matrix_inverse(*inverse))
     });
     group.bench_function("rgb_to_xyz_matrix", |b| {
-        b.iter(|| rgb_to_xyz_matrix::<encoding::Srgb, f64>())
+        b.iter(|| rgb_to_xyz_matrix::<encoding::Srgb, f32>())
     });
 }
 

--- a/palette/benches/matrix.rs
+++ b/palette/benches/matrix.rs
@@ -16,7 +16,7 @@ fn matrix(c: &mut Criterion) {
     let inp3 = [1.0, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
     let inp4 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
     let inverse: [f64; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
-    let color = LinSrgb::new(0.2, 0.8, 0.4);
+    let color = LinSrgb::new(0.2f64, 0.8, 0.4);
     let mat3 = rgb_to_xyz_matrix::<encoding::Srgb, f64>();
     let wp: Xyz<D65, f64> = D65::get_xyz().with_white_point();
 
@@ -24,7 +24,7 @@ fn matrix(c: &mut Criterion) {
         b.iter(|| multiply_xyz::<_>(black_box(inp1), black_box(inp2)))
     });
     group.bench_function("multiply_xyz_to_rgb", |b| {
-        b.iter(|| multiply_xyz_to_rgb::<encoding::Srgb, _>(black_box(inp1), black_box(wp)))
+        b.iter(|| multiply_xyz_to_rgb::<encoding::Srgb, _, _>(black_box(inp1), black_box(wp)))
     });
     group.bench_function("multiply_rgb_to_xyz", |b| {
         b.iter(|| multiply_rgb_to_xyz(black_box(mat3), black_box(color)))

--- a/palette/src/angle.rs
+++ b/palette/src/angle.rs
@@ -1,6 +1,12 @@
 //! Traits for working with angular values, such as for in hues.
 
-use crate::num::{Real, Round};
+use crate::{
+    bool_mask::HasBoolMask,
+    num::{Real, Round},
+};
+
+#[cfg(feature = "wide")]
+mod wide;
 
 /// Represents types that can express half of a rotation (i.e. 180 degrees).
 pub trait HalfRotation {
@@ -29,10 +35,10 @@ pub trait RealAngle: Real {
 }
 
 /// Angular equality, where 0 degrees and 360 degrees are equal.
-pub trait AngleEq: PartialEq {
+pub trait AngleEq: HasBoolMask {
     /// Check if `self` and `other` represent the same angle on a circle.
     #[must_use]
-    fn angle_eq(&self, other: &Self) -> bool;
+    fn angle_eq(&self, other: &Self) -> Self::Mask;
 }
 
 /// Angle types that can represent the full circle using positive and negative

--- a/palette/src/angle/wide.rs
+++ b/palette/src/angle/wide.rs
@@ -1,0 +1,58 @@
+use ::wide::{f32x4, f32x8, f64x2, f64x4, CmpEq};
+
+use super::*;
+
+macro_rules! impl_angle_wide_float {
+    ($($ty: ident),+) => {
+        $(
+            impl HalfRotation for $ty {
+                #[inline]
+                fn half_rotation() -> Self {
+                    $ty::splat(180.0)
+                }
+            }
+
+            impl FullRotation for $ty {
+                #[inline]
+                fn full_rotation() -> Self {
+                    $ty::splat(360.0)
+                }
+            }
+
+            impl RealAngle for $ty {
+                #[inline]
+                fn degrees_to_radians(self) -> Self {
+                    self.to_radians()
+                }
+
+                #[inline]
+                fn radians_to_degrees(self) -> Self {
+                    self.to_degrees()
+                }
+            }
+
+            impl AngleEq for $ty {
+                #[inline]
+                fn angle_eq(&self, other: &Self) -> Self {
+                    self.normalize_unsigned_angle().cmp_eq(other.normalize_unsigned_angle())
+                }
+            }
+
+            impl SignedAngle for $ty {
+                #[inline]
+                fn normalize_signed_angle(self) -> Self {
+                    self - Round::ceil(((self + 180.0) / 360.0) - 1.0) * 360.0
+                }
+            }
+
+            impl UnsignedAngle for $ty {
+                #[inline]
+                fn normalize_unsigned_angle(self) -> Self {
+                    self - (Round::floor(self / 360.0) * 360.0)
+                }
+            }
+        )+
+    };
+}
+
+impl_angle_wide_float!(f32x4, f32x8, f64x2, f64x4);

--- a/palette/src/blend.rs
+++ b/palette/src/blend.rs
@@ -38,7 +38,7 @@
 use crate::{
     cast::{self, ArrayCast},
     clamp,
-    num::{Arithmetics, One, Real, Zero},
+    num::{Arithmetics, Clamp, One, Real, Zero},
     stimulus::Stimulus,
 };
 
@@ -101,7 +101,7 @@ pub trait Premultiply: Sized {
 
 fn blend_alpha<T>(src: T, dst: T) -> T
 where
-    T: Zero + One + Arithmetics + PartialOrd + Clone,
+    T: Zero + One + Arithmetics + Clamp + Clone,
 {
     clamp(src.clone() + &dst - src * dst, T::zero(), T::one())
 }

--- a/palette/src/blend/compose.rs
+++ b/palette/src/blend/compose.rs
@@ -1,7 +1,7 @@
 use crate::{
     cast::ArrayCast,
     clamp,
-    num::{Arithmetics, One, Real, Zero},
+    num::{Arithmetics, Clamp, One, Real, Zero},
     stimulus::Stimulus,
     Alpha,
 };
@@ -47,7 +47,7 @@ pub trait Compose {
 impl<C, T, const N: usize> Compose for PreAlpha<C>
 where
     C: ArrayCast<Array = [T; N]> + Premultiply<Scalar = T>,
-    T: Real + Zero + One + Arithmetics + PartialOrd + Clone,
+    T: Real + Zero + One + Arithmetics + Clamp + Clone,
 {
     #[inline]
     fn over(self, mut other: Self) -> Self {

--- a/palette/src/blend/equations.rs
+++ b/palette/src/blend/equations.rs
@@ -73,7 +73,7 @@ where
         + Mul<S, Output = C>
         + ArrayCast<Array = [S; N]>,
     PreAlpha<C>: ArrayCast<Array = [S; M]>,
-    S: Real + One + Zero + MinMax + Sqrt + IsValidDivisor + Arithmetics + PartialOrd + Clone,
+    S: Real + One + Zero + MinMax + Sqrt + IsValidDivisor + Arithmetics + Clone,
 {
     fn apply_to(self, source: PreAlpha<C>, destination: PreAlpha<C>) -> PreAlpha<C> {
         let (src_color, mut dst_color) =

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -5,7 +5,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use crate::{
     cast::ArrayCast,
     clamp,
-    num::{Arithmetics, One, Real, Zero},
+    num::{self, Arithmetics, One, Real, Zero},
     stimulus::Stimulus,
     Alpha, ArrayExt, Mix, MixAssign, NextArray,
 };
@@ -125,7 +125,7 @@ where
 impl<C, T> Mix for PreAlpha<C>
 where
     C: Mix<Scalar = T> + Premultiply<Scalar = T>,
-    T: Real + Zero + One + PartialOrd + Arithmetics + Clone,
+    T: Real + Zero + One + num::Clamp + Arithmetics + Clone,
 {
     type Scalar = T;
 
@@ -143,7 +143,7 @@ where
 impl<C, T> MixAssign for PreAlpha<C>
 where
     C: MixAssign<Scalar = T> + Premultiply<Scalar = T>,
-    T: Real + Zero + One + PartialOrd + Arithmetics + AddAssign + Clone,
+    T: Real + Zero + One + num::Clamp + Arithmetics + AddAssign + Clone,
 {
     type Scalar = T;
 

--- a/palette/src/bool_mask.rs
+++ b/palette/src/bool_mask.rs
@@ -1,0 +1,175 @@
+//! Traits for abstracting over Boolean types.
+//!
+//! These traits are mainly useful for allowing SIMD values, where bit masks are
+//! typically used instead of `bool`.
+
+use core::ops::{BitAnd, BitOr, BitXor, Not};
+
+#[cfg(feature = "wide")]
+mod wide;
+
+/// Associates a Boolean type to the implementing type.
+///
+/// This is primarily used in traits and functions that can accept SIMD values
+/// and return a Boolean result. SIMD values use masks to select different values for
+/// each lane and `HasBoolMask::Mask` can be used to know which type that mask
+/// has.
+pub trait HasBoolMask {
+    /// The mask type to use for selecting `Self` values.
+    type Mask: BoolMask;
+}
+
+impl<T> HasBoolMask for &'_ T
+where
+    T: HasBoolMask,
+{
+    type Mask = T::Mask;
+}
+
+impl<T> HasBoolMask for &'_ mut T
+where
+    T: HasBoolMask,
+{
+    type Mask = T::Mask;
+}
+
+impl<T> HasBoolMask for [T]
+where
+    T: HasBoolMask,
+{
+    type Mask = T::Mask;
+}
+
+impl<T, const N: usize> HasBoolMask for [T; N]
+where
+    T: HasBoolMask,
+{
+    type Mask = T::Mask;
+}
+
+macro_rules! impl_has_bool_mask {
+    ($($ty:ident),+) => {
+        $(
+            impl HasBoolMask for $ty {
+                type Mask = bool;
+            }
+        )+
+    };
+}
+
+impl_has_bool_mask!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);
+
+/// Basic methods for boolean masks.
+pub trait BoolMask {
+    /// Create a new mask where each lane is set to `value`.
+    #[must_use]
+    fn from_bool(value: bool) -> Self;
+
+    /// Checks if all lanes in the mask are `true`.
+    #[must_use]
+    fn is_true(&self) -> bool;
+
+    /// Checks if all lanes in the mask are `false`.
+    #[must_use]
+    fn is_false(&self) -> bool;
+}
+
+impl BoolMask for bool {
+    #[inline]
+    fn from_bool(value: bool) -> Self {
+        value
+    }
+
+    #[inline]
+    fn is_true(&self) -> bool {
+        *self
+    }
+
+    #[inline]
+    fn is_false(&self) -> bool {
+        !*self
+    }
+}
+
+/// Makes a mask bale to select between two values.
+pub trait Select<T>
+where
+    T: HasBoolMask<Mask = Self>,
+{
+    /// Select lanes from `a` when corresponding lanes in `self` are `true`, and
+    /// select from `b` when `false`.
+    #[must_use]
+    fn select(self, a: T, b: T) -> T;
+}
+
+impl<T> Select<T> for bool
+where
+    T: HasBoolMask<Mask = Self>,
+{
+    #[inline(always)]
+    fn select(self, a: T, b: T) -> T {
+        if self {
+            a
+        } else {
+            b
+        }
+    }
+}
+
+/// Like [`Select`], but can avoid evaluating the input.
+pub trait LazySelect<T>: Select<T>
+where
+    T: HasBoolMask<Mask = Self>,
+{
+    /// Select lanes from the output of `a` when corresponding lanes in `self`
+    /// are `true`, and select from the output of `b` when `false`. May avoid
+    /// evaluating either option if it's not selected.
+    #[must_use]
+    fn lazy_select<A, B>(self, a: A, b: B) -> T
+    where
+        A: FnOnce() -> T,
+        B: FnOnce() -> T;
+}
+
+impl<T> LazySelect<T> for bool
+where
+    T: HasBoolMask<Mask = Self>,
+{
+    #[inline(always)]
+    fn lazy_select<A, B>(self, a: A, b: B) -> T
+    where
+        A: FnOnce() -> T,
+        B: FnOnce() -> T,
+    {
+        if self {
+            a()
+        } else {
+            b()
+        }
+    }
+}
+
+/// A helper trait that collects bit traits under one name.
+pub trait BitOps:
+    Sized
+    + BitAnd<Output = Self>
+    + BitOr<Output = Self>
+    + BitXor<Output = Self>
+    + Not<Output = Self>
+    + for<'a> BitAnd<&'a Self, Output = Self>
+    + for<'a> BitOr<&'a Self, Output = Self>
+    + for<'a> BitXor<&'a Self, Output = Self>
+{
+}
+
+impl<T> BitOps for T where
+    T: Sized
+        + BitAnd<Output = Self>
+        + BitOr<Output = Self>
+        + BitXor<Output = Self>
+        + Not<Output = Self>
+        + for<'a> BitAnd<&'a Self, Output = Self>
+        + for<'a> BitOr<&'a Self, Output = Self>
+        + for<'a> BitXor<&'a Self, Output = Self>
+{
+}

--- a/palette/src/bool_mask/wide.rs
+++ b/palette/src/bool_mask/wide.rs
@@ -1,0 +1,95 @@
+use wide::{f32x4, f32x8, f64x2, f64x4};
+
+use super::{BoolMask, HasBoolMask, LazySelect, Select};
+
+macro_rules! impl_wide_bool_mask {
+    ($($ty: ident: ($scalar: ident, $uint: ident)),+) => {
+        $(
+            impl BoolMask for $ty {
+                #[inline]
+                fn from_bool(value: bool) -> Self {
+                    $ty::splat(if value { $scalar::from_bits($uint::MAX) } else { 0.0 })
+                }
+
+                #[inline]
+                fn is_true(&self) -> bool {
+                    self.all()
+                }
+
+                #[inline]
+                fn is_false(&self) -> bool {
+                    self.none()
+                }
+            }
+
+            impl HasBoolMask for $ty {
+                type Mask = Self;
+            }
+
+            impl Select<Self> for $ty {
+                #[inline]
+                fn select(self, a: Self, b: Self) -> Self {
+                    self.blend(a, b)
+                }
+            }
+
+            impl LazySelect<Self> for $ty {
+                #[inline]
+                fn lazy_select<A, B>(self, a: A, b: B) -> Self
+                where
+                    A: FnOnce() -> Self,
+                    B: FnOnce() -> Self,
+                {
+                    let a = a();
+                    let b = b();
+
+                    self.select(a, b)
+                }
+            }
+        )+
+    };
+}
+
+impl_wide_bool_mask!(
+    f32x4: (f32, u32),
+    f32x8: (f32, u32),
+    f64x2: (f64, u64),
+    f64x4: (f64, u64)
+);
+
+#[cfg(test)]
+mod test {
+    use wide::{f32x4, f32x8, f64x2, f64x4};
+
+    use crate::bool_mask::BoolMask;
+
+    #[test]
+    fn from_true() {
+        assert!(f32x4::from_bool(true).is_true());
+        assert!(!f32x4::from_bool(true).is_false());
+
+        assert!(f32x8::from_bool(true).is_true());
+        assert!(!f32x8::from_bool(true).is_false());
+
+        assert!(f64x2::from_bool(true).is_true());
+        assert!(!f64x2::from_bool(true).is_false());
+
+        assert!(f64x4::from_bool(true).is_true());
+        assert!(!f64x4::from_bool(true).is_false());
+    }
+
+    #[test]
+    fn from_false() {
+        assert!(f32x4::from_bool(false).is_false());
+        assert!(!f32x4::from_bool(false).is_true());
+
+        assert!(f32x8::from_bool(false).is_false());
+        assert!(!f32x8::from_bool(false).is_true());
+
+        assert!(f64x2::from_bool(false).is_false());
+        assert!(!f64x2::from_bool(false).is_true());
+
+        assert!(f64x4::from_bool(false).is_false());
+        assert!(!f64x4::from_bool(false).is_true());
+    }
+}

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -294,11 +294,14 @@ mod tests {
     use core::marker::PhantomData;
 
     use super::{FromColor, FromColorUnclamped, IntoColor};
-    use crate::encoding::linear::Linear;
-    use crate::luma::{Luma, LumaStandard};
-    use crate::num::{One, Zero};
-    use crate::rgb::{Rgb, RgbSpace};
-    use crate::{Alpha, Clamp, Hsl, Hsluv, Hsv, Hwb, IsWithinBounds, Lab, Lch, Luv, Xyz, Yxy};
+    use crate::{
+        bool_mask::{BoolMask, HasBoolMask},
+        encoding::linear::Linear,
+        luma::{Luma, LumaStandard},
+        num::{One, Zero},
+        rgb::{Rgb, RgbSpace},
+        Alpha, Clamp, Hsl, Hsluv, Hsv, Hwb, IsWithinBounds, Lab, Lch, Luv, Xyz, Yxy,
+    };
 
     #[derive(FromColorUnclamped, WithAlpha)]
     #[palette(
@@ -317,6 +320,10 @@ mod tests {
     }
 
     impl<S> Copy for WithXyz<S> {}
+
+    impl<S> HasBoolMask for WithXyz<S> {
+        type Mask = bool;
+    }
 
     impl<S> IsWithinBounds for WithXyz<S> {
         fn is_within_bounds(&self) -> bool {
@@ -379,9 +386,19 @@ mod tests {
     )]
     struct WithoutXyz<T>(PhantomData<T>);
 
-    impl<T> IsWithinBounds for WithoutXyz<T> {
-        fn is_within_bounds(&self) -> bool {
-            true
+    impl<T> HasBoolMask for WithoutXyz<T>
+    where
+        T: HasBoolMask,
+    {
+        type Mask = T::Mask;
+    }
+
+    impl<T> IsWithinBounds for WithoutXyz<T>
+    where
+        T: HasBoolMask,
+    {
+        fn is_within_bounds(&self) -> T::Mask {
+            T::Mask::from_bool(true)
         }
     }
 

--- a/palette/src/convert/from_into_color.rs
+++ b/palette/src/convert/from_into_color.rs
@@ -43,7 +43,7 @@ pub trait FromColor<T>: Sized {
     /// ```
     /// use palette::{IsWithinBounds, FromColor, Lch, Srgb};
     ///
-    /// let rgb = Srgb::from_color(Lch::new(50.0, 100.0, -175.0));
+    /// let rgb = Srgb::from_color(Lch::new(50.0f32, 100.0, -175.0));
     /// assert!(rgb.is_within_bounds());
     /// ```
     #[must_use]

--- a/palette/src/convert/from_into_color_unclamped.rs
+++ b/palette/src/convert/from_into_color_unclamped.rs
@@ -18,7 +18,7 @@ pub trait FromColorUnclamped<T>: Sized {
     /// use palette::convert::FromColorUnclamped;
     /// use palette::{IsWithinBounds, Lch, Srgb};
     ///
-    /// let rgb = Srgb::from_color_unclamped(Lch::new(50.0, 100.0, -175.0));
+    /// let rgb = Srgb::from_color_unclamped(Lch::new(50.0f32, 100.0, -175.0));
     /// assert!(!rgb.is_within_bounds());
     /// ```
     #[must_use]

--- a/palette/src/convert/try_from_into_color.rs
+++ b/palette/src/convert/try_from_into_color.rs
@@ -70,7 +70,7 @@ pub trait TryFromColor<T>: Sized {
 
 impl<T, U> TryFromColor<T> for U
 where
-    U: FromColorUnclamped<T> + IsWithinBounds,
+    U: FromColorUnclamped<T> + IsWithinBounds<Mask = bool>,
 {
     #[inline]
     fn try_from_color(t: T) -> Result<Self, OutOfBounds<Self>> {

--- a/palette/src/encoding/srgb.rs
+++ b/palette/src/encoding/srgb.rs
@@ -4,7 +4,7 @@ use crate::{
     bool_mask::LazySelect,
     encoding::TransferFn,
     luma::LumaStandard,
-    num::{Arithmetics, One, PartialCmp, Powf, Real, Recip},
+    num::{Arithmetics, MulAdd, MulSub, One, PartialCmp, Powf, Real},
     rgb::{Primaries, RgbSpace, RgbStandard},
     white_point::{Any, WhitePoint, D65},
     Yxy,
@@ -66,21 +66,21 @@ where
 
 impl<T> TransferFn<T> for Srgb
 where
-    T: Real + One + Powf + Recip + Arithmetics + PartialCmp + Clone,
+    T: Real + One + Powf + MulAdd + MulSub + Arithmetics + PartialCmp + Clone,
     T::Mask: LazySelect<T>,
 {
     fn into_linear(x: T) -> T {
-        // Recip call shows performance benefits in benchmarks for this function
+        // Dividing the constants directly shows performance benefits in benchmarks for this function
         lazy_select! {
-            if x.lt_eq(&T::from_f64(0.04045)) => T::from_f64(12.92).recip() * &x,
-            else => ((T::from_f64(0.055) + &x) * T::from_f64(1.055).recip()).powf(T::from_f64(2.4)),
+            if x.lt_eq(&T::from_f64(0.04045)) => T::from_f64(1.0 / 12.92) * &x,
+            else => x.clone().mul_add(T::from_f64(1.0 / 1.055), T::from_f64(0.055 / 1.055)).powf(T::from_f64(2.4)),
         }
     }
 
     fn from_linear(x: T) -> T {
         lazy_select! {
             if x.lt_eq(&T::from_f64(0.0031308)) => T::from_f64(12.92) * &x,
-            else => x.clone().powf(T::one() / T::from_f64(2.4)) * T::from_f64(1.055) - T::from_f64(0.055),
+            else => x.clone().powf(T::from_f64(1.0 / 2.4)).mul_sub(T::from_f64(1.055), T::from_f64(0.055)),
         }
     }
 }

--- a/palette/src/gradient.rs
+++ b/palette/src/gradient.rs
@@ -9,7 +9,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 use crate::{
     clamp, clamp_min,
-    num::{Arithmetics, One, Real, Zero},
+    num::{Arithmetics, Clamp, One, Real, Zero},
     Mix,
 };
 
@@ -220,7 +220,7 @@ where
 
 impl<'a, C, T> Iterator for Take<'a, C, T>
 where
-    C::Scalar: Real + Arithmetics + PartialOrd + Clone,
+    C::Scalar: Real + Clamp + Arithmetics + PartialOrd + Clone,
     C: Mix + Clone,
     T: AsRef<[(C::Scalar, C)]>,
 {
@@ -253,7 +253,7 @@ where
 
 impl<'a, C, T> DoubleEndedIterator for Take<'a, C, T>
 where
-    C::Scalar: Real + Arithmetics + PartialOrd + Clone,
+    C::Scalar: Real + Clamp + Arithmetics + PartialOrd + Clone,
     C: Mix + Clone,
     T: AsRef<[(C::Scalar, C)]>,
 {
@@ -301,7 +301,7 @@ where
 impl<'a, C, T> Slice<'a, C, T>
 where
     C: Mix + 'a,
-    C::Scalar: Arithmetics + PartialOrd + Clone,
+    C::Scalar: Clamp + Arithmetics + PartialOrd + Clone,
 {
     /// Get a color from the gradient slice. The color of the closest domain
     /// limit will be returned if `i` is outside the domain.
@@ -351,7 +351,7 @@ impl<'a, C, T> Slice<'a, C, T>
 where
     C: Mix + 'a,
     T: Clone,
-    C::Scalar: Arithmetics + PartialOrd + Clone,
+    C::Scalar: Clamp + Arithmetics + PartialOrd + Clone,
 {
     /// Take `n` evenly spaced colors from the gradient slice, as an iterator.
     pub fn take(&self, n: usize) -> Take<C, T>
@@ -380,7 +380,7 @@ pub struct Range<T> {
 
 impl<T> Range<T>
 where
-    T: PartialOrd + Clone,
+    T: Clamp + PartialOrd + Clone,
 {
     fn clamp(&self, x: T) -> T {
         let min = self.from.clone().unwrap_or(x.clone());
@@ -569,7 +569,7 @@ where
 impl<'a, C, T> MaybeSlice<'a, C, T>
 where
     C: Mix + Clone + 'a,
-    C::Scalar: Arithmetics + PartialOrd + Clone,
+    C::Scalar: Clamp + Arithmetics + PartialOrd + Clone,
     T: AsRef<[(C::Scalar, C)]>,
 {
     fn get(&self, i: C::Scalar) -> C {

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -1,7 +1,7 @@
 use core::{
     any::TypeId,
     marker::PhantomData,
-    ops::{Add, AddAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, BitAnd, Not, Sub, SubAssign},
 };
 
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
@@ -19,10 +19,14 @@ use crate::num::{Cbrt, Powi, Sqrt};
 
 use crate::{
     angle::{FromAngle, RealAngle, SignedAngle},
+    bool_mask::{BitOps, HasBoolMask, LazySelect, Select},
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
     encoding::Srgb,
-    num::{Arithmetics, IsValidDivisor, MinMax, One, Real, Zero},
+    num::{
+        self, Arithmetics, FromScalarArray, IntoScalarArray, IsValidDivisor, MinMax, One,
+        PartialCmp, Real, Zero,
+    },
     rgb::{Rgb, RgbSpace, RgbStandard},
     stimulus::{FromStimulus, Stimulus},
     Alpha, Clamp, ClampAssign, FromColor, GetHue, Hsv, IsWithinBounds, Lighten, LightenAssign, Mix,
@@ -293,57 +297,79 @@ where
 
 impl<S, T> FromColorUnclamped<Rgb<S, T>> for Hsl<S, T>
 where
-    T: Real + Zero + One + MinMax + Arithmetics + PartialOrd + Clone,
+    T: RealAngle + Zero + One + MinMax + Arithmetics + PartialCmp + Clone,
+    T::Mask: BitOps + LazySelect<T> + Clone,
 {
-    fn from_color_unclamped(mut rgb: Rgb<S, T>) -> Self {
+    fn from_color_unclamped(rgb: Rgb<S, T>) -> Self {
+        // Based on OPTIMIZED RGB TO HSV COLOR CONVERSION USING SSE TECHNOLOGY
+        // by KOBALICEK, Petr & BLIZNAK, Michal
+        //
+        // This implementation assumes less about the underlying mask and number
+        // representation. The hue is also multiplied by 6 to avoid rounding
+        // errors when using degrees.
+
+        let six = T::from_f64(6.0);
+
         // Avoid negative numbers
-        rgb.red = rgb.red.max(T::zero());
-        rgb.green = rgb.green.max(T::zero());
-        rgb.blue = rgb.blue.max(T::zero());
+        let red = rgb.red.max(T::zero());
+        let green = rgb.green.max(T::zero());
+        let blue = rgb.blue.max(T::zero());
 
-        let (max, min, sep, coeff) = {
-            let (max, min, sep, coeff) = if rgb.red > rgb.green {
-                (
-                    rgb.red.clone(),
-                    rgb.green.clone(),
-                    rgb.green.clone() - &rgb.blue,
-                    T::zero(),
-                )
-            } else {
-                (
-                    rgb.green.clone(),
-                    rgb.red.clone(),
-                    rgb.blue.clone() - &rgb.red,
-                    T::from_f64(2.0),
-                )
-            };
-            if rgb.blue > max {
-                (rgb.blue, min, rgb.red - rgb.green, T::from_f64(4.0))
-            } else {
-                let min_val = if rgb.blue < min { rgb.blue } else { min };
-                (max, min_val, sep, coeff)
-            }
-        };
-
-        let mut h = T::zero();
-        let mut s = T::zero();
+        let max = red.clone().max(green.clone()).max(blue.clone());
+        let min = red.clone().min(green.clone()).min(blue.clone());
 
         let sum = max.clone() + &min;
-        let l = sum.clone() / T::from_f64(2.0);
-        if max != min {
-            let d = max - min;
-            s = if sum > T::one() {
-                d.clone() / (T::from_f64(2.0) - sum)
-            } else {
-                d.clone() / sum
-            };
-            h = ((sep / d) + coeff) * T::from_f64(60.0);
+        let lightness = T::from_f64(0.5) * &sum;
+
+        let chroma = max.clone() - &min;
+        let saturation = lazy_select! {
+            if min.eq(&max) => T::zero(),
+            if sum.gt(&T::one()) => chroma.clone() / (T::from_f64(2.0) - &sum),
+            else => chroma.clone() / &sum,
         };
 
+        // Each of these represents an RGB component. The maximum will be false
+        // while the two other will be true. They are later used for determining
+        // which branch in the hue equation we end up in.
+        let x = max.neq(&red);
+        let y = max.eq(&red) | max.neq(&green);
+        let z = max.eq(&red) | max.eq(&green);
+
+        // The hue base is the `1`, `2/6`, `4/6` or 0 part of the hue equation,
+        // except it's multiplied by 6 here.
+        let hue_base = x.clone().select(T::from_f64(-4.0), T::zero())
+            * z.clone().select(T::one(), -T::one())
+            + &six;
+
+        // Each of these is a part of `G - B`, `B - R`, `R - G` or 0 from the
+        // hue equation. They become positive, negative or 0, depending on which
+        // branch we should be in. This makes the sum of all three combine as
+        // expected.
+        let red_m = x.clone().select(red, T::zero()) * y.clone().select(T::one(), -T::one());
+        let green_m = y.clone().select(green, T::zero()) * z.clone().select(T::one(), -T::one());
+        let blue_m = z.select(blue, T::zero()) * y.select(-T::one(), T::one());
+
+        // This is the hue equation parts combined. The hue base is the constant
+        // and the RGB components are masked so up to two of them are non-zero.
+        // Once again, this is multiplied by 6, so the chroma isn't multiplied
+        // before dividing.
+        //
+        // We also avoid dividing by 0 for non-SIMD values.
+        let hue = chroma.eq(&T::zero()).lazy_select(
+            || T::zero(),
+            || hue_base + (red_m + green_m + blue_m) / &chroma,
+        );
+
+        // hue will always be within [0, 12) (it's multiplied by 6, compared to
+        // the paper), so we can subtract by 6 instead of using % to get it
+        // within [0, 6).
+        let hue_sub = hue.gt_eq(&six).select(six, T::zero());
+        let hue = hue - hue_sub;
+
         Hsl {
-            hue: h.into(),
-            saturation: s,
-            lightness: l,
+            hue: RgbHue::from_degrees(hue * T::from_f64(60.0)),
+            saturation,
+            lightness,
             standard: PhantomData,
         }
     }
@@ -351,29 +377,37 @@ where
 
 impl<S, T> FromColorUnclamped<Hsv<S, T>> for Hsl<S, T>
 where
-    T: Real + Zero + One + IsValidDivisor + Arithmetics + PartialOrd,
+    T: Real + Zero + One + IsValidDivisor + Arithmetics + PartialCmp + Clone,
+    T::Mask: LazySelect<T> + Not<Output = T::Mask>,
 {
     fn from_color_unclamped(hsv: Hsv<S, T>) -> Self {
-        let x = (T::from_f64(2.0) - &hsv.saturation) * &hsv.value;
-        let saturation = if !hsv.value.is_valid_divisor() {
-            T::zero()
-        } else if x < T::one() {
-            if x.is_valid_divisor() {
-                hsv.saturation * hsv.value / &x
-            } else {
-                T::zero()
-            }
-        } else {
-            let denom = T::from_f64(2.0) - &x;
-            if denom.is_valid_divisor() {
-                hsv.saturation * hsv.value / denom
-            } else {
-                T::zero()
-            }
+        let Hsv {
+            hue,
+            saturation,
+            value,
+            ..
+        } = hsv;
+
+        let x = (T::from_f64(2.0) - &saturation) * &value;
+        let saturation = lazy_select! {
+            if !value.is_valid_divisor() => T::zero(),
+            if x.lt(&T::one()) => {
+                lazy_select!{
+                    if x.is_valid_divisor() => saturation.clone() * &value / &x,
+                    else => T::zero(),
+                }
+            },
+            else => {
+                let denom = T::from_f64(2.0) - &x;
+                lazy_select! {
+                    if denom.is_valid_divisor() => saturation.clone() * &value / denom,
+                    else => T::zero(),
+                }
+            },
         };
 
         Hsl {
-            hue: hsv.hue,
+            hue,
             saturation,
             lightness: x / T::from_f64(2.0),
             standard: PhantomData,
@@ -405,21 +439,17 @@ impl<S, T, A> From<Alpha<Hsl<S, T>, A>> for (RgbHue<T>, T, T, A) {
     }
 }
 
-impl<S, T> IsWithinBounds for Hsl<S, T>
-where
-    T: Stimulus + PartialOrd,
-{
-    #[rustfmt::skip]
-    #[inline]
-    fn is_within_bounds(&self) -> bool {
-        self.saturation >= Self::min_saturation() && self.saturation <= Self::max_saturation() &&
-        self.lightness >= Self::min_lightness() && self.lightness <= Self::max_lightness()
+impl_is_within_bounds! {
+    Hsl<S> {
+        saturation => [Self::min_saturation(), Self::max_saturation()],
+        lightness => [Self::min_lightness(), Self::max_lightness()]
     }
+    where T: Stimulus
 }
 
 impl<S, T> Clamp for Hsl<S, T>
 where
-    T: Stimulus + PartialOrd,
+    T: Stimulus + num::Clamp,
 {
     #[inline]
     fn clamp(self) -> Self {
@@ -437,7 +467,7 @@ where
 
 impl<S, T> ClampAssign for Hsl<S, T>
 where
-    T: Stimulus + PartialOrd,
+    T: Stimulus + num::ClampAssign,
 {
     #[inline]
     fn clamp_assign(&mut self) {
@@ -460,17 +490,13 @@ impl_saturate!(Hsl<S> increase {saturation => [Self::min_saturation(), Self::max
 
 impl<S, T> GetHue for Hsl<S, T>
 where
-    T: Zero + PartialOrd + Clone,
+    T: Clone,
 {
     type Hue = RgbHue<T>;
 
     #[inline]
-    fn get_hue(&self) -> Option<RgbHue<T>> {
-        if self.saturation <= T::zero() {
-            None
-        } else {
-            Some(self.hue.clone())
-        }
+    fn get_hue(&self) -> RgbHue<T> {
+        self.hue.clone()
     }
 }
 
@@ -520,6 +546,13 @@ where
     }
 }
 
+impl<S, T> HasBoolMask for Hsl<S, T>
+where
+    T: HasBoolMask,
+{
+    type Mask = T::Mask;
+}
+
 impl<S, T> Default for Hsl<S, T>
 where
     T: Stimulus,
@@ -538,12 +571,14 @@ impl_color_add!(Hsl<S, T>, [hue, saturation, lightness], standard);
 impl_color_sub!(Hsl<S, T>, [hue, saturation, lightness], standard);
 
 impl_array_casts!(Hsl<S, T>, [T; 3]);
+impl_simd_array_conversion_hue!(Hsl<S>, [saturation, lightness], standard);
 
 impl_eq_hue!(Hsl<S>, RgbHue, [hue, saturation, lightness]);
 
 impl<S, T> RelativeContrast for Hsl<S, T>
 where
-    T: Real + PartialOrd + Arithmetics,
+    T: Real + Arithmetics + PartialCmp,
+    T::Mask: LazySelect<T>,
     S: RgbStandard<T>,
     Xyz<<S::Space as RgbSpace<T>>::WhitePoint, T>: FromColor<Self>,
 {
@@ -561,7 +596,8 @@ where
 #[cfg(feature = "random")]
 impl<S, T> Distribution<Hsl<S, T>> for Standard
 where
-    T: Real + Cbrt + Sqrt + Arithmetics + PartialOrd,
+    T: Real + One + Cbrt + Sqrt + Arithmetics + PartialCmp + Clone,
+    T::Mask: LazySelect<T> + Clone,
     Standard: Distribution<T> + Distribution<RgbHue<T>>,
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Hsl<S, T> {
@@ -583,7 +619,8 @@ where
 #[cfg(feature = "random")]
 impl<S, T> SampleUniform for Hsl<S, T>
 where
-    T: Real + Cbrt + Sqrt + Powi + Arithmetics + PartialOrd + Clone + SampleUniform,
+    T: Real + One + Cbrt + Sqrt + Powi + Arithmetics + PartialCmp + Clone + SampleUniform,
+    T::Mask: LazySelect<T> + Clone,
     RgbHue<T>: SampleBorrow<RgbHue<T>>,
     crate::hues::UniformRgbHue<T>: UniformSampler<X = RgbHue<T>>,
 {
@@ -593,7 +630,8 @@ where
 #[cfg(feature = "random")]
 impl<S, T> UniformSampler for UniformHsl<S, T>
 where
-    T: Real + Cbrt + Sqrt + Powi + Arithmetics + PartialOrd + Clone + SampleUniform,
+    T: Real + One + Cbrt + Sqrt + Powi + Arithmetics + PartialCmp + Clone + SampleUniform,
+    T::Mask: LazySelect<T> + Clone,
     RgbHue<T>: SampleBorrow<RgbHue<T>>,
     crate::hues::UniformRgbHue<T>: UniformSampler<X = RgbHue<T>>,
 {

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -284,6 +284,7 @@ where
     Rgb<S2, T>: FromColorUnclamped<Rgb<S1, T>>,
     Self: FromColorUnclamped<Rgb<S2, T>>,
 {
+    #[inline]
     fn from_color_unclamped(hsl: Hsl<S1, T>) -> Self {
         if TypeId::of::<S1>() == TypeId::of::<S2>() {
             hsl.reinterpret_as()
@@ -367,16 +368,16 @@ where
             let chroma = max.clone() - &min;
             let saturation = lazy_select! {
                 if min.eq(&max) => T::zero(),
-                if sum.gt(&T::one()) => chroma.clone() / (T::from_f64(2.0) - &sum),
-                else => chroma.clone() / &sum,
+                else => chroma.clone() /
+                    sum.gt(&T::one()).select(T::from_f64(2.0) - &sum, sum.clone()),
             };
 
             // Each of these represents an RGB component. The maximum will be false
             // while the two other will be true. They are later used for determining
             // which branch in the hue equation we end up in.
             let x = max.neq(&red);
-            let y = !x.clone() | max.neq(&green);
-            let z = !x.clone() | max.eq(&green);
+            let y = max.eq(&red) | max.neq(&green);
+            let z = max.eq(&red) | max.eq(&green);
 
             // The hue base is the `1`, `2/6`, `4/6` or 0 part of the hue equation,
             // except it's multiplied by 6 here.

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -19,7 +19,7 @@ use crate::num::{Cbrt, Powi, Sqrt};
 
 use crate::{
     angle::{FromAngle, RealAngle, SignedAngle},
-    bool_mask::{BitOps, HasBoolMask, LazySelect, Select},
+    bool_mask::{BitOps, BoolMask, HasBoolMask, LazySelect, Select},
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
     encoding::Srgb,
@@ -298,79 +298,133 @@ where
 impl<S, T> FromColorUnclamped<Rgb<S, T>> for Hsl<S, T>
 where
     T: RealAngle + Zero + One + MinMax + Arithmetics + PartialCmp + Clone,
-    T::Mask: BitOps + LazySelect<T> + Clone,
+    T::Mask: BoolMask + BitOps + LazySelect<T> + Clone + 'static,
 {
     fn from_color_unclamped(rgb: Rgb<S, T>) -> Self {
-        // Based on OPTIMIZED RGB TO HSV COLOR CONVERSION USING SSE TECHNOLOGY
-        // by KOBALICEK, Petr & BLIZNAK, Michal
-        //
-        // This implementation assumes less about the underlying mask and number
-        // representation. The hue is also multiplied by 6 to avoid rounding
-        // errors when using degrees.
-
-        let six = T::from_f64(6.0);
-
         // Avoid negative numbers
         let red = rgb.red.max(T::zero());
         let green = rgb.green.max(T::zero());
         let blue = rgb.blue.max(T::zero());
 
-        let max = red.clone().max(green.clone()).max(blue.clone());
-        let min = red.clone().min(green.clone()).min(blue.clone());
+        // The SIMD optimized version showed significant slowdown for regular floats.
+        if TypeId::of::<T::Mask>() == TypeId::of::<bool>() {
+            let (max, min, sep, coeff) = {
+                let (max, min, sep, coeff) = if red.gt(&green).is_true() {
+                    (red.clone(), green.clone(), green.clone() - &blue, T::zero())
+                } else {
+                    (
+                        green.clone(),
+                        red.clone(),
+                        blue.clone() - &red,
+                        T::from_f64(2.0),
+                    )
+                };
+                if blue.gt(&max).is_true() {
+                    (blue, min, red - green, T::from_f64(4.0))
+                } else {
+                    let min_val = if blue.lt(&min).is_true() { blue } else { min };
+                    (max, min_val, sep, coeff)
+                }
+            };
 
-        let sum = max.clone() + &min;
-        let lightness = T::from_f64(0.5) * &sum;
+            let mut h = T::zero();
+            let mut s = T::zero();
 
-        let chroma = max.clone() - &min;
-        let saturation = lazy_select! {
-            if min.eq(&max) => T::zero(),
-            if sum.gt(&T::one()) => chroma.clone() / (T::from_f64(2.0) - &sum),
-            else => chroma.clone() / &sum,
-        };
+            let sum = max.clone() + &min;
+            let l = sum.clone() / T::from_f64(2.0);
+            if max.neq(&min).is_true() {
+                let d = max - min;
+                s = if sum.gt(&T::one()).is_true() {
+                    d.clone() / (T::from_f64(2.0) - sum)
+                } else {
+                    d.clone() / sum
+                };
+                h = ((sep / d) + coeff) * T::from_f64(60.0);
+            };
 
-        // Each of these represents an RGB component. The maximum will be false
-        // while the two other will be true. They are later used for determining
-        // which branch in the hue equation we end up in.
-        let x = max.neq(&red);
-        let y = max.eq(&red) | max.neq(&green);
-        let z = max.eq(&red) | max.eq(&green);
+            Hsl {
+                hue: h.into(),
+                saturation: s,
+                lightness: l,
+                standard: PhantomData,
+            }
+        } else {
+            // Based on OPTIMIZED RGB TO HSV COLOR CONVERSION USING SSE TECHNOLOGY
+            // by KOBALICEK, Petr & BLIZNAK, Michal
+            //
+            // This implementation assumes less about the underlying mask and number
+            // representation. The hue is also multiplied by 6 to avoid rounding
+            // errors when using degrees.
 
-        // The hue base is the `1`, `2/6`, `4/6` or 0 part of the hue equation,
-        // except it's multiplied by 6 here.
-        let hue_base = x.clone().select(T::from_f64(-4.0), T::zero())
-            * z.clone().select(T::one(), -T::one())
-            + &six;
+            let six = T::from_f64(6.0);
 
-        // Each of these is a part of `G - B`, `B - R`, `R - G` or 0 from the
-        // hue equation. They become positive, negative or 0, depending on which
-        // branch we should be in. This makes the sum of all three combine as
-        // expected.
-        let red_m = x.clone().select(red, T::zero()) * y.clone().select(T::one(), -T::one());
-        let green_m = y.clone().select(green, T::zero()) * z.clone().select(T::one(), -T::one());
-        let blue_m = z.select(blue, T::zero()) * y.select(-T::one(), T::one());
+            let max = red.clone().max(green.clone()).max(blue.clone());
+            let min = red.clone().min(green.clone()).min(blue.clone());
 
-        // This is the hue equation parts combined. The hue base is the constant
-        // and the RGB components are masked so up to two of them are non-zero.
-        // Once again, this is multiplied by 6, so the chroma isn't multiplied
-        // before dividing.
-        //
-        // We also avoid dividing by 0 for non-SIMD values.
-        let hue = chroma.eq(&T::zero()).lazy_select(
-            || T::zero(),
-            || hue_base + (red_m + green_m + blue_m) / &chroma,
-        );
+            let sum = max.clone() + &min;
+            let lightness = T::from_f64(0.5) * &sum;
 
-        // hue will always be within [0, 12) (it's multiplied by 6, compared to
-        // the paper), so we can subtract by 6 instead of using % to get it
-        // within [0, 6).
-        let hue_sub = hue.gt_eq(&six).select(six, T::zero());
-        let hue = hue - hue_sub;
+            let chroma = max.clone() - &min;
+            let saturation = lazy_select! {
+                if min.eq(&max) => T::zero(),
+                if sum.gt(&T::one()) => chroma.clone() / (T::from_f64(2.0) - &sum),
+                else => chroma.clone() / &sum,
+            };
 
-        Hsl {
-            hue: RgbHue::from_degrees(hue * T::from_f64(60.0)),
-            saturation,
-            lightness,
-            standard: PhantomData,
+            // Each of these represents an RGB component. The maximum will be false
+            // while the two other will be true. They are later used for determining
+            // which branch in the hue equation we end up in.
+            let x = max.neq(&red);
+            let y = !x.clone() | max.neq(&green);
+            let z = !x.clone() | max.eq(&green);
+
+            // The hue base is the `1`, `2/6`, `4/6` or 0 part of the hue equation,
+            // except it's multiplied by 6 here.
+            let hue_base = x.clone().select(
+                z.clone().select(T::from_f64(-4.0), T::from_f64(4.0)),
+                T::zero(),
+            ) + &six;
+
+            // Each of these is a part of `G - B`, `B - R`, `R - G` or 0 from the
+            // hue equation. They become positive, negative or 0, depending on which
+            // branch we should be in. This makes the sum of all three combine as
+            // expected.
+            let red_m = lazy_select! {
+               if x.clone() => y.clone().select(red.clone(), -red),
+               else => T::zero(),
+            };
+            let green_m = lazy_select! {
+               if y.clone() => z.clone().select(green.clone(), -green),
+               else => T::zero(),
+            };
+            let blue_m = lazy_select! {
+               if z => y.select(-blue.clone(), blue),
+               else => T::zero(),
+            };
+
+            // This is the hue equation parts combined. The hue base is the constant
+            // and the RGB components are masked so up to two of them are non-zero.
+            // Once again, this is multiplied by 6, so the chroma isn't multiplied
+            // before dividing.
+            //
+            // We also avoid dividing by 0 for non-SIMD values.
+            let hue = lazy_select! {
+                if chroma.eq(&T::zero()) => T::zero(),
+                else => hue_base + (red_m + green_m + blue_m) / &chroma,
+            };
+
+            // hue will always be within [0, 12) (it's multiplied by 6, compared to
+            // the paper), so we can subtract by 6 instead of using % to get it
+            // within [0, 6).
+            let hue_sub = hue.gt_eq(&six).select(six, T::zero());
+            let hue = hue - hue_sub;
+
+            Hsl {
+                hue: RgbHue::from_degrees(hue * T::from_f64(60.0)),
+                saturation,
+                lightness,
+                standard: PhantomData,
+            }
         }
     }
 }

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -287,6 +287,7 @@ where
     Rgb<S2, T>: FromColorUnclamped<Rgb<S1, T>>,
     Self: FromColorUnclamped<Rgb<S2, T>>,
 {
+    #[inline]
     fn from_color_unclamped(hsv: Hsv<S1, T>) -> Self {
         if TypeId::of::<S1>() == TypeId::of::<S2>() {
             hsv.reinterpret_as()
@@ -369,8 +370,8 @@ where
             // while the two other will be true. They are later used for determining
             // which branch in the hue equation we end up in.
             let x = value.neq(&red);
-            let y = !x.clone() | value.neq(&green);
-            let z = !x.clone() | value.eq(&green);
+            let y = value.eq(&red) | value.neq(&green);
+            let z = value.eq(&red) | value.eq(&green);
 
             // The hue base is the `1`, `2/6`, `4/6` or 0 part of the hue equation,
             // except it's multiplied by 6 here.
@@ -428,6 +429,7 @@ where
     T: Real + Zero + One + IsValidDivisor + Arithmetics + PartialCmp + Clone,
     T::Mask: LazySelect<T>,
 {
+    #[inline]
     fn from_color_unclamped(hsl: Hsl<S, T>) -> Self {
         let x = lazy_select! {
             if hsl.lightness.lt(&T::from_f64(0.5)) => hsl.lightness.clone(),
@@ -456,6 +458,7 @@ where
     T: One + Zero + IsValidDivisor + Arithmetics,
     T::Mask: LazySelect<T>,
 {
+    #[inline]
     fn from_color_unclamped(hwb: Hwb<S, T>) -> Self {
         let Hwb {
             hue,

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -161,21 +161,21 @@ macro_rules! make_hues {
             }
         }
 
-        impl<T: AngleEq> PartialEq for $name<T> {
+        impl<T> PartialEq for $name<T> where T: AngleEq<Mask = bool> + PartialEq {
             #[inline]
             fn eq(&self, other: &$name<T>) -> bool {
                 self.0.angle_eq(&other.0)
             }
         }
 
-        impl<T: AngleEq> PartialEq<T> for $name<T> {
+        impl<T> PartialEq<T> for $name<T> where T: AngleEq<Mask = bool> + PartialEq {
             #[inline]
             fn eq(&self, other: &T) -> bool {
                 self.0.angle_eq(other)
             }
         }
 
-        impl<T: AngleEq + Eq> Eq for $name<T> {}
+        impl<T> Eq for $name<T> where T: AngleEq<Mask = bool> + Eq {}
 
         // For hues, the difference is calculated and compared to zero. However due to
         // the way floating point's work this is not so simple.
@@ -187,7 +187,7 @@ macro_rules! make_hues {
         // ulps. Because of this we loose some precision for values close to 0.0.
         impl<T> AbsDiffEq for $name<T>
         where
-            T: RealAngle + SignedAngle + Zero + AngleEq + Sub<Output = T> + AbsDiffEq + Clone,
+            T: RealAngle + SignedAngle + Zero + AngleEq<Mask = bool> + Sub<Output = T> + AbsDiffEq + Clone,
             T::Epsilon: HalfRotation + Mul<Output = T::Epsilon>,
         {
             type Epsilon = T::Epsilon;
@@ -208,7 +208,7 @@ macro_rules! make_hues {
 
         impl<T> RelativeEq for $name<T>
         where
-            T: RealAngle + SignedAngle + Zero + AngleEq + Sub<Output = T> + Clone + RelativeEq,
+            T: RealAngle + SignedAngle + Zero + AngleEq<Mask = bool> + Sub<Output = T> + Clone + RelativeEq,
             T::Epsilon: HalfRotation + Mul<Output = T::Epsilon>,
         {
             fn default_max_relative() -> Self::Epsilon {
@@ -237,7 +237,7 @@ macro_rules! make_hues {
 
         impl<T> UlpsEq for $name<T>
         where
-            T: RealAngle + SignedAngle + Zero + AngleEq + Sub<Output = T> + Clone + UlpsEq,
+            T: RealAngle + SignedAngle + Zero + AngleEq<Mask = bool> + Sub<Output = T> + Clone + UlpsEq,
             T::Epsilon: HalfRotation + Mul<Output = T::Epsilon>,
         {
             fn default_max_ulps() -> u32 {

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -304,6 +304,7 @@ where
     Hsv<S2, T>: FromColorUnclamped<Hsv<S1, T>>,
     Self: FromColorUnclamped<Hsv<S2, T>>,
 {
+    #[inline]
     fn from_color_unclamped(hwb: Hwb<S1, T>) -> Self {
         if TypeId::of::<S1>() == TypeId::of::<S2>() {
             hwb.reinterpret_as()
@@ -319,6 +320,7 @@ impl<S, T> FromColorUnclamped<Hsv<S, T>> for Hwb<S, T>
 where
     T: One + Arithmetics,
 {
+    #[inline]
     fn from_color_unclamped(color: Hsv<S, T>) -> Self {
         Hwb {
             hue: color.hue,

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -15,6 +15,12 @@ mod lighten_saturate;
 mod equality;
 #[macro_use]
 mod blend;
+#[macro_use]
+mod lazy_select;
+#[macro_use]
+mod simd;
+#[macro_use]
+mod clamp;
 
 #[cfg(feature = "random")]
 #[macro_use]

--- a/palette/src/macros/clamp.rs
+++ b/palette/src/macros/clamp.rs
@@ -1,0 +1,26 @@
+macro_rules! impl_is_within_bounds {
+    (
+        $ty: ident
+        {$($component: ident => [$get_min: expr, $get_max: expr]),+}
+        $(where $($where: tt)+)?
+    ) => {
+        impl_is_within_bounds!($ty<> {$($component => [$get_min, $get_max]),+} $(where $($where)+)?);
+    };
+    (
+        $ty: ident <$($ty_param: ident),*>
+        {$($component: ident => [$get_min: expr, $get_max: expr]),+}
+        $(where $($where: tt)+)?
+    ) => {
+        impl<$($ty_param,)* T> IsWithinBounds for $ty<$($ty_param,)* T>
+        where
+            T: PartialCmp,
+            T::Mask: BitAnd<Output = T::Mask>,
+            $($($where)+)?
+        {
+            #[inline]
+            fn is_within_bounds(&self) -> T::Mask {
+                $(self.$component.gt_eq(&$get_min) & self.$component.lt_eq(&$get_max))&+
+            }
+        }
+    };
+}

--- a/palette/src/macros/lazy_select.rs
+++ b/palette/src/macros/lazy_select.rs
@@ -1,0 +1,21 @@
+/// Chains calls to `LazySelect::lazy_select` to mimic an if-else chain.
+///
+/// ```
+/// let result = lazy_select! {
+///     if predicate1 => result1,
+///     if predicate2 => result2,
+///     else => result3,
+/// };
+/// ```
+macro_rules! lazy_select {
+    ( if $if_pred:expr => $if_body:expr, $(if $else_if_pred:expr => $else_if_body:expr,)* else => $else_body:expr $(,)?) => {
+        crate::bool_mask::LazySelect::lazy_select(
+            $if_pred,
+            || $if_body,
+            || lazy_select!($(if $else_if_pred => $else_if_body,)* else => $else_body)
+        )
+    };
+    (else => $else_body:expr) => {
+        $else_body
+    }
+}

--- a/palette/src/macros/mix.rs
+++ b/palette/src/macros/mix.rs
@@ -5,7 +5,7 @@ macro_rules! impl_mix {
     ($ty: ident <$($ty_param: ident),*> $(where $($where: tt)+)?) => {
         impl<$($ty_param,)* T> Mix for $ty<$($ty_param,)* T>
         where
-            T: Real + Zero + One + Arithmetics + PartialOrd + Clone,
+            T: Real + Zero + One + Arithmetics + num::Clamp + Clone,
             $($($where)+)?
         {
             type Scalar = T;
@@ -19,7 +19,7 @@ macro_rules! impl_mix {
 
         impl<$($ty_param,)* T> MixAssign for $ty<$($ty_param,)* T>
         where
-            T: Real + Zero + One + AddAssign + Arithmetics + PartialOrd + Clone,
+            T: Real + Zero + One + AddAssign + Arithmetics + num::Clamp + Clone,
             $($($where)+)?
         {
             type Scalar = T;
@@ -40,7 +40,7 @@ macro_rules! impl_mix_hue {
     ($ty: ident <$($ty_param: ident),*> {$($other_field: ident),*} $(phantom: $phantom: ident)?) => {
         impl<$($ty_param,)* T> Mix for $ty<$($ty_param,)* T>
         where
-            T: RealAngle + SignedAngle + Zero + One + PartialOrd + Arithmetics + Clone,
+            T: RealAngle + SignedAngle + Zero + One + num::Clamp + Arithmetics + Clone,
         {
             type Scalar = T;
 
@@ -64,7 +64,7 @@ macro_rules! impl_mix_hue {
 
         impl<$($ty_param,)* T> MixAssign for $ty<$($ty_param,)* T>
         where
-            T: RealAngle + SignedAngle + Zero + One + PartialOrd + AddAssign + Arithmetics + Clone,
+            T: RealAngle + SignedAngle + Zero + One + num::Clamp + AddAssign + Arithmetics + Clone,
         {
             type Scalar = T;
 

--- a/palette/src/macros/simd.rs
+++ b/palette/src/macros/simd.rs
@@ -1,0 +1,271 @@
+macro_rules! make_recursive_tuples {
+    ($first:tt $(,$rest:tt)+) => {
+        make_recursive_tuples!(@ $first [$($rest),+])
+    };
+    (@ $tuple:tt [$first:tt $(,$rest:tt)*]) => {
+        make_recursive_tuples!(@ ($tuple, $first) [$($rest),*])
+    };
+    (@ $tuple:tt []) => {
+        $tuple
+    }
+}
+
+macro_rules! impl_simd_array_conversion {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_simd_array_conversion!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($ty_param: ident),* > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($ty_param,)* T, V, const N: usize> From<[$self_ty<$($ty_param,)* T>; N]> for $self_ty<$($ty_param,)* V>
+        where
+            [T; N]: Default,
+            V: FromScalarArray<N, Scalar = T>,
+        {
+            fn from(colors: [$self_ty<$($ty_param,)* T>; N]) -> Self {
+                $(let mut $element: [T; N] = Default::default();)*
+
+                for (index, color) in IntoIterator::into_iter(colors).enumerate() {
+                    $($element[index] = color.$element;)*
+                }
+
+                $self_ty {
+                    $($element: V::from_array($element),)*
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<[Alpha<$self_ty<$($ty_param,)* T>, T>; N]> for Alpha<$self_ty<$($ty_param,)* V>, V>
+        where
+            [T; N]: Default,
+            V: FromScalarArray<N, Scalar = T>,
+        {
+            fn from(colors: [Alpha<$self_ty<$($ty_param,)* T>, T>; N]) -> Self {
+                $(let mut $element: [T; N] = Default::default();)*
+                let mut alpha: [T; N] = Default::default();
+
+                for (index, color) in IntoIterator::into_iter(colors).enumerate() {
+                    $($element[index] = color.color.$element;)*
+                    alpha[index] = color.alpha
+                }
+
+                Alpha {
+                    color: $self_ty {
+                        $($element: V::from_array($element),)*
+                        $($phantom: PhantomData,)?
+                    },
+                    alpha: V::from_array(alpha),
+                }
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<[PreAlpha<$self_ty<$($ty_param,)* T>>; N]> for PreAlpha<$self_ty<$($ty_param,)* V>>
+        where
+            [T; N]: Default,
+            V: FromScalarArray<N, Scalar = T>,
+            $self_ty<$($ty_param,)* T>: Premultiply<Scalar = T>,
+            $self_ty<$($ty_param,)* V>: Premultiply<Scalar = V>,
+        {
+            fn from(colors: [PreAlpha<$self_ty<$($ty_param,)* T>>; N]) -> Self {
+                $(let mut $element: [T; N] = Default::default();)*
+                let mut alpha: [T; N] = Default::default();
+
+                for (index, color) in IntoIterator::into_iter(colors).enumerate() {
+                    $($element[index] = color.color.$element;)*
+                    alpha[index] = color.alpha
+                }
+
+                PreAlpha {
+                    color: $self_ty {
+                        $($element: V::from_array($element),)*
+                        $($phantom: PhantomData,)?
+                    },
+                    alpha: V::from_array(alpha),
+                }
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<$self_ty<$($ty_param,)* V>> for [$self_ty<$($ty_param,)* T>; N]
+        where
+            Self: Default,
+            V: IntoScalarArray<N, Scalar = T>,
+        {
+            fn from(color: $self_ty<$($ty_param,)* V>) -> Self {
+                let mut colors = Self::default();
+                $(let $element = color.$element.into_array();)*
+
+                for make_recursive_tuples!(index $(,$element)*) in
+                    (0..)$(.zip($element))*
+                {
+                    colors[index] = $self_ty {
+                        $($element,)*
+                        $($phantom: PhantomData,)?
+                    };
+                }
+
+                colors
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<Alpha<$self_ty<$($ty_param,)* V>, V>> for [Alpha<$self_ty<$($ty_param,)* T>, T>; N]
+        where
+            Self: Default,
+            V: IntoScalarArray<N, Scalar = T>,
+        {
+            fn from(color: Alpha<$self_ty<$($ty_param,)* V>, V>) -> Self {
+                let mut colors = Self::default();
+                $(let $element = color.color.$element.into_array();)*
+                let alpha = color.alpha.into_array();
+
+                for make_recursive_tuples!(index $(,$element)*, alpha) in
+                    (0..)$(.zip($element))*.zip(alpha)
+                {
+                    colors[index] = Alpha {
+                        color: $self_ty {
+                            $($element,)*
+                            $($phantom: PhantomData,)?
+                        },
+                        alpha,
+                    };
+                }
+
+                colors
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<PreAlpha<$self_ty<$($ty_param,)* V>>> for [PreAlpha<$self_ty<$($ty_param,)* T>>; N]
+        where
+            Self: Default,
+            V: IntoScalarArray<N, Scalar = T>,
+            $self_ty<$($ty_param,)* T>: Premultiply<Scalar = T>,
+            $self_ty<$($ty_param,)* V>: Premultiply<Scalar = V>,
+        {
+            fn from(color: PreAlpha<$self_ty<$($ty_param,)* V>>) -> Self {
+                let mut colors = Self::default();
+                $(let $element = color.color.$element.into_array();)*
+                let alpha = color.alpha.into_array();
+
+                for make_recursive_tuples!(index $(,$element)*, alpha) in
+                    (0..)$(.zip($element))*.zip(alpha)
+                {
+                    colors[index] = PreAlpha {
+                        color: $self_ty {
+                            $($element,)*
+                            $($phantom: PhantomData,)?
+                        },
+                        alpha,
+                    };
+                }
+
+                colors
+            }
+        }
+    };
+}
+
+macro_rules! impl_simd_array_conversion_hue {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_simd_array_conversion_hue!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($ty_param: ident),* > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($ty_param,)* T, V, const N: usize> From<[$self_ty<$($ty_param,)* T>; N]> for $self_ty<$($ty_param,)* V>
+        where
+            [T; N]: Default,
+            V: FromScalarArray<N, Scalar = T>,
+        {
+            fn from(colors: [$self_ty<$($ty_param,)* T>; N]) -> Self {
+                let mut hue: [T; N] = Default::default();
+                $(let mut $element: [T; N] = Default::default();)*
+
+                for (index, color) in IntoIterator::into_iter(colors).enumerate() {
+                    hue[index] = color.hue.into_inner();
+                    $($element[index] = color.$element;)*
+                }
+
+                $self_ty {
+                    hue: V::from_array(hue).into(),
+                    $($element: V::from_array($element),)*
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<[Alpha<$self_ty<$($ty_param,)* T>, T>; N]> for Alpha<$self_ty<$($ty_param,)* V>, V>
+        where
+            [T; N]: Default,
+            V: FromScalarArray<N, Scalar = T>,
+        {
+            fn from(colors: [Alpha<$self_ty<$($ty_param,)* T>, T>; N]) -> Self {
+                let mut hue: [T; N] = Default::default();
+                $(let mut $element: [T; N] = Default::default();)*
+                let mut alpha: [T; N] = Default::default();
+
+                for (index, color) in IntoIterator::into_iter(colors).enumerate() {
+                    hue[index] = color.color.hue.into_inner();
+                    $($element[index] = color.color.$element;)*
+                    alpha[index] = color.alpha
+                }
+
+                Alpha {
+                    color: $self_ty {
+                        hue: V::from_array(hue).into(),
+                        $($element: V::from_array($element),)*
+                        $($phantom: PhantomData,)?
+                    },
+                    alpha: V::from_array(alpha),
+                }
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<$self_ty<$($ty_param,)* V>> for [$self_ty<$($ty_param,)* T>; N]
+        where
+            Self: Default,
+            V: IntoScalarArray<N, Scalar = T>,
+        {
+            fn from(color: $self_ty<$($ty_param,)* V>) -> Self {
+                let mut colors = Self::default();
+                let hue = color.hue.into_inner().into_array();
+                $(let $element = color.$element.into_array();)*
+
+                for make_recursive_tuples!(index, hue $(,$element)*) in
+                    (0..).zip(hue)$(.zip($element))*
+                {
+                    colors[index] = $self_ty {
+                        hue: hue.into(),
+                        $($element,)*
+                        $($phantom: PhantomData,)?
+                    };
+                }
+
+                colors
+            }
+        }
+
+        impl<$($ty_param,)* T, V, const N: usize> From<Alpha<$self_ty<$($ty_param,)* V>, V>> for [Alpha<$self_ty<$($ty_param,)* T>, T>; N]
+        where
+            Self: Default,
+            V: IntoScalarArray<N, Scalar = T>,
+        {
+            fn from(color: Alpha<$self_ty<$($ty_param,)* V>, V>) -> Self {
+                let mut colors = Self::default();
+                let hue = color.color.hue.into_inner().into_array();
+                $(let $element = color.color.$element.into_array();)*
+                let alpha = color.alpha.into_array();
+
+                for make_recursive_tuples!(index, hue $(,$element)*, alpha) in
+                    (0..).zip(hue)$(.zip($element))*.zip(alpha)
+                {
+                    colors[index] = Alpha {
+                        color: $self_ty {
+                            hue: hue.into(),
+                            $($element,)*
+                            $($phantom: PhantomData,)?
+                        },
+                        alpha,
+                    };
+                }
+
+                colors
+            }
+        }
+    };
+}

--- a/palette/src/num.rs
+++ b/palette/src/num.rs
@@ -272,6 +272,20 @@ pub trait ClampAssign {
     fn clamp_max_assign(&mut self, max: Self);
 }
 
+/// Combined multiplication and addition operation.
+pub trait MulAdd {
+    /// Multiplies self with `m` and add `a`, as in `(self * m) + a`.
+    #[must_use]
+    fn mul_add(self, m: Self, a: Self) -> Self;
+}
+
+/// Combined multiplication and subtraction operation.
+pub trait MulSub {
+    /// Multiplies self with `m` and subtract `s`, as in `(self * m) - s`.
+    #[must_use]
+    fn mul_sub(self, m: Self, s: Self) -> Self;
+}
+
 macro_rules! impl_uint {
     ($($ty: ident),+) => {
         $(
@@ -379,6 +393,20 @@ macro_rules! impl_uint {
                 #[inline]
                 fn clamp_max_assign(&mut self, max: Self) {
                     *self = core::cmp::Ord::min(*self, max);
+                }
+            }
+
+            impl MulAdd for $ty {
+                #[inline]
+                fn mul_add(self, m: Self, a: Self) -> Self {
+                    (self * m) + a
+                }
+            }
+
+            impl MulSub for $ty {
+                #[inline]
+                fn mul_sub(self, m: Self, s: Self) -> Self {
+                    (self * m) - s
                 }
             }
         )+
@@ -624,6 +652,21 @@ macro_rules! impl_float {
                 #[inline]
                 fn clamp_max_assign(&mut self, max: Self) {
                     *self = $ty::min(*self, max);
+                }
+            }
+
+            #[cfg(feature = "std")]
+            impl MulAdd for $ty {
+                #[inline]
+                fn mul_add(self, m: Self, a: Self) -> Self {
+                    $ty::mul_add(self, m, a)
+                }
+            }
+
+            impl MulSub for $ty {
+                #[inline]
+                fn mul_sub(self, m: Self, s: Self) -> Self {
+                    (self * m) - s
                 }
             }
         )+

--- a/palette/src/num.rs
+++ b/palette/src/num.rs
@@ -12,10 +12,14 @@
 //! some of the traits, and new methods can be added as new traits without
 //! affecting old functionality.
 
-use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
+
+use crate::bool_mask::HasBoolMask;
 
 #[cfg(all(not(feature = "std"), feature = "libm"))]
 mod libm;
+#[cfg(feature = "wide")]
+mod wide;
 
 /// Numbers that belong to the real number set. It's both a semantic marker and
 /// provides a constructor for number constants.
@@ -23,6 +27,32 @@ pub trait Real {
     /// Create a number from an `f64` value, mainly for converting constants.
     #[must_use]
     fn from_f64(n: f64) -> Self;
+}
+
+/// Trait for creating a vectorized value from a scalar value.
+pub trait FromScalar {
+    /// The scalar type that is stored in each lane of `Self`. Scalar types
+    /// should set this to equal `Self`.
+    type Scalar;
+
+    /// Create a new vectorized value where each lane is `scalar`. This
+    /// corresponds to `splat` for SIMD types.
+    #[must_use]
+    fn from_scalar(scalar: Self::Scalar) -> Self;
+}
+
+/// Conversion from an array of scalars to a vectorized value.
+pub trait FromScalarArray<const N: usize>: FromScalar {
+    /// Creates a vectorized value from an array of scalars.
+    #[must_use]
+    fn from_array(scalars: [Self::Scalar; N]) -> Self;
+}
+
+/// Conversion from a vectorized value to an array of scalars.
+pub trait IntoScalarArray<const N: usize>: FromScalar {
+    /// Creates an array of scalars from a vectorized value.
+    #[must_use]
+    fn into_array(self) -> [Self::Scalar; N];
 }
 
 /// Methods for the value `0`.
@@ -47,7 +77,6 @@ where
         + Mul<Output = Self>
         + Div<Output = Self>
         + Neg<Output = Self>
-        + Rem<Output = Self>
         + Sized,
     for<'a> Self: Add<&'a Self, Output = Self>
         + Sub<&'a Self, Output = Self>
@@ -63,7 +92,6 @@ where
         + Mul<Output = Self>
         + Div<Output = Self>
         + Neg<Output = Self>
-        + Rem<Output = Self>
         + Sized,
     for<'a> Self: Add<&'a Self, Output = Self>
         + Sub<&'a Self, Output = Self>
@@ -184,14 +212,14 @@ pub trait Exp {
 }
 
 /// Methods for checking if a number can be used as a divisor.
-pub trait IsValidDivisor {
+pub trait IsValidDivisor: HasBoolMask {
     /// Return `true` if `self` can be used as a divisor in `x / self`.
     ///
     /// This checks that division by `self` will result in a finite and defined
     /// value. Integers check for `self != 0`, while floating point types call
     /// [`is_normal`][std::primitive::f32::is_normal].
     #[must_use]
-    fn is_valid_divisor(&self) -> bool;
+    fn is_valid_divisor(&self) -> Self::Mask;
 }
 
 /// Methods for calculating the lengths of a hypotenuse.
@@ -217,9 +245,60 @@ pub trait Round {
     fn ceil(self) -> Self;
 }
 
+/// Trait for clamping a value.
+pub trait Clamp {
+    /// Clamp self to be within the range `[min, max]`.
+    #[must_use]
+    fn clamp(self, min: Self, max: Self) -> Self;
+
+    /// Clamp self to be within the range `[min, ∞)`.
+    #[must_use]
+    fn clamp_min(self, min: Self) -> Self;
+
+    /// Clamp self to be within the range `(-∞, max]`.
+    #[must_use]
+    fn clamp_max(self, max: Self) -> Self;
+}
+
+/// Assigning trait for clamping a value.
+pub trait ClampAssign {
+    /// Clamp self to be within the range `[min, max]`.
+    fn clamp_assign(&mut self, min: Self, max: Self);
+
+    /// Clamp self to be within the range `[min, ∞)`.
+    fn clamp_min_assign(&mut self, min: Self);
+
+    /// Clamp self to be within the range `(-∞, max]`.
+    fn clamp_max_assign(&mut self, max: Self);
+}
+
 macro_rules! impl_uint {
     ($($ty: ident),+) => {
         $(
+            impl FromScalar for $ty {
+                type Scalar = Self;
+
+                #[inline]
+                fn from_scalar(scalar: Self) -> Self {
+                    scalar
+                }
+            }
+
+            impl FromScalarArray<1> for $ty {
+                #[inline]
+                fn from_array(scalars: [Self; 1]) -> Self {
+                    let [scalar] = scalars;
+                    scalar
+                }
+            }
+
+            impl IntoScalarArray<1> for $ty {
+                #[inline]
+                fn into_array(self) -> [Self; 1] {
+                    [self]
+                }
+            }
+
             impl Zero for $ty {
                 #[inline]
                 fn zero() -> Self {
@@ -268,6 +347,40 @@ macro_rules! impl_uint {
                     *self != 0
                 }
             }
+
+            impl Clamp for $ty {
+                #[inline]
+                fn clamp(self, min: Self, max: Self) -> Self {
+                    core::cmp::Ord::clamp(self, min, max)
+                }
+
+                #[inline]
+                fn clamp_min(self, min: Self) -> Self {
+                    core::cmp::Ord::max(self, min)
+                }
+
+                #[inline]
+                fn clamp_max(self, max: Self) -> Self {
+                    core::cmp::Ord::min(self, max)
+                }
+            }
+
+            impl ClampAssign for $ty {
+                #[inline]
+                fn clamp_assign(&mut self, min: Self, max: Self) {
+                    *self = core::cmp::Ord::clamp(*self, min, max);
+                }
+
+                #[inline]
+                fn clamp_min_assign(&mut self, min: Self) {
+                    *self = core::cmp::Ord::max(*self, min);
+                }
+
+                #[inline]
+                fn clamp_max_assign(&mut self, max: Self) {
+                    *self = core::cmp::Ord::min(*self, max);
+                }
+            }
         )+
     };
 }
@@ -279,6 +392,30 @@ macro_rules! impl_float {
                 #[inline]
                 fn from_f64(n: f64) -> $ty {
                     n as $ty
+                }
+            }
+
+            impl FromScalar for $ty {
+                type Scalar = Self;
+
+                #[inline]
+                fn from_scalar(scalar: Self) -> Self {
+                    scalar
+                }
+            }
+
+            impl FromScalarArray<1> for $ty {
+                #[inline]
+                fn from_array(scalars: [Self; 1]) -> Self {
+                    let [scalar] = scalars;
+                    scalar
+                }
+            }
+
+            impl IntoScalarArray<1> for $ty {
+                #[inline]
+                fn into_array(self) -> [Self; 1] {
+                    [self]
                 }
             }
 
@@ -455,6 +592,40 @@ macro_rules! impl_float {
                     $ty::ceil(self)
                 }
             }
+
+            impl Clamp for $ty {
+                #[inline]
+                fn clamp(self, min: Self, max: Self) -> Self {
+                    $ty::clamp(self, min, max)
+                }
+
+                #[inline]
+                fn clamp_min(self, min: Self) -> Self {
+                    $ty::max(self, min)
+                }
+
+                #[inline]
+                fn clamp_max(self, max: Self) -> Self {
+                    $ty::min(self, max)
+                }
+            }
+
+            impl ClampAssign for $ty {
+                #[inline]
+                fn clamp_assign(&mut self, min: Self, max: Self) {
+                    *self = $ty::clamp(*self, min, max);
+                }
+
+                #[inline]
+                fn clamp_min_assign(&mut self, min: Self) {
+                    *self = $ty::max(*self, min);
+                }
+
+                #[inline]
+                fn clamp_max_assign(&mut self, max: Self) {
+                    *self = $ty::min(*self, max);
+                }
+            }
         )+
     };
 }
@@ -501,3 +672,73 @@ fn pow<T: Clone + One + Mul<T, Output = T>>(mut base: T, mut exp: u32) -> T {
     }
     acc
 }
+
+/// Trait for lanewise comparison of two values.
+///
+/// This is similar to `PartialEq` and `PartialOrd`, except that it returns a
+/// Boolean mask instead of `bool` or [`Ordering`][core::cmp::Ordering].
+pub trait PartialCmp: HasBoolMask {
+    /// Compares `self < other`.
+    #[must_use]
+    fn lt(&self, other: &Self) -> Self::Mask;
+
+    /// Compares `self <= other`.
+    #[must_use]
+    fn lt_eq(&self, other: &Self) -> Self::Mask;
+
+    /// Compares `self == other`.
+    #[must_use]
+    fn eq(&self, other: &Self) -> Self::Mask;
+
+    /// Compares `self != other`.
+    #[must_use]
+    fn neq(&self, other: &Self) -> Self::Mask;
+
+    /// Compares `self >= other`.
+    #[must_use]
+    fn gt_eq(&self, other: &Self) -> Self::Mask;
+
+    /// Compares `self > other`.
+    #[must_use]
+    fn gt(&self, other: &Self) -> Self::Mask;
+}
+
+macro_rules! impl_partial_cmp {
+    ($($ty:ident),+) => {
+        $(
+            impl PartialCmp for $ty {
+                #[inline]
+                fn lt(&self, other: &Self) -> Self::Mask {
+                    self < other
+                }
+
+                #[inline]
+                fn lt_eq(&self, other: &Self) -> Self::Mask {
+                    self <= other
+                }
+
+                #[inline]
+                fn eq(&self, other: &Self) -> Self::Mask {
+                    self == other
+                }
+
+                #[inline]
+                fn neq(&self, other: &Self) -> Self::Mask {
+                    self != other
+                }
+
+                #[inline]
+                fn gt_eq(&self, other: &Self) -> Self::Mask {
+                    self >= other
+                }
+
+                #[inline]
+                fn gt(&self, other: &Self) -> Self::Mask {
+                    self > other
+                }
+            }
+        )+
+    };
+}
+
+impl_partial_cmp!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);

--- a/palette/src/num/libm.rs
+++ b/palette/src/num/libm.rs
@@ -239,3 +239,17 @@ impl Round for f64 {
         ::libm::ceil(self)
     }
 }
+
+impl MulAdd for f32 {
+    #[inline]
+    fn mul_add(self, m: Self, a: Self) -> Self {
+        ::libm::fmaf(self, m, a)
+    }
+}
+
+impl MulAdd for f64 {
+    #[inline]
+    fn mul_add(self, m: Self, a: Self) -> Self {
+        ::libm::fma(self, m, a)
+    }
+}

--- a/palette/src/num/wide.rs
+++ b/palette/src/num/wide.rs
@@ -283,6 +283,20 @@ macro_rules! impl_wide_float {
                     self.cmp_gt(*other)
                 }
             }
+
+            impl MulAdd for $ty {
+                #[inline]
+                fn mul_add(self, m: Self, a: Self) -> Self {
+                    $ty::mul_add(self, m, a)
+                }
+            }
+
+            impl MulSub for $ty {
+                #[inline]
+                fn mul_sub(self, m: Self, s: Self) -> Self {
+                    $ty::mul_sub(self, m, s)
+                }
+            }
         )+
     };
 }

--- a/palette/src/num/wide.rs
+++ b/palette/src/num/wide.rs
@@ -1,0 +1,335 @@
+use ::wide::{f32x4, f32x8, f64x2, f64x4, CmpEq, CmpGe, CmpGt, CmpLe, CmpLt, CmpNe};
+
+use super::*;
+
+macro_rules! impl_wide_float {
+    ($($ty: ident { array: [$scalar: ident; $n: expr], powf: $pow_self: ident, }),+) => {
+        $(
+            impl Real for $ty {
+                #[inline]
+                fn from_f64(n: f64) -> $ty {
+                    $ty::splat(n as $scalar)
+                }
+            }
+
+            impl FromScalar for $ty {
+                type Scalar = $scalar;
+
+                #[inline]
+                fn from_scalar(scalar: $scalar) -> Self {
+                    $ty::splat(scalar)
+                }
+            }
+
+            impl FromScalarArray<$n> for $ty {
+                #[inline]
+                fn from_array(scalars: [$scalar; $n]) -> Self {
+                    scalars.into()
+                }
+            }
+
+            impl IntoScalarArray<$n> for $ty {
+                #[inline]
+                fn into_array(self) -> [$scalar; $n] {
+                    self.into()
+                }
+            }
+
+            impl Zero for $ty {
+                #[inline]
+                fn zero() -> Self {
+                    $ty::ZERO
+                }
+            }
+
+            impl One for $ty {
+                #[inline]
+                fn one() -> Self {
+                    $ty::ONE
+                }
+            }
+
+            impl MinMax for $ty {
+                #[inline]
+                fn max(self, other: Self) -> Self {
+                    $ty::max(self, other)
+                }
+
+                #[inline]
+                fn min(self, other: Self) -> Self {
+                    $ty::min(self, other)
+                }
+
+                #[inline]
+                fn min_max(self, other: Self) -> (Self, Self) {
+                    ($ty::min(self, other), $ty::max(self, other))
+                }
+            }
+
+            impl Powu for $ty {
+                #[inline]
+                fn powu(self, exp: u32) -> Self {
+                    pow(self, exp)
+                }
+            }
+
+            impl IsValidDivisor for $ty {
+                #[inline]
+                fn is_valid_divisor(&self) -> Self {
+                    !self.cmp_eq($ty::ZERO)
+                }
+            }
+
+            impl Trigonometry for $ty {
+                #[inline]
+                fn sin(self) -> Self {
+                    $ty::sin(self)
+                }
+
+                #[inline]
+                fn cos(self) -> Self {
+                    $ty::cos(self)
+                }
+
+                #[inline]
+                fn sin_cos(self) -> (Self, Self) {
+                    $ty::sin_cos(self)
+                }
+
+                #[inline]
+                fn tan(self) -> Self {
+                    $ty::tan(self)
+                }
+
+                #[inline]
+                fn asin(self) -> Self {
+                    $ty::asin(self)
+                }
+
+                #[inline]
+                fn acos(self) -> Self {
+                    $ty::acos(self)
+                }
+
+                #[inline]
+                fn atan(self) -> Self {
+                    $ty::atan(self)
+                }
+
+                #[inline]
+                fn atan2(self, other: Self) -> Self {
+                    $ty::atan2(self, other)
+                }
+            }
+
+            impl Abs for $ty {
+                #[inline]
+                fn abs(self) -> Self {
+                    $ty::abs(self)
+                }
+            }
+
+            impl Sqrt for $ty {
+                #[inline]
+                fn sqrt(self) -> Self {
+                    $ty::sqrt(self)
+                }
+            }
+
+            impl Cbrt for $ty {
+                #[inline]
+                fn cbrt(self) -> Self {
+                    let mut array = self.into_array();
+
+                    for scalar in &mut array {
+                        *scalar = scalar.cbrt();
+                    }
+
+                    array.into()
+                }
+            }
+
+            impl Powf for $ty {
+                #[inline]
+                fn powf(self, exp: Self) -> Self {
+                    $ty::$pow_self(self, exp)
+                }
+            }
+
+            impl Powi for $ty {
+                #[inline]
+                fn powi(mut self, mut exp: i32) -> Self {
+                    if exp < 0 {
+                        exp = exp.wrapping_neg();
+                        self = self.recip();
+                    }
+
+                    Powu::powu(self, exp as u32)
+                }
+            }
+
+            // impl Recip for $ty {
+            //     #[inline]
+            //     fn recip(self) -> Self {
+            //         $ty::recip(self)
+            //     }
+            // }
+
+            impl Exp for $ty {
+                #[inline]
+                fn exp(self) -> Self {
+                    $ty::exp(self)
+                }
+            }
+
+            impl Hypot for $ty {
+                #[inline]
+                fn hypot(self, other: Self) -> Self {
+                    (self * self + other * other).sqrt()
+                }
+            }
+
+            impl Round for $ty {
+                #[inline]
+                fn round(self) -> Self {
+                    $ty::round(self)
+                }
+
+                #[inline]
+                fn floor(self) -> Self {
+                    let mut array = self.into_array();
+
+                    for scalar in &mut array {
+                        *scalar = scalar.floor();
+                    }
+
+                    array.into()
+                }
+
+                #[inline]
+                fn ceil(self) -> Self {
+                    let mut array = self.into_array();
+
+                    for scalar in &mut array {
+                        *scalar = scalar.ceil();
+                    }
+
+                    array.into()
+                }
+            }
+
+            impl Clamp for $ty {
+                #[inline]
+                fn clamp(self, min: Self, max: Self) -> Self {
+                    self.min(max).max(min)
+                }
+
+                #[inline]
+                fn clamp_min(self, min: Self) -> Self {
+                    $ty::max(self, min)
+                }
+
+                #[inline]
+                fn clamp_max(self, max: Self) -> Self {
+                    $ty::min(self, max)
+                }
+            }
+
+            impl ClampAssign for $ty {
+                #[inline]
+                fn clamp_assign(&mut self, min: Self, max: Self) {
+                    *self = $ty::clamp(*self, min, max);
+                }
+
+                #[inline]
+                fn clamp_min_assign(&mut self, min: Self) {
+                    *self = $ty::max(*self, min);
+                }
+
+                #[inline]
+                fn clamp_max_assign(&mut self, max: Self) {
+                    *self = $ty::min(*self, max);
+                }
+            }
+
+            impl PartialCmp for $ty {
+                #[inline]
+                fn lt(&self, other: &Self) -> Self::Mask {
+                    self.cmp_lt(*other)
+                }
+
+                #[inline]
+                fn lt_eq(&self, other: &Self) -> Self::Mask {
+                    self.cmp_le(*other)
+                }
+
+                #[inline]
+                fn eq(&self, other: &Self) -> Self::Mask {
+                    self.cmp_eq(*other)
+                }
+
+                #[inline]
+                fn neq(&self, other: &Self) -> Self::Mask {
+                    self.cmp_ne(*other)
+                }
+
+                #[inline]
+                fn gt_eq(&self, other: &Self) -> Self::Mask {
+                    self.cmp_ge(*other)
+                }
+
+                #[inline]
+                fn gt(&self, other: &Self) -> Self::Mask {
+                    self.cmp_gt(*other)
+                }
+            }
+        )+
+    };
+}
+
+impl_wide_float!(
+    f32x4 {
+        array: [f32; 4],
+        powf: pow_f32x4,
+    },
+    f32x8 {
+        array: [f32; 8],
+        powf: pow_f32x8,
+    },
+    f64x2 {
+        array: [f64; 2],
+        powf: pow_f64x2,
+    },
+    f64x4 {
+        array: [f64; 4],
+        powf: pow_f64x4,
+    }
+);
+
+impl Recip for f32x4 {
+    #[inline]
+    fn recip(self) -> Self {
+        f32x4::recip(self)
+    }
+}
+
+impl Recip for f32x8 {
+    #[inline]
+    fn recip(self) -> Self {
+        f32x8::recip(self)
+    }
+}
+
+impl Recip for f64x2 {
+    #[inline]
+    fn recip(self) -> Self {
+        f64x2::ONE / self
+    }
+}
+
+impl Recip for f64x4 {
+    #[inline]
+    fn recip(self) -> Self {
+        f64x4::ONE / self
+    }
+}

--- a/palette/tests/color_checker_data/color_checker.rs
+++ b/palette/tests/color_checker_data/color_checker.rs
@@ -9,18 +9,16 @@ The Rgb colors in this data appear to be adapted to the reference white point fo
 use approx::assert_relative_eq;
 use lazy_static::lazy_static;
 
-use palette::convert::IntoColorUnclamped;
-use palette::white_point::D50;
-use palette::{Lab, Xyz, Yxy};
+use palette::{convert::IntoColorUnclamped, num::IntoScalarArray, white_point::D50, Lab, Xyz, Yxy};
 
 use super::load_data::{load_color_checker, ColorCheckerRaw};
 use super::MAX_ERROR;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct ColorCheckerData {
-    yxy: Yxy<D50, f64>,
-    xyz: Xyz<D50, f64>,
-    lab: Lab<D50, f64>,
+pub struct ColorCheckerData<T = f64> {
+    yxy: Yxy<D50, T>,
+    xyz: Xyz<D50, T>,
+    lab: Lab<D50, T>,
 }
 
 impl From<ColorCheckerRaw> for ColorCheckerData {
@@ -35,8 +33,14 @@ impl From<ColorCheckerRaw> for ColorCheckerData {
 
 macro_rules! impl_from_color {
     ($self_ty:ident) => {
-        impl From<$self_ty<D50, f64>> for ColorCheckerData {
-            fn from(color: $self_ty<D50, f64>) -> ColorCheckerData {
+        impl<T> From<$self_ty<D50, T>> for ColorCheckerData<T>
+        where
+            T: Copy,
+            $self_ty<D50, T>: IntoColorUnclamped<Yxy<D50, T>>
+                + IntoColorUnclamped<Xyz<D50, T>>
+                + IntoColorUnclamped<Lab<D50, T>>,
+        {
+            fn from(color: $self_ty<D50, T>) -> ColorCheckerData<T> {
                 ColorCheckerData {
                     yxy: color.into_color_unclamped(),
                     xyz: color.into_color_unclamped(),
@@ -50,6 +54,33 @@ macro_rules! impl_from_color {
 impl_from_color!(Yxy);
 impl_from_color!(Xyz);
 impl_from_color!(Lab);
+
+impl<V> Into<[ColorCheckerData<V::Scalar>; 2]> for ColorCheckerData<V>
+where
+    V: IntoScalarArray<2>,
+    Xyz<D50, V>: Into<[Xyz<D50, V::Scalar>; 2]>,
+    Yxy<D50, V>: Into<[Yxy<D50, V::Scalar>; 2]>,
+    Lab<D50, V>: Into<[Lab<D50, V::Scalar>; 2]>,
+{
+    fn into(self) -> [ColorCheckerData<V::Scalar>; 2] {
+        let [xyz0, xyz1]: [_; 2] = self.xyz.into();
+        let [yxy0, yxy1]: [_; 2] = self.yxy.into();
+        let [lab0, lab1]: [_; 2] = self.lab.into();
+
+        [
+            ColorCheckerData {
+                xyz: xyz0,
+                yxy: yxy0,
+                lab: lab0,
+            },
+            ColorCheckerData {
+                xyz: xyz1,
+                yxy: yxy1,
+                lab: lab1,
+            },
+        ]
+    }
+}
 
 lazy_static! {
     static ref TEST_DATA: Vec<ColorCheckerData> = load_color_checker();
@@ -77,5 +108,47 @@ pub fn run_from_lab_tests() {
     for expected in TEST_DATA.iter() {
         let result = ColorCheckerData::from(expected.lab);
         check_equal(&result, expected);
+    }
+}
+
+#[cfg(feature = "wide")]
+pub mod wide_f64x2 {
+    use super::*;
+
+    pub fn run_from_yxy_tests() {
+        for expected in TEST_DATA.chunks_exact(2) {
+            let [result0, result1]: [ColorCheckerData; 2] =
+                ColorCheckerData::from(Yxy::<_, wide::f64x2>::from([
+                    expected[0].yxy,
+                    expected[1].yxy,
+                ]))
+                .into();
+            check_equal(&result0, &expected[0]);
+            check_equal(&result1, &expected[1]);
+        }
+    }
+    pub fn run_from_xyz_tests() {
+        for expected in TEST_DATA.chunks_exact(2) {
+            let [result0, result1]: [ColorCheckerData; 2] =
+                ColorCheckerData::from(Xyz::<_, wide::f64x2>::from([
+                    expected[0].xyz,
+                    expected[1].xyz,
+                ]))
+                .into();
+            check_equal(&result0, &expected[0]);
+            check_equal(&result1, &expected[1]);
+        }
+    }
+    pub fn run_from_lab_tests() {
+        for expected in TEST_DATA.chunks_exact(2) {
+            let [result0, result1]: [ColorCheckerData; 2] =
+                ColorCheckerData::from(Lab::<_, wide::f64x2>::from([
+                    expected[0].lab,
+                    expected[1].lab,
+                ]))
+                .into();
+            check_equal(&result0, &expected[0]);
+            check_equal(&result1, &expected[1]);
+        }
     }
 }

--- a/palette/tests/color_checker_data/mod.rs
+++ b/palette/tests/color_checker_data/mod.rs
@@ -29,3 +29,32 @@ pub fn color_checker_from_xyz() {
 pub fn color_checker_from_lab() {
     color_checker::run_from_lab_tests();
 }
+
+#[cfg(feature = "wide")]
+pub mod wide {
+    #[test]
+    pub fn babel_from_yxy() {
+        super::babel::wide_f64x2::run_from_yxy_tests();
+    }
+    #[test]
+    pub fn babel_from_xyz() {
+        super::babel::wide_f64x2::run_from_xyz_tests();
+    }
+    #[test]
+    pub fn babel_from_lab() {
+        super::babel::wide_f64x2::run_from_lab_tests();
+    }
+
+    #[test]
+    pub fn color_checker_from_yxy() {
+        super::color_checker::wide_f64x2::run_from_yxy_tests();
+    }
+    #[test]
+    pub fn color_checker_from_xyz() {
+        super::color_checker::wide_f64x2::run_from_xyz_tests();
+    }
+    #[test]
+    pub fn color_checker_from_lab() {
+        super::color_checker::wide_f64x2::run_from_lab_tests();
+    }
+}

--- a/palette/tests/convert/data_color_mine.rs
+++ b/palette/tests/convert/data_color_mine.rs
@@ -10,7 +10,7 @@ use serde_derive::Deserialize;
 use palette::{
     angle::AngleEq,
     convert::{FromColorUnclamped, IntoColorUnclamped},
-    num::{IntoScalarArray, One, Real, Zero},
+    num::{FromScalarArray, IntoScalarArray, One, Real, Zero},
     rgb::RgbStandard,
     white_point::{WhitePoint, D65},
     Hsl, Hsv, Hwb, Lab, Lch, LinSrgb, Srgb, Xyz, Yxy,
@@ -220,6 +220,57 @@ impl_from_color!(F, Lch<D65, F>);
 impl_from_rgb_derivative!(F, Hsl<::palette::encoding::Srgb, F>);
 impl_from_rgb_derivative!(F, Hsv<::palette::encoding::Srgb, F>);
 impl_from_rgb_derivative!(F, Hwb<::palette::encoding::Srgb, F>);
+
+impl<F, S, const N: usize> From<[ColorMine<F>; N]> for ColorMine<S>
+where
+    [Xyz<D65, F>; N]: Default,
+    [Yxy<D65, F>; N]: Default,
+    [Lab<D65, F>; N]: Default,
+    [Lch<D65, F>; N]: Default,
+    [LinSrgb<F>; N]: Default,
+    [Srgb<F>; N]: Default,
+    [Hsl<::palette::encoding::Srgb, F>; N]: Default,
+    [Hsv<::palette::encoding::Srgb, F>; N]: Default,
+    [Hwb<::palette::encoding::Srgb, F>; N]: Default,
+    [F; N]: Default,
+    S: FromScalarArray<N, Scalar = F>,
+{
+    fn from(colors: [ColorMine<F>; N]) -> Self {
+        let mut xyz: [Xyz<D65, F>; N] = Default::default();
+        let mut yxy: [Yxy<D65, F>; N] = Default::default();
+        let mut lab: [Lab<D65, F>; N] = Default::default();
+        let mut lch: [Lch<D65, F>; N] = Default::default();
+        let mut linear_rgb: [LinSrgb<F>; N] = Default::default();
+        let mut rgb: [Srgb<F>; N] = Default::default();
+        let mut hsl: [Hsl<::palette::encoding::Srgb, F>; N] = Default::default();
+        let mut hsv: [Hsv<::palette::encoding::Srgb, F>; N] = Default::default();
+        let mut hwb: [Hwb<::palette::encoding::Srgb, F>; N] = Default::default();
+
+        for (index, color) in IntoIterator::into_iter(colors).enumerate() {
+            xyz[index] = color.xyz;
+            yxy[index] = color.yxy;
+            lab[index] = color.lab;
+            lch[index] = color.lch;
+            linear_rgb[index] = color.linear_rgb;
+            rgb[index] = color.rgb;
+            hsl[index] = color.hsl;
+            hsv[index] = color.hsv;
+            hwb[index] = color.hwb;
+        }
+
+        ColorMine {
+            xyz: xyz.into(),
+            yxy: yxy.into(),
+            lab: lab.into(),
+            lch: lch.into(),
+            linear_rgb: linear_rgb.into(),
+            rgb: rgb.into(),
+            hsl: hsl.into(),
+            hsv: hsv.into(),
+            hwb: hwb.into(),
+        }
+    }
+}
 
 impl<F, S> Into<[ColorMine<F>; 2]> for ColorMine<S>
 where

--- a/palette/tests/convert/mod.rs
+++ b/palette/tests/convert/mod.rs
@@ -12,6 +12,7 @@ pub fn xyz_yxy_conversion() {
 pub fn color_difference_ciede() {
     data_ciede_2000::run_tests();
 }
+
 #[test]
 pub fn color_mine_from_lab() {
     data_color_mine::run_from_lab_tests();
@@ -20,7 +21,6 @@ pub fn color_mine_from_lab() {
 pub fn color_mine_from_lch() {
     data_color_mine::run_from_lch_tests();
 }
-
 #[test]
 pub fn color_mine_from_xyz() {
     data_color_mine::run_from_xyz_tests();
@@ -48,4 +48,49 @@ pub fn color_mine_from_hsv() {
 #[test]
 pub fn color_mine_from_hwb() {
     data_color_mine::run_from_hwb_tests();
+}
+
+#[cfg(feature = "wide")]
+pub mod wide {
+    #[test]
+    pub fn xyz_yxy_conversion() {
+        super::data_cie_15_2004::wide_f32x4::run_tests();
+    }
+
+    #[test]
+    pub fn color_mine_from_xyz() {
+        super::data_color_mine::wide_f64x2::run_from_xyz_tests();
+    }
+    #[test]
+    pub fn color_mine_from_yxy() {
+        super::data_color_mine::wide_f64x2::run_from_yxy_tests();
+    }
+    #[test]
+    pub fn color_mine_from_linear_rgb() {
+        super::data_color_mine::wide_f64x2::run_from_linear_rgb_tests();
+    }
+    #[test]
+    pub fn color_mine_from_rgb() {
+        super::data_color_mine::wide_f64x2::run_from_rgb_tests();
+    }
+    #[test]
+    pub fn color_mine_from_hsl() {
+        super::data_color_mine::wide_f64x2::run_from_hsl_tests();
+    }
+    #[test]
+    pub fn color_mine_from_hsv() {
+        super::data_color_mine::wide_f64x2::run_from_hsv_tests();
+    }
+    #[test]
+    pub fn color_mine_from_hwb() {
+        super::data_color_mine::wide_f64x2::run_from_hwb_tests();
+    }
+    #[test]
+    pub fn color_mine_from_lab() {
+        super::data_color_mine::wide_f64x2::run_from_lab_tests();
+    }
+    #[test]
+    pub fn color_mine_from_lch() {
+        super::data_color_mine::wide_f64x2::run_from_lch_tests();
+    }
 }

--- a/palette/tests/pointer_dataset/mod.rs
+++ b/palette/tests/pointer_dataset/mod.rs
@@ -8,3 +8,15 @@ pub fn from_lab() {
 pub fn from_lch() {
     pointer_data::run_from_lch_tests();
 }
+
+#[cfg(feature = "wide")]
+mod wide {
+    #[test]
+    pub fn from_lab() {
+        super::pointer_data::wide_f64x2::run_from_lab_tests();
+    }
+    #[test]
+    pub fn from_lch() {
+        super::pointer_data::wide_f64x2::run_from_lch_tests();
+    }
+}


### PR DESCRIPTION
This adds initial support for SIMD types in most places. An exception is the `Luv` related types, where the conversion logic need extra attention. Some of the conversions aren't necessarily optimal but the focus was on making it work at all.

Integration with the [wide](https://crates.io/crates/wide) crate has been added behind a feature flag, as a first example. More SIMD crates can be added in the future.

## Breaking Change

Some functions that used to return `bool` is now returning a mask type. This mask type is still `bool` for regular floats and ints, so this change will mostly affect generic code. `GetHue` was also changed to no longer return `Option<T>` for SIMD friendliness.