### PR TITLE
Reduce the minimum compile time a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [1.55.0, stable, beta, nightly]
+        toolchain: [1.60.0, stable, beta, nightly]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,18 @@ jobs:
           override: true
           target: thumbv6m-none-eabi
           profile: minimal
-      - uses: actions-rs/cargo@v1
+      - name: Minimal check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -v -p palette --no-default-features --features std
+      - name: find-crate check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: -v -p palette --no-default-features --features "std find-crate"
+      - name: Default check
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: -v --workspace --exclude no_std_test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
         "bytemuck",
         "wide"
     ],
-    "rust-analyzer.assist.importEnforceGranularity": true,
-    "rust-analyzer.assist.importGranularity": "crate",
-    "rust-analyzer.assist.importGroup": true
+    "rust-analyzer.imports.granularity.enforce": true,
+    "rust-analyzer.imports.granularity.group": "crate",
+    "rust-analyzer.imports.group.enable": true
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "palette_derive",
 
     # Test crates
-    "no_std_test"
+    "no_std_test",
 ]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.55.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
+This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
 
 ## Contributing
 

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -21,18 +21,20 @@ readme = "README.md"
 keywords = ["color", "conversion", "linear", "pixel", "rgb"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+resolver = "2"
 categories = ["graphics", "multimedia::images", "no-std"]
 build = "build/main.rs"
 
 [features]
-default = ["named_from_str", "named_gradients", "std"]
+default = ["named_from_str", "named_gradients", "std", "approx"]
 named_from_str = ["named", "phf"]
 named = []
 named_gradients = ["std"]
 random = ["rand"]
 serializing = ["serde", "std"]
 #ignore in feature test
-std = ["approx/std"]
+find-crate = ["palette_derive/find-crate"]
+std = ["approx?/std"]
 
 [lib]
 bench = false
@@ -40,7 +42,7 @@ bench = false
 [dependencies]
 palette_derive = { version = "0.6.0", path = "../palette_derive" }
 fast-srgb8 = "1.0.0"
-approx = { version = "0.5", default-features = false }
+approx = { version = "0.5", default-features = false, optional = true }
 libm = { version = "0.2.1", default-features = false, optional = true }
 
 [dependencies.phf]

--- a/palette/README.md
+++ b/palette/README.md
@@ -44,6 +44,7 @@ These features are enabled by default:
 * `"named_from_str"` - Enables `named::from_str`, which maps name strings to colors.
 * `"named_gradients"`- Enables gradient constants, located in `gradient::named`. This requires the standard library.
 * `"std"` - Enables use of the standard library.
+* `"approx"` - Enables approximate comparison using [`approx`].
 
 These features are disabled by default:
 
@@ -52,6 +53,7 @@ These features are disabled by default:
 * `"libm"` - Uses the [`libm`] floating point math library (for when the `std` feature is disabled).
 * `"bytemuck"` - Enables casting between plain data types using [`bytemuck`].
 * `"wide"` - Enables support for using SIMD types from [`wide`].
+* `"find-crate"` - Enables derives to find the `palette` crate when it's renamed in `Cargo.toml`.
 
 ### Using palette in an embedded environment
 
@@ -353,3 +355,4 @@ at your option.
 [`libm`]: https://crates.io/crates/libm
 [`bytemuck`]: https://crates.io/crates/bytemuck
 [`wide`]: https://crates.io/crates/wide
+[`approx`]: https://crates.io/crates/approx

--- a/palette/README.md
+++ b/palette/README.md
@@ -16,7 +16,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.55.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
+This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
 
 ## Getting Started
 

--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -5,6 +5,7 @@ use core::{
     },
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{
@@ -345,6 +346,7 @@ impl<C: Default, T: Stimulus> Default for Alpha<C, T> {
     }
 }
 
+#[cfg(feature = "approx")]
 impl<C, T> AbsDiffEq for Alpha<C, T>
 where
     C: AbsDiffEq<Epsilon = T::Epsilon>,
@@ -363,6 +365,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<C, T> RelativeEq for Alpha<C, T>
 where
     C: RelativeEq<Epsilon = T::Epsilon>,
@@ -385,6 +388,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<C, T> UlpsEq for Alpha<C, T>
 where
     C: UlpsEq<Epsilon = T::Epsilon>,

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -1,5 +1,6 @@
 use core::ops::{Add, AddAssign, Deref, DerefMut, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 use crate::{
@@ -177,6 +178,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<C, T> AbsDiffEq for PreAlpha<C>
 where
     C: AbsDiffEq<Epsilon = T::Epsilon> + Premultiply<Scalar = T>,
@@ -195,6 +197,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<C, T> RelativeEq for PreAlpha<C>
 where
     C: RelativeEq<Epsilon = T::Epsilon> + Premultiply<Scalar = T>,
@@ -217,6 +220,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<C, T> UlpsEq for PreAlpha<C>
 where
     C: UlpsEq<Epsilon = T::Epsilon> + Premultiply<Scalar = T>,

--- a/palette/src/gradient.rs
+++ b/palette/src/gradient.rs
@@ -5,6 +5,7 @@
 
 use core::{cmp::max, marker::PhantomData};
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 use crate::{
@@ -460,6 +461,7 @@ impl<T> From<::std::ops::RangeFull> for Range<T> {
     }
 }
 
+#[cfg(feature = "approx")]
 impl<T> AbsDiffEq for Range<T>
 where
     T: AbsDiffEq,
@@ -488,6 +490,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<T> RelativeEq for Range<T>
 where
     T: RelativeEq,
@@ -519,6 +522,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<T> UlpsEq for Range<T>
 where
     T: UlpsEq,

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -4,6 +4,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Not, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -12,6 +12,7 @@ use rand::{
     Rng,
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 #[cfg(feature = "random")]

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -4,6 +4,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -1,8 +1,12 @@
+#[cfg(any(feature = "approx", feature = "random"))]
+use core::ops::Mul;
+
 use core::{
     cmp::PartialEq,
-    ops::{Add, AddAssign, Mul, Sub, SubAssign},
+    ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 #[cfg(feature = "random")]
@@ -14,13 +18,13 @@ use rand::{
     Rng,
 };
 
+#[cfg(feature = "approx")]
+use crate::{angle::HalfRotation, num::Zero};
+
 #[cfg(feature = "random")]
 use crate::angle::FullRotation;
 
-use crate::{
-    angle::{AngleEq, FromAngle, HalfRotation, RealAngle, SignedAngle, UnsignedAngle},
-    num::Zero,
-};
+use crate::angle::{AngleEq, FromAngle, RealAngle, SignedAngle, UnsignedAngle};
 
 macro_rules! make_hues {
     ($($(#[$doc:meta])+ struct $name:ident;)+) => ($(
@@ -185,6 +189,7 @@ macro_rules! make_hues {
         //
         // The recommendation is use 180 * epsilon as the epsilon and do not compare by
         // ulps. Because of this we loose some precision for values close to 0.0.
+        #[cfg(feature = "approx")]
         impl<T> AbsDiffEq for $name<T>
         where
             T: RealAngle + SignedAngle + Zero + AngleEq<Mask = bool> + Sub<Output = T> + AbsDiffEq + Clone,
@@ -206,6 +211,7 @@ macro_rules! make_hues {
             }
         }
 
+        #[cfg(feature = "approx")]
         impl<T> RelativeEq for $name<T>
         where
             T: RealAngle + SignedAngle + Zero + AngleEq<Mask = bool> + Sub<Output = T> + Clone + RelativeEq,
@@ -235,6 +241,7 @@ macro_rules! make_hues {
             }
         }
 
+        #[cfg(feature = "approx")]
         impl<T> UlpsEq for $name<T>
         where
             T: RealAngle + SignedAngle + Zero + AngleEq<Mask = bool> + Sub<Output = T> + Clone + UlpsEq,

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -4,6 +4,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, DivAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{
@@ -576,6 +577,7 @@ impl_color_sub!(Hwb<S, T>, [hue, whiteness, blackness], standard);
 impl_array_casts!(Hwb<S, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Hwb<S>, [whiteness, blackness], standard);
 
+#[cfg(feature = "approx")]
 impl<S, T> AbsDiffEq for Hwb<S, T>
 where
     T: Stimulus + PartialOrd + Add<Output = T> + AbsDiffEq + Clone,
@@ -605,6 +607,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<S, T> RelativeEq for Hwb<S, T>
 where
     T: Stimulus + PartialOrd + Add<Output = T> + RelativeEq + Clone,
@@ -637,6 +640,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<S, T> UlpsEq for Hwb<S, T>
 where
     T: Stimulus + PartialOrd + Add<Output = T> + UlpsEq + Clone,

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -3,6 +3,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, BitOr, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -3,6 +3,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, BitOr, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -3,6 +3,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Mul, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -205,6 +205,7 @@
 #[cfg(any(feature = "std", test))]
 extern crate core;
 
+#[cfg(feature = "approx")]
 #[cfg_attr(test, macro_use)]
 extern crate approx;
 

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -6,6 +6,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{
@@ -1017,6 +1018,7 @@ impl<S> From<Lumaa<S, u8>> for u16 {
 
 impl_simd_array_conversion!(Luma<S>, [luma], standard);
 
+#[cfg(feature = "approx")]
 impl<S, T> AbsDiffEq for Luma<S, T>
 where
     T: AbsDiffEq,
@@ -1032,6 +1034,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<S, T> RelativeEq for Luma<S, T>
 where
     T: RelativeEq,
@@ -1050,6 +1053,7 @@ where
     }
 }
 
+#[cfg(feature = "approx")]
 impl<S, T> UlpsEq for Luma<S, T>
 where
     T: UlpsEq,

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -3,6 +3,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/macros/equality.rs
+++ b/palette/src/macros/equality.rs
@@ -15,6 +15,7 @@ macro_rules! impl_eq {
 
         impl<$($ty_param,)* T> Eq for $self_ty<$($ty_param,)* T> where T: Eq {}
 
+        #[cfg(feature = "approx")]
         impl<$($ty_param,)* T> AbsDiffEq for $self_ty<$($ty_param,)* T>
         where T: AbsDiffEq,
             T::Epsilon: Clone,
@@ -33,6 +34,7 @@ macro_rules! impl_eq {
             }
         }
 
+        #[cfg(feature = "approx")]
         impl<$($ty_param,)* T> RelativeEq for $self_ty<$($ty_param,)* T>
         where T: RelativeEq,
             T::Epsilon: Clone,
@@ -49,6 +51,7 @@ macro_rules! impl_eq {
             }
         }
 
+        #[cfg(feature = "approx")]
         impl<$($ty_param,)* T> UlpsEq for $self_ty<$($ty_param,)* T>
         where T: UlpsEq,
             T::Epsilon: Clone,
@@ -89,6 +92,7 @@ macro_rules! impl_eq_hue {
             $hue_ty<T>: Eq,
         {}
 
+        #[cfg(feature = "approx")]
         impl<$($ty_param,)* T> AbsDiffEq for $self_ty<$($ty_param,)* T>
         where
             T: AbsDiffEq,
@@ -109,6 +113,7 @@ macro_rules! impl_eq_hue {
             }
         }
 
+        #[cfg(feature = "approx")]
         impl<$($ty_param,)* T> RelativeEq for $self_ty<$($ty_param,)* T>
         where
             T: RelativeEq,
@@ -127,6 +132,7 @@ macro_rules! impl_eq_hue {
             }
         }
 
+        #[cfg(feature = "approx")]
         impl<$($ty_param,)* T> UlpsEq for $self_ty<$($ty_param,)* T>
         where
             T: UlpsEq,

--- a/palette/src/macros/lazy_select.rs
+++ b/palette/src/macros/lazy_select.rs
@@ -1,6 +1,6 @@
 /// Chains calls to `LazySelect::lazy_select` to mimic an if-else chain.
 ///
-/// ```
+/// ```igonre
 /// let result = lazy_select! {
 ///     if predicate1 => result1,
 ///     if predicate2 => result2,

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -1,5 +1,6 @@
 use core::ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
 #[cfg(feature = "random")]

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -1,5 +1,6 @@
 use core::ops::{Add, AddAssign, BitAnd, Sub, SubAssign};
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -7,6 +7,7 @@ use core::{
     str::FromStr,
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -3,6 +3,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -3,6 +3,7 @@ use core::{
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
 };
 
+#[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg(feature = "random")]
 use rand::{

--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "palette_derive"
-version = "0.6.0" #automatically updated
+version = "0.6.0"                                                      #automatically updated
 authors = ["Erik Hedvall <hello@erikhedvall.nu>"]
 exclude = []
 description = "Automatically implement traits from the palette crate."
@@ -10,15 +10,23 @@ readme = "README.md"
 keywords = ["palette", "derive", "macros"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+resolver = "2"
 
 [lib]
 proc-macro = true
 bench = false
 
 [dependencies]
-syn = { version = "^1.0", features = ["extra-traits"] }
+syn = { version = "^1.0", default-features = false, features = [
+    "derive",
+    "parsing",
+    "printing",
+    "clone-impls",
+    "extra-traits",
+    "proc-macro",
+] }
 quote = "^1.0"
 proc-macro2 = "^1.0"
-find-crate = "0.6"
+find-crate = { version = "0.6", optional = true }
 
 [features]

--- a/palette_derive/README.md
+++ b/palette_derive/README.md
@@ -4,7 +4,7 @@ Contains derive macros for the [`palette`](https://crates.io/crates/palette/) cr
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.55.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
+This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
 
 ## License
 

--- a/palette_derive/src/util.rs
+++ b/palette_derive/src/util.rs
@@ -37,6 +37,7 @@ pub fn color_path(color: &str, internal: bool) -> TokenStream {
     }
 }
 
+#[cfg(feature = "find-crate")]
 fn find_crate_name() -> Ident {
     use find_crate::Error;
 
@@ -48,4 +49,9 @@ fn find_crate_name() -> Ident {
             error
         ),
     }
+}
+
+#[cfg(not(feature = "find-crate"))]
+fn find_crate_name() -> Ident {
+    Ident::new("palette", Span::call_site())
 }

--- a/scripts/test_features.sh
+++ b/scripts/test_features.sh
@@ -4,7 +4,7 @@ set -e
 features=""
 
 #Features that will always be activated
-required_features="std"
+required_features="std approx"
 
 
 #Find features


### PR DESCRIPTION
Reduces the minimum compile time a bit by reducing the feature set of `syn`, making more dependencies optional and changing to dependency resolver version 2. I got inspired by #285 to at least make the build time somewhat better. This reduces it by about 30% on my slow laptop (from ~15 seconds to ~10 seconds), but your mileage may vary and it also depends on what other dependencies are in the mix.

## Breaking Change

* Increases MSRV to 1.60.0 to get the `?` syntax in cargo features. Required for making `approx` optional.
* `approx` is now optional, but still enabled by default.
* The crate will no longer find itself by default if it's renamed in `Cargo.tom`. It requires the `find-crate` feature.

## Slow Laptop Benchmarks

```text
Slow laptop type    Microsoft Surface Pro 7 i5
Slow OS setup       Ubuntu in WSL2 in Windows 11
Processor           Intel(R) Core(TM) i5-1035G4 CPU @ 1.10GHz   1.50 GHz
Installed RAM       8,00 GB (7,60 GB usable)
System type         64-bit operating system, x64-based processor

rustc 1.62.0 (a8314ef7d 2022-06-27)
```

### Commands

Debug mode:

```sh
cargo clean
cargo check --timings --no-default-features --features=std -p palette
```

Release mode:

```sh
cargo clean
cargo check --timings --no-default-features --features=std -p palette --release
```

### Before

| Debug mode | Release mode |
|-----|-----|
| ![before - debug](https://user-images.githubusercontent.com/225229/178365051-46e4539b-6b01-44ce-884d-fa4740c94fd3.png) | ![before - release](https://user-images.githubusercontent.com/225229/178365050-aa9f2320-f700-4ca4-bc04-676ff6996013.png)

### After

| Debug mode | Release mode |
|-----|-----|
| ![after - debug](https://user-images.githubusercontent.com/225229/178365046-0b9db772-2dcb-4dde-b8de-bec44de4ec91.png) | ![after - release](https://user-images.githubusercontent.com/225229/178365041-632f47da-64f7-4aa7-b4a1-596b8c22bb33.png)

