### PR TITLE
Update phf to 0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [1.48.0, stable, beta, nightly]
+        toolchain: [1.60.0, stable, beta, nightly]
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
     branches:
       - master
+      - "[0-9]+.[0-9]+"
   push:
     branches:
       - staging

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.48.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
+This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches and similar changes.
 
 ## Contributing
 

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
     ".gitignore",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
-    "version.sh"
+    "version.sh",
 ]
 description = "Convert and manage colors with a focus on correctness, flexibility and ease of use."
 documentation = "https://docs.rs/palette/0.6.0/palette/"
@@ -44,7 +44,7 @@ num-traits = { version = "0.2", default-features = false }
 approx = { version = "0.5", default-features = false }
 
 [dependencies.phf]
-version = "0.9"
+version = "0.11.0"
 optional = true
 default-features = false
 features = ["macros"]

--- a/palette/README.md
+++ b/palette/README.md
@@ -16,7 +16,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.48.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
+This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches and similar changes.
 
 ## Getting Started
 

--- a/palette/tests/hsluv_dataset/hsluv_dataset.rs
+++ b/palette/tests/hsluv_dataset/hsluv_dataset.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 struct HsluvExample {
-    name: String,
     lchuv: Lchuv<D65, f64>,
     hsluv: Hsluv<D65, f64>,
     luv: Luv<D65, f64>,
@@ -46,7 +45,6 @@ fn load_data() -> Examples {
             (
                 k.clone(),
                 HsluvExample {
-                    name: k.clone(),
                     luv: Luv::new(luv_data[0], luv_data[1], luv_data[2]),
                     hsluv: Hsluv::new(hsluv_data[0], hsluv_data[1], hsluv_data[2]),
                     lchuv: Lchuv::new(lchuv_data[0], lchuv_data[1], lchuv_data[2]),

--- a/palette_derive/README.md
+++ b/palette_derive/README.md
@@ -4,7 +4,7 @@ Contains derive macros for the [`palette`](https://crates.io/crates/palette/) cr
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.48.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will be considered a breaking change.
+This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches and similar changes.
 
 ## License
 


### PR DESCRIPTION
As mentioned in #289 a transitive dependency, via `phf`, was flagged by Windows Defender. The dependency could be removed in `phf`, and this change updates the version of `phf` in `palette` to one that doesn't depend on the removed dependency. `phf` is not part of the public API and can thus be patched as a non-breaking change.

I'm treating this as a security patch and making an exception from the general MSRV rule. Also clarifying in print that this exception may have to happen. It may still support older versions when the `named` feature is disabled, unless they are eagerly parsing the `phf` crate.

## Closed Issues

* Fixes #289, by changing to a newer `phf` version.