### PR TITLE
Expose doc comment for Rgb::from_str

### DIFF
--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1164,8 +1164,8 @@ impl std::error::Error for FromHexError {
 impl<S> FromStr for Rgb<S, u8> {
     type Err = FromHexError;
 
-    // Parses a color hex code of format '#ff00bb' or '#abc' into a
-    // Rgb<S, u8> instance.
+    /// Parses a color hex code of format '#ff00bb' or '#abc' into a
+    /// [`Rgb<S, u8>`] instance.
     fn from_str(hex: &str) -> Result<Self, Self::Err> {
         let hex_code = hex.strip_prefix('#').map_or(hex, |stripped| stripped);
         match hex_code.len() {

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1164,7 +1164,7 @@ impl std::error::Error for FromHexError {
 impl<S> FromStr for Rgb<S, u8> {
     type Err = FromHexError;
 
-    /// Parses a color hex code of format '#ff00bb' or '#abc' into a
+    /// Parses a color hex code of format '#ff00bb' or '#abc' (with or without the leading '#') into a
     /// [`Rgb<S, u8>`] instance.
     fn from_str(hex: &str) -> Result<Self, Self::Err> {
         let hex_code = hex.strip_prefix('#').map_or(hex, |stripped| stripped);


### PR DESCRIPTION
<!-- Describe your changes as well as possible. What has changed and why? Someone who hasn't followed previous discussions should be able to understand why this change was made and/or be able to find out why. -->

<!--
## Closed Issues

* Fixes #1234, by doing XYZ.
* Closes #4321, by implementing ABC.
-->

<!--
## Breaking Change

Will this pull request break dependent code? Describe how/why and give an example of how to migrate existing code to use the new version.
-->

I was looking through the crate's documentation for a way to parse an RGB hex code string and stumbled on [Rgb::from_str](https://docs.rs/palette/0.6.1/palette/rgb/struct.Rgb.html#impl-FromStr-for-Rgb%3CS%2C%20u8%3E). However, there were no examples/description provided and so I had no idea if the format I was working with would be accepted. Clicking the source tab revealed a helpful comment.

This change just exposes that as a doc comment.