### PR TITLE
Removed manual conversion impls, fixed some docs, reduced trait bounds

### DIFF
--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -755,6 +755,8 @@ mod test {
     use super::Hsl;
     use crate::{FromColor, Hsv, Srgb};
 
+    test_convert_into_from_xyz!(Hsl);
+
     #[test]
     fn red() {
         let a = Hsl::from_color(Srgb::new(1.0, 0.0, 0.0));

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -479,6 +479,8 @@ mod test {
     use super::Hsluv;
     use crate::{white_point::D65, FromColor, Lchuv, LuvHue, Saturate};
 
+    test_convert_into_from_xyz!(Hsluv);
+
     #[test]
     fn lchuv_round_trip() {
         for hue in (0..=20).map(|x| x as f64 * 18.0) {

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -754,6 +754,8 @@ mod test {
     use super::Hsv;
     use crate::{FromColor, Hsl, Srgb};
 
+    test_convert_into_from_xyz!(Hsv);
+
     #[test]
     fn red() {
         let a = Hsv::from_color(Srgb::new(1.0, 0.0, 0.0));

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -787,6 +787,8 @@ mod test {
     use super::Hwb;
     use crate::{Clamp, FromColor, Srgb};
 
+    test_convert_into_from_xyz!(Hwb);
+
     #[test]
     fn red() {
         let a = Hwb::from_color(Srgb::new(1.0, 0.0, 0.0));

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -1,6 +1,6 @@
 use core::{
     marker::PhantomData,
-    ops::{Add, AddAssign, BitAnd, BitOr, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, BitAnd, BitOr, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
 #[cfg(feature = "approx")]
@@ -295,12 +295,12 @@ impl_premultiply!(Lab<Wp> {l, a, b} phantom: white_point);
 
 impl<Wp, T> GetHue for Lab<Wp, T>
 where
-    T: RealAngle + Trigonometry + Clone,
+    T: RealAngle + Trigonometry + Add<T, Output = T> + Neg<Output = T> + Clone,
 {
     type Hue = LabHue<T>;
 
     fn get_hue(&self) -> LabHue<T> {
-        LabHue::from_radians(self.b.clone().atan2(self.a.clone()))
+        LabHue::from_cartesian(self.a.clone(), self.b.clone())
     }
 }
 
@@ -468,6 +468,8 @@ mod test {
     use super::Lab;
     use crate::white_point::D65;
     use crate::{FromColor, LinSrgb};
+
+    test_convert_into_from_xyz!(Lab);
 
     #[test]
     fn red() {

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -497,6 +497,8 @@ mod test {
     use crate::white_point::D65;
     use crate::Lch;
 
+    test_convert_into_from_xyz!(Lch);
+
     #[test]
     fn ranges() {
         assert_ranges! {

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -479,6 +479,8 @@ mod test {
     use crate::white_point::D65;
     use crate::Lchuv;
 
+    test_convert_into_from_xyz!(Lchuv);
+
     #[test]
     fn ranges() {
         assert_ranges! {

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -1189,6 +1189,8 @@ mod test {
     use crate::encoding::Srgb;
     use crate::Luma;
 
+    test_convert_into_from_xyz!(Luma);
+
     #[test]
     fn ranges() {
         assert_ranges! {

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -1,6 +1,6 @@
 use core::{
     marker::PhantomData,
-    ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+    ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
 #[cfg(feature = "approx")]
@@ -302,12 +302,12 @@ impl_premultiply!(Luv<Wp> {l, u, v} phantom: white_point);
 
 impl<Wp, T> GetHue for Luv<Wp, T>
 where
-    T: RealAngle + Trigonometry + Clone,
+    T: RealAngle + Trigonometry + Add<T, Output = T> + Neg<Output = T> + Clone,
 {
     type Hue = LuvHue<T>;
 
     fn get_hue(&self) -> LuvHue<T> {
-        LuvHue::from_radians(self.v.clone().atan2(self.u.clone()))
+        LuvHue::from_cartesian(self.u.clone(), self.v.clone())
     }
 }
 
@@ -450,6 +450,8 @@ mod test {
     use super::Luv;
     use crate::white_point::D65;
     use crate::{FromColor, LinSrgb};
+
+    test_convert_into_from_xyz!(Luv);
 
     #[test]
     fn red() {

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -21,6 +21,8 @@ mod lazy_select;
 mod simd;
 #[macro_use]
 mod clamp;
+#[macro_use]
+mod convert;
 
 #[cfg(feature = "random")]
 #[macro_use]

--- a/palette/src/macros/convert.rs
+++ b/palette/src/macros/convert.rs
@@ -1,0 +1,19 @@
+/// Check that traits for converting to and from XYZ have been implemented.
+#[cfg(test)]
+macro_rules! test_convert_into_from_xyz {
+    ($ty:ty) => {
+        #[test]
+        fn convert_from_xyz() {
+            use crate::FromColor;
+
+            let _: $ty = <$ty>::from_color(crate::Xyz::default());
+        }
+
+        #[test]
+        fn convert_into_xyz() {
+            use crate::FromColor;
+
+            let _: crate::Xyz = crate::Xyz::from_color(<$ty>::default());
+        }
+    };
+}

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -1,6 +1,6 @@
 use core::ops::BitOr;
 
-use core::ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
@@ -61,12 +61,12 @@ impl_premultiply!(Oklab { l, a, b });
 
 impl<T> GetHue for Oklab<T>
 where
-    T: RealAngle + Zero + Arithmetics + Trigonometry + Clone + Default + PartialEq,
+    T: RealAngle + Trigonometry + Add<T, Output = T> + Neg<Output = T> + Clone,
 {
     type Hue = OklabHue<T>;
 
     fn get_hue(&self) -> OklabHue<T> {
-        self.try_hue().unwrap_or_default()
+        OklabHue::from_cartesian(self.a.clone(), self.b.clone())
     }
 }
 

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -5,7 +5,7 @@ use crate::{
     convert::FromColorUnclamped,
     num::{Hypot, One, Zero},
     white_point::D65,
-    GetHue, Oklab, OklabHue, Xyz,
+    GetHue, Oklab, OklabHue,
 };
 
 mod alpha;
@@ -29,7 +29,7 @@ mod random;
     palette_internal,
     white_point = "D65",
     component = "T",
-    skip_derives(Oklab, Oklch, Xyz)
+    skip_derives(Oklab, Oklch)
 )]
 #[repr(C)]
 pub struct Oklch<T = f32> {
@@ -101,17 +101,6 @@ impl<T> FromColorUnclamped<Oklch<T>> for Oklch<T> {
     }
 }
 
-impl<T> FromColorUnclamped<Xyz<D65, T>> for Oklch<T>
-where
-    Oklab<T>: FromColorUnclamped<Xyz<D65, T>>,
-    Self: FromColorUnclamped<Oklab<T>>,
-{
-    fn from_color_unclamped(color: Xyz<D65, T>) -> Self {
-        let lab = Oklab::<T>::from_color_unclamped(color);
-        Self::from_color_unclamped(lab)
-    }
-}
-
 impl<T> FromColorUnclamped<Oklab<T>> for Oklch<T>
 where
     T: Hypot + Clone,
@@ -119,7 +108,7 @@ where
 {
     fn from_color_unclamped(color: Oklab<T>) -> Self {
         let hue = color.get_hue();
-        let chroma = color.chroma();
+        let chroma = color.get_chroma();
         Oklch::new(color.l, chroma, hue)
     }
 }
@@ -162,6 +151,8 @@ unsafe impl<T> bytemuck::Pod for Oklch<T> where T: bytemuck::Pod {}
 #[cfg(test)]
 mod test {
     use crate::Oklch;
+
+    test_convert_into_from_xyz!(Oklch);
 
     #[test]
     fn ranges() {

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -31,7 +31,7 @@ use crate::{
     stimulus::{Stimulus, StimulusColor},
     white_point::{Any, WhitePoint, D65},
     Alpha, Clamp, ClampAssign, IsWithinBounds, Lab, Lighten, LightenAssign, Luma, Luv, Mix,
-    MixAssign, Okhsl, Okhsv, Okhwb, Oklab, Oklch, RelativeContrast, Yxy,
+    MixAssign, Oklab, RelativeContrast, Yxy,
 };
 
 /// CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in
@@ -53,7 +53,7 @@ pub type Xyza<Wp = D65, T = f32> = Alpha<Xyz<Wp, T>, T>;
     palette_internal,
     white_point = "Wp",
     component = "T",
-    skip_derives(Xyz, Yxy, Luv, Rgb, Lab, Oklab, Oklch, Okhsl, Okhsv, Okhwb, Luma)
+    skip_derives(Xyz, Yxy, Luv, Rgb, Lab, Oklab, Luma)
 )]
 #[repr(C)]
 pub struct Xyz<Wp = D65, T = f32> {
@@ -330,49 +330,6 @@ where
     }
 }
 
-impl<T> FromColorUnclamped<Oklch<T>> for Xyz<D65, T>
-where
-    Oklch<T>: IntoColorUnclamped<Oklab<T>>,
-    Self: FromColorUnclamped<Oklab<T>>,
-{
-    fn from_color_unclamped(color: Oklch<T>) -> Self {
-        let oklab: Oklab<T> = color.into_color_unclamped();
-        Self::from_color_unclamped(oklab)
-    }
-}
-
-impl<T> FromColorUnclamped<Okhsv<T>> for Xyz<D65, T>
-where
-    Okhsv<T>: IntoColorUnclamped<Oklab<T>>,
-    Self: FromColorUnclamped<Oklab<T>>,
-{
-    fn from_color_unclamped(color: Okhsv<T>) -> Self {
-        let oklab: Oklab<T> = color.into_color_unclamped();
-        Self::from_color_unclamped(oklab)
-    }
-}
-
-impl<T> FromColorUnclamped<Okhsl<T>> for Xyz<D65, T>
-where
-    Okhsl<T>: IntoColorUnclamped<Oklab<T>>,
-    Self: FromColorUnclamped<Oklab<T>>,
-{
-    fn from_color_unclamped(color: Okhsl<T>) -> Self {
-        let oklab: Oklab<T> = color.into_color_unclamped();
-        Self::from_color_unclamped(oklab)
-    }
-}
-
-impl<T> FromColorUnclamped<Okhwb<T>> for Xyz<D65, T>
-where
-    Okhwb<T>: IntoColorUnclamped<Okhsv<T>>,
-    Self: FromColorUnclamped<Okhsv<T>>,
-{
-    fn from_color_unclamped(color: Okhwb<T>) -> Self {
-        let okhsv: Okhsv<T> = color.into_color_unclamped();
-        Self::from_color_unclamped(okhsv)
-    }
-}
 impl<Wp, T, S> FromColorUnclamped<Luma<S, T>> for Xyz<Wp, T>
 where
     Self: Mul<T, Output = Self>,
@@ -607,6 +564,8 @@ mod test {
     const X_N: f64 = 0.95047;
     const Y_N: f64 = 1.0;
     const Z_N: f64 = 1.08883;
+
+    test_convert_into_from_xyz!(Xyz);
 
     #[test]
     fn luma() {

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -448,6 +448,8 @@ mod test {
     use crate::white_point::D65;
     use crate::{FromColor, LinLuma, LinSrgb};
 
+    test_convert_into_from_xyz!(Yxy);
+
     #[test]
     fn luma() {
         let a = Yxy::<D65>::from_color(LinLuma::new(0.5));


### PR DESCRIPTION
This is a continuation of #258, with various improvements:

 * The manual conversion implementations could just be removed.  They were not needed and the errors were due to a misunderstanding.
 * Some documentation links were broken and some phrasing was changed.
 * There were still some redundant trait bounds that could be removed or simplified. I did also change places that required `Copy` to use `Clone`.