### PR TITLE
Lift linearity restriction for `Rgb` and `Luma` and update docs

### DIFF
--- a/palette/examples/blend.rs
+++ b/palette/examples/blend.rs
@@ -2,8 +2,8 @@
 //! their characteristics.
 //!
 //! The output image shows the color spaces as groups of three columns. The
-//! color spaces are RGB and XYZ. The columns within a group show the foreground
-//! image with its transparency multiplied by 0%, 50%, and 100% each.
+//! color spaces are sRGB and XYZ. The columns within a group show the
+//! foreground image with its transparency multiplied by 0%, 50%, and 100% each.
 //!
 //! Each row is a different composition function, ordered from top to bottom as
 //! `multiply`, `screen`, `overlay`, `darken`, `lighten`, `dodge`, `burn`,
@@ -30,8 +30,8 @@ fn main() {
     let mut image = image::RgbaImage::new(tile_width * COLUMNS, tile_height * BLEND_FNS);
 
     for ((x, y, background), foreground) in background.enumerate_pixels().zip(foreground.pixels()) {
-        let background = Srgba::from(background.0).into_linear();
-        let foreground = Srgba::from(foreground.0).into_linear();
+        let background = Srgba::from(background.0).into_format();
+        let foreground = Srgba::from(foreground.0).into_format();
 
         let bg_rgb = background;
         let bg_xyz = Xyza::from_color(background);

--- a/palette/examples/compose.rs
+++ b/palette/examples/compose.rs
@@ -2,9 +2,9 @@
 //! their characteristics.
 //!
 //! The output image shows the color spaces as groups of three columns. The
-//! color spaces are RGB, XYZ, xyY, L\*a\*b\*, Oklab, and L\*u\*v\*. The columns
-//! within a group show the foreground image with its transparency multiplied by
-//! 0%, 50%, and 100% each.
+//! color spaces are sRGB, XYZ, xyY, L\*a\*b\*, Oklab, and L\*u\*v\*. The
+//! columns within a group show the foreground image with its transparency
+//! multiplied by 0%, 50%, and 100% each.
 //!
 //! Each row is a different composition function, ordered from top to bottom as
 //! `over`, `inside`, `outside`, `atop`, `xor`, and `plus`.
@@ -37,8 +37,8 @@ fn main() {
     let mut image = image::RgbaImage::new(tile_width * COLUMNS, tile_height * BLEND_FNS);
 
     for ((x, y, background), foreground) in background.enumerate_pixels().zip(foreground.pixels()) {
-        let background = Srgba::from(background.0).into_linear();
-        let foreground = Srgba::from(foreground.0).into_linear();
+        let background = Srgba::from(background.0).into_format();
+        let foreground = Srgba::from(foreground.0).into_format();
 
         let bg_rgb = background.into();
         let bg_xyz = Xyza::from_color(background).into();

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -23,7 +23,7 @@ use crate::{
     cast::{ComponentOrder, Packed, UintCast},
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
-    encoding::{linear::LinearFn, FromLinear, IntoLinear, Linear, Srgb},
+    encoding::{FromLinear, IntoLinear, Linear, Srgb},
     luma::LumaStandard,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, IsValidDivisor, MinMax, One,
@@ -640,9 +640,9 @@ where
     }
 }
 
-impl_mix!(Luma<S> where S: LumaStandard<TransferFn = LinearFn>,);
-impl_lighten!(Luma<S> increase {luma => [Self::min_luma(), Self::max_luma()]} other {} phantom: standard where T: Stimulus, S: LumaStandard<TransferFn = LinearFn>);
-impl_premultiply!(Luma<S> {luma} phantom: standard where S: LumaStandard<TransferFn = LinearFn>);
+impl_mix!(Luma<S>);
+impl_lighten!(Luma<S> increase {luma => [Self::min_luma(), Self::max_luma()]} other {} phantom: standard where T: Stimulus);
+impl_premultiply!(Luma<S> {luma} phantom: standard);
 
 impl<S, T> StimulusColor for Luma<S, T> where T: Stimulus {}
 
@@ -662,205 +662,10 @@ where
     }
 }
 
-impl<S, T> Add<Luma<S, T>> for Luma<S, T>
-where
-    T: Add,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Add>::Output>;
-
-    fn add(self, other: Luma<S, T>) -> Self::Output {
-        Luma {
-            luma: self.luma + other.luma,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Add<T> for Luma<S, T>
-where
-    T: Add,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Add>::Output>;
-
-    fn add(self, c: T) -> Self::Output {
-        Luma {
-            luma: self.luma + c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> AddAssign<Luma<S, T>> for Luma<S, T>
-where
-    T: AddAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn add_assign(&mut self, other: Luma<S, T>) {
-        self.luma += other.luma;
-    }
-}
-
-impl<S, T> AddAssign<T> for Luma<S, T>
-where
-    T: AddAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn add_assign(&mut self, c: T) {
-        self.luma += c;
-    }
-}
-
-impl<S, T> Sub<Luma<S, T>> for Luma<S, T>
-where
-    T: Sub,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Sub>::Output>;
-
-    fn sub(self, other: Luma<S, T>) -> Self::Output {
-        Luma {
-            luma: self.luma - other.luma,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Sub<T> for Luma<S, T>
-where
-    T: Sub,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Sub>::Output>;
-
-    fn sub(self, c: T) -> Self::Output {
-        Luma {
-            luma: self.luma - c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> SubAssign<Luma<S, T>> for Luma<S, T>
-where
-    T: SubAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn sub_assign(&mut self, other: Luma<S, T>) {
-        self.luma -= other.luma;
-    }
-}
-
-impl<S, T> SubAssign<T> for Luma<S, T>
-where
-    T: SubAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn sub_assign(&mut self, c: T) {
-        self.luma -= c;
-    }
-}
-
-impl<S, T> Mul<Luma<S, T>> for Luma<S, T>
-where
-    T: Mul,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Mul>::Output>;
-
-    fn mul(self, other: Luma<S, T>) -> Self::Output {
-        Luma {
-            luma: self.luma * other.luma,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Mul<T> for Luma<S, T>
-where
-    T: Mul,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Mul>::Output>;
-
-    fn mul(self, c: T) -> Self::Output {
-        Luma {
-            luma: self.luma * c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> MulAssign<Luma<S, T>> for Luma<S, T>
-where
-    T: MulAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn mul_assign(&mut self, other: Luma<S, T>) {
-        self.luma *= other.luma;
-    }
-}
-
-impl<S, T> MulAssign<T> for Luma<S, T>
-where
-    T: MulAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn mul_assign(&mut self, c: T) {
-        self.luma *= c;
-    }
-}
-
-impl<S, T> Div<Luma<S, T>> for Luma<S, T>
-where
-    T: Div,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Div>::Output>;
-
-    fn div(self, other: Luma<S, T>) -> Self::Output {
-        Luma {
-            luma: self.luma / other.luma,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Div<T> for Luma<S, T>
-where
-    T: Div,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    type Output = Luma<S, <T as Div>::Output>;
-
-    fn div(self, c: T) -> Self::Output {
-        Luma {
-            luma: self.luma / c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> DivAssign<Luma<S, T>> for Luma<S, T>
-where
-    T: DivAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn div_assign(&mut self, other: Luma<S, T>) {
-        self.luma /= other.luma;
-    }
-}
-
-impl<S, T> DivAssign<T> for Luma<S, T>
-where
-    T: DivAssign,
-    S: LumaStandard<TransferFn = LinearFn>,
-{
-    fn div_assign(&mut self, c: T) {
-        self.luma /= c;
-    }
-}
+impl_color_add!(Luma<S, T>, [luma], standard);
+impl_color_sub!(Luma<S, T>, [luma], standard);
+impl_color_mul!(Luma<S, T>, [luma], standard);
+impl_color_div!(Luma<S, T>, [luma], standard);
 
 impl_array_casts!(Luma<S, T>, [T; 1]);
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -27,7 +27,7 @@ use crate::{
     cast::{ComponentOrder, Packed},
     clamp, clamp_assign, contrast_ratio,
     convert::{FromColorUnclamped, IntoColorUnclamped},
-    encoding::{linear::LinearFn, FromLinear, IntoLinear, Linear, Srgb},
+    encoding::{FromLinear, IntoLinear, Linear, Srgb},
     luma::LumaStandard,
     matrix::{matrix_inverse, multiply_xyz_to_rgb, rgb_to_xyz_matrix},
     num::{
@@ -797,7 +797,7 @@ where
     }
 }
 
-impl_mix!(Rgb<S> where S: RgbStandard<TransferFn = LinearFn>,);
+impl_mix!(Rgb<S>);
 impl_lighten! {
     Rgb<S>
     increase {
@@ -807,7 +807,7 @@ impl_lighten! {
     }
     other {}
     phantom: standard
-    where T: Stimulus, S: RgbStandard<TransferFn = LinearFn>,
+    where T: Stimulus,
 }
 
 impl<S, T> GetHue for Rgb<S, T>
@@ -826,7 +826,7 @@ where
     }
 }
 
-impl_premultiply!(Rgb<S> {red, green, blue} phantom: standard where S: RgbStandard<TransferFn = LinearFn>);
+impl_premultiply!(Rgb<S> {red, green, blue} phantom: standard);
 
 impl<S, T> StimulusColor for Rgb<S, T> where T: Stimulus {}
 
@@ -846,237 +846,10 @@ where
     }
 }
 
-impl<S, T> Add<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Add,
-{
-    type Output = Rgb<S, <T as Add>::Output>;
-
-    fn add(self, other: Rgb<S, T>) -> Self::Output {
-        Rgb {
-            red: self.red + other.red,
-            green: self.green + other.green,
-            blue: self.blue + other.blue,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Add<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Add + Clone,
-{
-    type Output = Rgb<S, <T as Add>::Output>;
-
-    fn add(self, c: T) -> Self::Output {
-        Rgb {
-            red: self.red + c.clone(),
-            green: self.green + c.clone(),
-            blue: self.blue + c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> AddAssign<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: AddAssign,
-{
-    fn add_assign(&mut self, other: Rgb<S, T>) {
-        self.red += other.red;
-        self.green += other.green;
-        self.blue += other.blue;
-    }
-}
-
-impl<S, T> AddAssign<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: AddAssign + Clone,
-{
-    fn add_assign(&mut self, c: T) {
-        self.red += c.clone();
-        self.green += c.clone();
-        self.blue += c;
-    }
-}
-
-impl<S, T> Sub<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Sub,
-{
-    type Output = Rgb<S, <T as Sub>::Output>;
-
-    fn sub(self, other: Rgb<S, T>) -> Self::Output {
-        Rgb {
-            red: self.red - other.red,
-            green: self.green - other.green,
-            blue: self.blue - other.blue,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Sub<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Sub + Clone,
-{
-    type Output = Rgb<S, <T as Sub>::Output>;
-
-    fn sub(self, c: T) -> Self::Output {
-        Rgb {
-            red: self.red - c.clone(),
-            green: self.green - c.clone(),
-            blue: self.blue - c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> SubAssign<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: SubAssign,
-{
-    fn sub_assign(&mut self, other: Rgb<S, T>) {
-        self.red -= other.red;
-        self.green -= other.green;
-        self.blue -= other.blue;
-    }
-}
-
-impl<S, T> SubAssign<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: SubAssign + Clone,
-{
-    fn sub_assign(&mut self, c: T) {
-        self.red -= c.clone();
-        self.green -= c.clone();
-        self.blue -= c;
-    }
-}
-
-impl<S, T> Mul<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Mul,
-{
-    type Output = Rgb<S, <T as Mul>::Output>;
-
-    fn mul(self, other: Rgb<S, T>) -> Self::Output {
-        Rgb {
-            red: self.red * other.red,
-            green: self.green * other.green,
-            blue: self.blue * other.blue,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Mul<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Mul + Clone,
-{
-    type Output = Rgb<S, <T as Mul>::Output>;
-
-    fn mul(self, c: T) -> Self::Output {
-        Rgb {
-            red: self.red * c.clone(),
-            green: self.green * c.clone(),
-            blue: self.blue * c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> MulAssign<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: MulAssign,
-{
-    fn mul_assign(&mut self, other: Rgb<S, T>) {
-        self.red *= other.red;
-        self.green *= other.green;
-        self.blue *= other.blue;
-    }
-}
-
-impl<S, T> MulAssign<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: MulAssign + Clone,
-{
-    fn mul_assign(&mut self, c: T) {
-        self.red *= c.clone();
-        self.green *= c.clone();
-        self.blue *= c;
-    }
-}
-
-impl<S, T> Div<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Div,
-{
-    type Output = Rgb<S, <T as Div>::Output>;
-
-    fn div(self, other: Rgb<S, T>) -> Self::Output {
-        Rgb {
-            red: self.red / other.red,
-            green: self.green / other.green,
-            blue: self.blue / other.blue,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> Div<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: Div + Clone,
-{
-    type Output = Rgb<S, <T as Div>::Output>;
-
-    fn div(self, c: T) -> Self::Output {
-        Rgb {
-            red: self.red / c.clone(),
-            green: self.green / c.clone(),
-            blue: self.blue / c,
-            standard: PhantomData,
-        }
-    }
-}
-
-impl<S, T> DivAssign<Rgb<S, T>> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: DivAssign,
-{
-    fn div_assign(&mut self, other: Rgb<S, T>) {
-        self.red /= other.red;
-        self.green /= other.green;
-        self.blue /= other.blue;
-    }
-}
-
-impl<S, T> DivAssign<T> for Rgb<S, T>
-where
-    S: RgbStandard<TransferFn = LinearFn>,
-    T: DivAssign + Clone,
-{
-    fn div_assign(&mut self, c: T) {
-        self.red /= c.clone();
-        self.green /= c.clone();
-        self.blue /= c;
-    }
-}
+impl_color_add!(Rgb<S, T>, [red, green, blue], standard);
+impl_color_sub!(Rgb<S, T>, [red, green, blue], standard);
+impl_color_mul!(Rgb<S, T>, [red, green, blue], standard);
+impl_color_div!(Rgb<S, T>, [red, green, blue], standard);
 
 impl<S, T> From<(T, T, T)> for Rgb<S, T> {
     fn from(components: (T, T, T)) -> Self {


### PR DESCRIPTION
This removes the requirement that `Rgb` and `Luma` colors have to be linear for arithmetic operators and a few other traits to be available. There are many cases where non-linear colors are fine (or even required) and hard blocking them ended up being a bit too harsh.

The crate root documentation is also updated to hopefully be a bit more usage oriented and give more useful examples up-front.