### PR TITLE
Allow RGB/XYZ conversion matrices to be pre-defined

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-      - uses: boa-dev/criterion-compare-action@v3.2.0
+      - uses: boa-dev/criterion-compare-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branchName: ${{ github.base_ref }}

--- a/palette/src/matrix.rs
+++ b/palette/src/matrix.rs
@@ -152,6 +152,25 @@ where
     ]
 }
 
+/// Maps a matrix from one item type to another.
+///
+/// This turned out to be easier for the compiler to optimize than `matrix.map(f)`.
+#[inline(always)]
+pub fn matrix_map<T, U>(matrix: Mat3<T>, mut f: impl FnMut(T) -> U) -> Mat3<U> {
+    let [m1, m2, m3, m4, m5, m6, m7, m8, m9] = matrix;
+    [
+        f(m1),
+        f(m2),
+        f(m3),
+        f(m4),
+        f(m5),
+        f(m6),
+        f(m7),
+        f(m8),
+        f(m9),
+    ]
+}
+
 /// Generates the Srgb to Xyz transformation matrix for a given white point.
 #[inline]
 pub fn rgb_to_xyz_matrix<S, T>() -> Mat3<T>

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -64,7 +64,7 @@ use crate::{
     encoding::{self, FromLinear, Gamma, IntoLinear, Linear},
     stimulus::{FromStimulus, Stimulus},
     white_point::Any,
-    Yxy,
+    Mat3, Yxy,
 };
 
 pub use self::rgb::{FromHexError, Rgb, Rgba};
@@ -121,6 +121,26 @@ pub trait RgbSpace {
 
     /// The white point of the RGB color space.
     type WhitePoint;
+
+    /// Get a pre-defined matrix for converting an RGB value with this standard
+    /// into an XYZ value.
+    ///
+    /// Returning `None` (as in the default implementation) means that the
+    /// matrix will be computed dynamically, which is significantly slower.
+    #[inline(always)]
+    fn rgb_to_xyz_matrix() -> Option<Mat3<f64>> {
+        None
+    }
+
+    /// Get a pre-defined matrix for converting an XYZ value into an RGB value
+    /// with this standard.
+    ///
+    /// Returning `None` (as in the default implementation) means that the
+    /// matrix will be computed dynamically, which is significantly slower.
+    #[inline(always)]
+    fn xyz_to_rgb_matrix() -> Option<Mat3<f64>> {
+        None
+    }
 }
 
 impl<P, W> RgbSpace for (P, W) {


### PR DESCRIPTION
As suggested by @Kannen in https://github.com/Ogeon/palette/issues/199#issuecomment-1479207597, make it possible to have RGB to XYZ and XYZ to RGB matrices pre-defined for an RGB space. This results in significantly faster conversions.