### PR TITLE
Remove  `impl<C> $op_trait<PreAlpha<C>> for {f32,f64}` `impl`s to work around issue #283

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -38,6 +38,10 @@ std = ["approx?/std"]
 [lib]
 bench = false
 
+[[example]]
+name = "issue_283"
+path = "regression_tests/issue_283.rs"
+
 [dependencies]
 palette_derive = { version = "0.7.0", path = "../palette_derive" }
 fast-srgb8 = "1.0.0"
@@ -76,6 +80,7 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 enterpolation = "0.2.0"
+scad = "1.2.2" # For regression testing #283
 
 [dev-dependencies.clap]
 version = "3.2.23"

--- a/palette/regression_tests/issue_283.rs
+++ b/palette/regression_tests/issue_283.rs
@@ -1,0 +1,13 @@
+// Checks that issue #283 (fixed in 0.7.1) doesn't re-appear. The cause was the
+// existence of `impl Mul<PreAlpha<C>> for f32` and `impl Mul<PreAlpha<C>> for
+// f64`.
+
+// Both of these uses are necessary for triggering the issue
+#[allow(unused_imports)]
+use palette::Oklch;
+#[allow(unused_imports)]
+use scad::OffsetType;
+
+fn main() {
+    println!("{}", 42.0 * 1.0); // bug also happens when specifying f32 or f64
+}

--- a/palette/src/blend/pre_alpha.rs
+++ b/palette/src/blend/pre_alpha.rs
@@ -296,20 +296,22 @@ macro_rules! impl_scalar_binop {
                 }
             }
 
-            impl<C> $op_trait<PreAlpha<C>> for $ty
-            where
-                C: Premultiply<Scalar = $ty>,
-                $ty: $op_trait<$ty, Output = $ty> + $op_trait<C, Output = C>,
-            {
-                type Output = PreAlpha<C>;
-
-                fn $op_trait_fn(self, color: PreAlpha<C>) -> Self::Output {
-                    PreAlpha {
-                        color: $op_trait::<C>::$op_trait_fn(self, color.color),
-                        alpha: $op_trait::<$ty>::$op_trait_fn(self, color.alpha),
-                    }
-                }
-            }
+            // // Disabled as work-around for https://github.com/Ogeon/palette/issues/283
+            // // Blocked by https://github.com/rust-lang/rust/issues/80542
+            // impl<C> $op_trait<PreAlpha<C>> for $ty
+            // where
+            //     C: Premultiply<Scalar = $ty>,
+            //     $ty: $op_trait<$ty, Output = $ty> + $op_trait<C, Output = C>,
+            // {
+            //     type Output = PreAlpha<C>;
+            //
+            //     fn $op_trait_fn(self, color: PreAlpha<C>) -> Self::Output {
+            //         PreAlpha {
+            //             color: $op_trait::<C>::$op_trait_fn(self, color.color),
+            //             alpha: $op_trait::<$ty>::$op_trait_fn(self, color.alpha),
+            //         }
+            //     }
+            // }
 
             impl<C> $op_assign_trait<$ty> for PreAlpha<C>
             where


### PR DESCRIPTION
The compiler seem to sometimes get stuck in a loop when these operator implementations are involved. This removes them for now, until the issue is fixed.

## Closed Issues

* Fixes #283, by removing the problem causing `impl`s.

## Breaking Change

Removes the possibility to write `1.0 * my_pre_alpha_value`.
