### PR TITLE
Improve serializing

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -75,6 +75,7 @@ lazy_static = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+ron = "0.8.0"
 enterpolation = "0.2.0"
 
 [dev-dependencies.clap]

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -247,7 +247,7 @@ extern crate phf;
 
 #[cfg(feature = "serializing")]
 #[macro_use]
-extern crate serde;
+extern crate serde as _;
 #[cfg(all(test, feature = "serializing"))]
 extern crate serde_json;
 
@@ -446,6 +446,9 @@ pub mod named;
 
 #[cfg(feature = "random")]
 mod random_sampling;
+
+#[cfg(feature = "serializing")]
+mod serde;
 
 mod alpha;
 pub mod angle;

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -448,7 +448,7 @@ pub mod named;
 mod random_sampling;
 
 #[cfg(feature = "serializing")]
-mod serde;
+pub mod serde;
 
 mod alpha;
 pub mod angle;

--- a/palette/src/serde.rs
+++ b/palette/src/serde.rs
@@ -1,4 +1,329 @@
+//! Utilities for serializing and deserializing with `serde`.
+//!
+//! These modules and functions can be combined with `serde`'s [field
+//! attributes](https://serde.rs/field-attrs.html) to better control how to
+//! serialize and deserialize colors. See each item's examples for more details.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{
+    blend::{PreAlpha, Premultiply},
+    cast::{self, ArrayCast, UintCast},
+    stimulus::Stimulus,
+    Alpha,
+};
+
 pub(crate) use self::{alpha_deserializer::AlphaDeserializer, alpha_serializer::AlphaSerializer};
 
 mod alpha_deserializer;
 mod alpha_serializer;
+
+/// Combines [`serialize_as_array`] and [`deserialize_as_array`] as a module for `#[serde(with = "...")]`.
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use palette::{Srgb, Srgba};
+///
+/// #[derive(Serialize, Deserialize, PartialEq, Debug)]
+/// struct MyColors {
+///     #[serde(with = "palette::serde::as_array")]
+///     opaque: Srgb,
+///     #[serde(with = "palette::serde::as_array")]
+///     transparent: Srgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     opaque: Srgb::new(0.6, 0.8, 0.3),
+///     transparent: Srgba::new(0.6, 0.8, 0.3, 0.5),
+/// };
+///
+/// let json = serde_json::to_string(&my_colors).unwrap();
+///
+/// assert_eq!(
+///     json,
+///     r#"{"opaque":[0.6,0.8,0.3],"transparent":[0.6,0.8,0.3,0.5]}"#
+/// );
+///
+/// assert_eq!(
+///     serde_json::from_str::<MyColors>(&json).unwrap(),
+///     my_colors
+/// );
+/// ```
+pub mod as_array {
+    pub use super::deserialize_as_array as deserialize;
+    pub use super::serialize_as_array as serialize;
+}
+
+/// Serialize the value as an array of its components.
+///
+/// ```
+/// use serde::Serialize;
+/// use palette::{Srgb, Srgba};
+///
+/// #[derive(Serialize)]
+/// struct MyColors {
+///     #[serde(serialize_with = "palette::serde::serialize_as_array")]
+///     opaque: Srgb,
+///     #[serde(serialize_with = "palette::serde::serialize_as_array")]
+///     transparent: Srgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     opaque: Srgb::new(0.6, 0.8, 0.3),
+///     transparent: Srgba::new(0.6, 0.8, 0.3, 0.5),
+/// };
+///
+/// assert_eq!(
+///     serde_json::to_string(&my_colors).unwrap(),
+///     r#"{"opaque":[0.6,0.8,0.3],"transparent":[0.6,0.8,0.3,0.5]}"#
+/// );
+/// ```
+pub fn serialize_as_array<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: ArrayCast,
+    T::Array: Serialize,
+    S: Serializer,
+{
+    cast::into_array_ref(value).serialize(serializer)
+}
+
+/// Deserialize a value from an array of its components.
+///
+/// ```
+/// use serde::Deserialize;
+/// use palette::{Srgb, Srgba};
+///
+/// #[derive(Deserialize, PartialEq, Debug)]
+/// struct MyColors {
+///     #[serde(deserialize_with = "palette::serde::deserialize_as_array")]
+///     opaque: Srgb,
+///     #[serde(deserialize_with = "palette::serde::deserialize_as_array")]
+///     transparent: Srgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     opaque: Srgb::new(0.6, 0.8, 0.3),
+///     transparent: Srgba::new(0.6, 0.8, 0.3, 0.5),
+/// };
+///
+/// let json = r#"{"opaque":[0.6,0.8,0.3],"transparent":[0.6,0.8,0.3,0.5]}"#;
+/// assert_eq!(
+///     serde_json::from_str::<MyColors>(json).unwrap(),
+///     my_colors
+/// );
+/// ```
+pub fn deserialize_as_array<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: ArrayCast,
+    T::Array: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(cast::from_array(T::Array::deserialize(deserializer)?))
+}
+
+/// Combines [`serialize_as_uint`] and [`deserialize_as_uint`] as a module for `#[serde(with = "...")]`.
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use palette::{Srgb, Srgba, rgb::{PackedArgb, PackedRgba}};
+///
+/// #[derive(Serialize, Deserialize, PartialEq, Debug)]
+/// struct MyColors {
+///     #[serde(with = "palette::serde::as_uint")]
+///     argb: PackedArgb,
+///     #[serde(with = "palette::serde::as_uint")]
+///     rgba: PackedRgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     argb: Srgb::new(0x17, 0xC6, 0x4C).into(),
+///     rgba: Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+/// };
+///
+/// let json = serde_json::to_string(&my_colors).unwrap();
+///
+/// assert_eq!(
+///     json,
+///     r#"{"argb":4279748172,"rgba":398871807}"#
+/// );
+///
+/// assert_eq!(
+///     serde_json::from_str::<MyColors>(&json).unwrap(),
+///     my_colors
+/// );
+/// ```
+pub mod as_uint {
+    pub use super::deserialize_as_uint as deserialize;
+    pub use super::serialize_as_uint as serialize;
+}
+
+/// Serialize the value as an unsigned integer.
+///
+/// ```
+/// use serde::Serialize;
+/// use palette::{Srgb, Srgba, rgb::{PackedArgb, PackedRgba}};
+///
+/// #[derive(Serialize)]
+/// struct MyColors {
+///     #[serde(serialize_with = "palette::serde::serialize_as_uint")]
+///     argb: PackedArgb,
+///     #[serde(serialize_with = "palette::serde::serialize_as_uint")]
+///     rgba: PackedRgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     argb: Srgb::new(0x17, 0xC6, 0x4C).into(),
+///     rgba: Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+/// };
+///
+/// assert_eq!(
+///     serde_json::to_string(&my_colors).unwrap(),
+///     r#"{"argb":4279748172,"rgba":398871807}"#
+/// );
+/// ```
+pub fn serialize_as_uint<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: UintCast,
+    T::Uint: Serialize,
+    S: Serializer,
+{
+    cast::into_uint_ref(value).serialize(serializer)
+}
+
+/// Deserialize a value from an unsigned integer.
+///
+/// ```
+/// use serde::Deserialize;
+/// use palette::{Srgb, Srgba, rgb::{PackedArgb, PackedRgba}};
+///
+/// #[derive(Deserialize, PartialEq, Debug)]
+/// struct MyColors {
+///     #[serde(deserialize_with = "palette::serde::deserialize_as_uint")]
+///     argb: PackedArgb,
+///     #[serde(deserialize_with = "palette::serde::deserialize_as_uint")]
+///     rgba: PackedRgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     argb: Srgb::new(0x17, 0xC6, 0x4C).into(),
+///     rgba: Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+/// };
+///
+/// let json = r#"{"argb":4279748172,"rgba":398871807}"#;
+/// assert_eq!(
+///     serde_json::from_str::<MyColors>(json).unwrap(),
+///     my_colors
+/// );
+/// ```
+pub fn deserialize_as_uint<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: UintCast,
+    T::Uint: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(cast::from_uint(T::Uint::deserialize(deserializer)?))
+}
+
+/// Deserialize a transparent color without requiring the alpha to be specified.
+///
+/// A color with missing alpha will be interpreted as fully opaque.
+///
+/// ```
+/// use serde::Deserialize;
+/// use palette::Srgba;
+///
+/// #[derive(Deserialize, PartialEq, Debug)]
+/// struct MyColors {
+///     #[serde(deserialize_with = "palette::serde::deserialize_with_optional_alpha")]
+///     opaque: Srgba,
+///     #[serde(deserialize_with = "palette::serde::deserialize_with_optional_alpha")]
+///     transparent: Srgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     opaque: Srgba::new(0.6, 0.8, 0.3, 1.0),
+///     transparent: Srgba::new(0.6, 0.8, 0.3, 0.5),
+/// };
+///
+/// let json = r#"{
+///     "opaque":{"red":0.6,"green":0.8,"blue":0.3},
+///     "transparent":{"red":0.6,"green":0.8,"blue":0.3,"alpha":0.5}
+/// }"#;
+/// assert_eq!(
+///     serde_json::from_str::<MyColors>(json).unwrap(),
+///     my_colors
+/// );
+/// ```
+pub fn deserialize_with_optional_alpha<'de, T, A, D>(
+    deserializer: D,
+) -> Result<Alpha<T, A>, D::Error>
+where
+    T: Deserialize<'de>,
+    A: Stimulus + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let mut alpha: Option<A> = None;
+
+    let color = T::deserialize(crate::serde::AlphaDeserializer {
+        inner: deserializer,
+        alpha: &mut alpha,
+    })?;
+
+    Ok(Alpha {
+        color,
+        alpha: alpha.unwrap_or_else(A::max_intensity),
+    })
+}
+
+/// Deserialize a premultiplied transparent color without requiring the alpha to be specified.
+///
+/// A color with missing alpha will be interpreted as fully opaque.
+///
+/// ```
+/// use serde::Deserialize;
+/// use palette::{LinSrgba, LinSrgb, blend::PreAlpha};
+///
+/// type PreRgba = PreAlpha<LinSrgb<f32>>;
+///
+/// #[derive(Deserialize, PartialEq, Debug)]
+/// struct MyColors {
+///     #[serde(deserialize_with = "palette::serde::deserialize_with_optional_pre_alpha")]
+///     opaque: PreRgba,
+///     #[serde(deserialize_with = "palette::serde::deserialize_with_optional_pre_alpha")]
+///     transparent: PreRgba,
+/// }
+///
+/// let my_colors = MyColors {
+///     opaque: LinSrgba::new(0.6, 0.8, 0.3, 1.0).into(),
+///     transparent: LinSrgba::new(0.6, 0.8, 0.3, 0.5).into(),
+/// };
+///
+/// let json = r#"{
+///     "opaque":{"red":0.6,"green":0.8,"blue":0.3},
+///     "transparent":{"red":0.3,"green":0.4,"blue":0.15,"alpha":0.5}
+/// }"#;
+/// assert_eq!(
+///     serde_json::from_str::<MyColors>(json).unwrap(),
+///     my_colors
+/// );
+/// ```
+pub fn deserialize_with_optional_pre_alpha<'de, T, D>(
+    deserializer: D,
+) -> Result<PreAlpha<T>, D::Error>
+where
+    T: Premultiply + Deserialize<'de>,
+    T::Scalar: Stimulus + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let mut alpha: Option<T::Scalar> = None;
+
+    let color = T::deserialize(crate::serde::AlphaDeserializer {
+        inner: deserializer,
+        alpha: &mut alpha,
+    })?;
+
+    Ok(PreAlpha {
+        color,
+        alpha: alpha.unwrap_or_else(T::Scalar::max_intensity),
+    })
+}

--- a/palette/src/serde.rs
+++ b/palette/src/serde.rs
@@ -1,0 +1,4 @@
+pub(crate) use self::{alpha_deserializer::AlphaDeserializer, alpha_serializer::AlphaSerializer};
+
+mod alpha_deserializer;
+mod alpha_serializer;

--- a/palette/src/serde/alpha_deserializer.rs
+++ b/palette/src/serde/alpha_deserializer.rs
@@ -1,0 +1,796 @@
+use core::marker::PhantomData;
+
+use serde::{
+    de::{DeserializeSeed, MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+/// Deserializes a color with an attached alpha value. The alpha value is
+/// expected to be found alongside the other values in a flattened structure.
+pub(crate) struct AlphaDeserializer<'a, D, A> {
+    pub inner: D,
+    pub alpha: &'a mut Option<A>,
+}
+
+impl<'de, 'a, D, A> Deserializer<'de> for AlphaDeserializer<'a, D, A>
+where
+    D: Deserializer<'de>,
+    A: Deserialize<'de>,
+{
+    type Error = D::Error;
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_seq(AlphaSeqVisitor {
+            inner: visitor,
+            alpha: self.alpha,
+        })
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_tuple(
+            len + 1,
+            AlphaMapVisitor {
+                inner: visitor,
+                alpha: self.alpha,
+                field_count: Some(len),
+            },
+        )
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_tuple_struct(
+            name,
+            len + 1,
+            AlphaMapVisitor {
+                inner: visitor,
+                alpha: self.alpha,
+                field_count: Some(len),
+            },
+        )
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_map(AlphaMapVisitor {
+            inner: visitor,
+            alpha: self.alpha,
+            field_count: None,
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_struct(
+            name,
+            fields, // We can't add to the expected fields so we just hope it works anyway.
+            AlphaMapVisitor {
+                inner: visitor,
+                alpha: self.alpha,
+                field_count: Some(fields.len()),
+            },
+        )
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_ignored_any(AlphaSeqVisitor {
+            inner: visitor,
+            alpha: self.alpha,
+        })
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_tuple(
+            1,
+            AlphaMapVisitor {
+                inner: visitor,
+                alpha: self.alpha,
+                field_count: None,
+            },
+        )
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.inner.deserialize_newtype_struct(
+            name,
+            AlphaMapVisitor {
+                inner: visitor,
+                alpha: self.alpha,
+                field_count: Some(0),
+            },
+        )
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        self.deserialize_tuple_struct(name, 1, visitor)
+    }
+
+    // Unsupported methods:
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        alpha_deserializer_error()
+    }
+}
+
+fn alpha_deserializer_error() -> ! {
+    unimplemented!("AlphaDeserializer can only deserialize structs, maps and sequences")
+}
+
+/// Deserializes a sequence with the alpha value last.
+struct AlphaSeqVisitor<'a, D, A> {
+    inner: D,
+    alpha: &'a mut Option<A>,
+}
+
+impl<'de, 'a, D, A> Visitor<'de> for AlphaSeqVisitor<'a, D, A>
+where
+    D: Visitor<'de>,
+    A: Deserialize<'de>,
+{
+    type Value = D::Value;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.inner.expecting(formatter)?;
+        write!(formatter, " with an alpha value")
+    }
+
+    fn visit_seq<T>(self, mut seq: T) -> Result<Self::Value, T::Error>
+    where
+        T: serde::de::SeqAccess<'de>,
+    {
+        let color = self.inner.visit_seq(&mut seq)?;
+        *self.alpha = seq.next_element()?;
+
+        Ok(color)
+    }
+}
+
+/// Deserializes a map or a struct with an "alpha" key, or a tuple with the
+/// alpha value as the last value.
+struct AlphaMapVisitor<'a, D, A> {
+    inner: D,
+    alpha: &'a mut Option<A>,
+    field_count: Option<usize>,
+}
+
+impl<'de, 'a, D, A> Visitor<'de> for AlphaMapVisitor<'a, D, A>
+where
+    D: Visitor<'de>,
+    A: Deserialize<'de>,
+{
+    type Value = D::Value;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.inner.expecting(formatter)?;
+        write!(formatter, " with an alpha value")
+    }
+
+    fn visit_seq<T>(self, mut seq: T) -> Result<Self::Value, T::Error>
+    where
+        T: serde::de::SeqAccess<'de>,
+    {
+        let color = if self.field_count == None {
+            self.inner.visit_unit()?
+        } else {
+            self.inner.visit_seq(&mut seq)?
+        };
+        *self.alpha = seq.next_element()?;
+
+        Ok(color)
+    }
+
+    fn visit_map<T>(self, map: T) -> Result<Self::Value, T::Error>
+    where
+        T: serde::de::MapAccess<'de>,
+    {
+        self.inner.visit_map(MapWrapper {
+            inner: map,
+            alpha: self.alpha,
+            field_count: self.field_count,
+        })
+    }
+
+    fn visit_newtype_struct<T>(self, deserializer: T) -> Result<Self::Value, T::Error>
+    where
+        T: Deserializer<'de>,
+    {
+        *self.alpha = Some(A::deserialize(deserializer)?);
+        self.inner.visit_unit()
+    }
+}
+
+/// Intercepts map deserializing to catch the alpha value while deserializing
+/// the entries.
+struct MapWrapper<'a, T, A> {
+    inner: T,
+    alpha: &'a mut Option<A>,
+    field_count: Option<usize>,
+}
+
+impl<'a, 'de, T, A> MapAccess<'de> for MapWrapper<'a, T, A>
+where
+    T: MapAccess<'de>,
+    A: Deserialize<'de>,
+{
+    type Error = T::Error;
+
+    fn next_key_seed<K>(&mut self, mut seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        // Look for and extract the alpha value if its key is found, then return
+        // the next key after that. The first key that isn't alpha is
+        // immediately returned to the wrapped type's visitor.
+        loop {
+            seed = match self.inner.next_key_seed(AlphaFieldDeserializerSeed {
+                inner: seed,
+                field_count: self.field_count,
+            }) {
+                Ok(Some(AlphaField::Alpha(seed))) => {
+                    // We found the alpha value, so deserialize it...
+                    if self.alpha.is_some() {
+                        return Err(serde::de::Error::duplicate_field("alpha"));
+                    }
+                    *self.alpha = Some(self.inner.next_value()?);
+
+                    // ...then give the seed back for the next key
+                    seed
+                }
+                Ok(Some(AlphaField::Other(other))) => return Ok(Some(other)),
+                Ok(None) => return Ok(None),
+                Err(error) => return Err(error),
+            };
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        self.inner.next_value_seed(seed)
+    }
+}
+
+struct AlphaFieldDeserializerSeed<T> {
+    inner: T,
+    field_count: Option<usize>,
+}
+
+impl<'de, T> DeserializeSeed<'de> for AlphaFieldDeserializerSeed<T>
+where
+    T: DeserializeSeed<'de>,
+{
+    type Value = AlphaField<T, T::Value>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_identifier(AlphaFieldVisitor {
+            inner: self.inner,
+            field_count: self.field_count,
+        })
+    }
+}
+
+/// An alpha struct field or another struct field.
+enum AlphaField<A, O> {
+    Alpha(A),
+    Other(O),
+}
+
+/// A struct field name that hasn't been serialized yet.
+enum StructField<'de> {
+    Unsigned(u64),
+    Str(&'de str),
+    Bytes(&'de [u8]),
+}
+
+struct AlphaFieldVisitor<T> {
+    inner: T,
+    field_count: Option<usize>,
+}
+
+impl<'de, T> Visitor<'de> for AlphaFieldVisitor<T>
+where
+    T: DeserializeSeed<'de>,
+{
+    type Value = AlphaField<T, T::Value>;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(formatter, "alpha field")
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // We need the field count here to get the last tuple field. No field
+        // count implies that we definitely expected a struct or a map.
+        let field_count = self.field_count.ok_or(serde::de::Error::invalid_type(
+            serde::de::Unexpected::Unsigned(v),
+            &"map key or struct field",
+        ))?;
+
+        // Assume that it's the alpha value if it's after the expected number of
+        // fields. Otherwise, pass on to the wrapped type's deserializer.
+        if v == field_count as u64 {
+            Ok(AlphaField::Alpha(self.inner))
+        } else {
+            Ok(AlphaField::Other(self.inner.deserialize(
+                StructFieldDeserializer {
+                    struct_field: StructField::Unsigned(v),
+                    error: PhantomData,
+                },
+            )?))
+        }
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // Assume that it's the alpha value if it's named "alpha". Otherwise,
+        // pass on to the wrapped type's deserializer.
+        if v == "alpha" {
+            Ok(AlphaField::Alpha(self.inner))
+        } else {
+            Ok(AlphaField::Other(self.inner.deserialize(
+                StructFieldDeserializer {
+                    struct_field: StructField::Str(v),
+                    error: PhantomData,
+                },
+            )?))
+        }
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // Assume that it's the alpha value if it's named "alpha". Otherwise,
+        // pass on to the wrapped type's deserializer.
+        if v == b"alpha" {
+            Ok(AlphaField::Alpha(self.inner))
+        } else {
+            Ok(AlphaField::Other(self.inner.deserialize(
+                StructFieldDeserializer {
+                    struct_field: StructField::Bytes(v),
+                    error: PhantomData,
+                },
+            )?))
+        }
+    }
+}
+
+/// Deserializes a non-alpha struct field name.
+struct StructFieldDeserializer<'a, E> {
+    struct_field: StructField<'a>,
+    error: PhantomData<fn() -> E>,
+}
+
+impl<'a, 'de, E> Deserializer<'de> for StructFieldDeserializer<'a, E>
+where
+    E: serde::de::Error,
+{
+    type Error = E;
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.struct_field {
+            StructField::Unsigned(v) => visitor.visit_u64(v),
+            StructField::Str(v) => visitor.visit_str(v),
+            StructField::Bytes(v) => visitor.visit_bytes(v),
+        }
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_identifier(visitor)
+    }
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_identifier(visitor)
+    }
+
+    // Unsupported methods::
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct_field_deserializer_error()
+    }
+}
+
+fn struct_field_deserializer_error() -> ! {
+    unimplemented!("StructFieldDeserializer can only deserialize identifiers")
+}

--- a/palette/src/serde/alpha_serializer.rs
+++ b/palette/src/serde/alpha_serializer.rs
@@ -1,0 +1,420 @@
+use serde::{
+    ser::{
+        SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    },
+    Serialize, Serializer,
+};
+
+/// Serializes a color with an attached alpha value. The alpha value is added
+/// alongside the other values in a flattened structure.
+pub(crate) struct AlphaSerializer<'a, S, A> {
+    pub inner: S,
+    pub alpha: &'a A,
+}
+
+impl<'a, S, A> Serializer for AlphaSerializer<'a, S, A>
+where
+    S: Serializer,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    type SerializeSeq = AlphaSerializer<'a, S::SerializeSeq, A>;
+
+    type SerializeTuple = AlphaSerializer<'a, S::SerializeTuple, A>;
+
+    type SerializeTupleStruct = AlphaSerializer<'a, S::SerializeTupleStruct, A>;
+
+    type SerializeTupleVariant = AlphaSerializer<'a, S::SerializeTupleVariant, A>;
+
+    type SerializeMap = AlphaSerializer<'a, S::SerializeMap, A>;
+
+    type SerializeStruct = AlphaSerializer<'a, S::SerializeStruct, A>;
+
+    type SerializeStructVariant = AlphaSerializer<'a, S::SerializeStructVariant, A>;
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(AlphaSerializer {
+            inner: self.inner.serialize_seq(len.map(|len| len + 1))?,
+            alpha: self.alpha,
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Ok(AlphaSerializer {
+            inner: self.inner.serialize_tuple(len + 1)?,
+            alpha: self.alpha,
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Ok(AlphaSerializer {
+            inner: self.inner.serialize_tuple_struct(name, len + 1)?,
+            alpha: self.alpha,
+        })
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(AlphaSerializer {
+            inner: self.inner.serialize_map(len.map(|len| len + 1))?,
+            alpha: self.alpha,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(AlphaSerializer {
+            inner: self.inner.serialize_struct(name, len + 1)?,
+            alpha: self.alpha,
+        })
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        let mut serializer = self.serialize_tuple_struct(name, 1)?;
+        serializer.serialize_field(value)?;
+        serializer.end()
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_newtype_struct(name, self.alpha)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.serialize_tuple(0)?.end()
+    }
+
+    // Unsupported methods:
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        alpha_serializer_error()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        alpha_serializer_error()
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        alpha_serializer_error()
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        let _ = v;
+        alpha_serializer_error()
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        let _ = v;
+        alpha_serializer_error()
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.inner.is_human_readable()
+    }
+}
+
+fn alpha_serializer_error() -> ! {
+    unimplemented!("AlphaSerializer can only serialize structs, maps and sequences")
+}
+
+impl<'a, S, A> SerializeSeq for AlphaSerializer<'a, S, A>
+where
+    S: SerializeSeq,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_element(value)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_element(self.alpha)?;
+        self.inner.end()
+    }
+}
+
+impl<'a, S, A> SerializeTuple for AlphaSerializer<'a, S, A>
+where
+    S: SerializeTuple,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_element(value)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_element(self.alpha)?;
+        self.inner.end()
+    }
+}
+
+impl<'a, S, A> SerializeTupleStruct for AlphaSerializer<'a, S, A>
+where
+    S: SerializeTupleStruct,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_field(value)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_field(self.alpha)?;
+        self.inner.end()
+    }
+}
+
+impl<'a, S, A> SerializeTupleVariant for AlphaSerializer<'a, S, A>
+where
+    S: SerializeTupleVariant,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_field(value)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_field(self.alpha)?;
+        self.inner.end()
+    }
+}
+
+impl<'a, S, A> SerializeMap for AlphaSerializer<'a, S, A>
+where
+    S: SerializeMap,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_key(key)
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_value(value)
+    }
+
+    fn serialize_entry<K: ?Sized, V: ?Sized>(
+        &mut self,
+        key: &K,
+        value: &V,
+    ) -> Result<(), Self::Error>
+    where
+        K: Serialize,
+        V: Serialize,
+    {
+        self.inner.serialize_entry(key, value)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_entry("alpha", self.alpha)?;
+        self.inner.end()
+    }
+}
+
+impl<'a, S, A> SerializeStruct for AlphaSerializer<'a, S, A>
+where
+    S: SerializeStruct,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_field(key, value)
+    }
+
+    fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
+        self.inner.skip_field(key)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_field("alpha", self.alpha)?;
+        self.inner.end()
+    }
+}
+
+impl<'a, S, A> SerializeStructVariant for AlphaSerializer<'a, S, A>
+where
+    S: SerializeStructVariant,
+    A: Serialize,
+{
+    type Ok = S::Ok;
+
+    type Error = S::Error;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Serialize,
+    {
+        self.inner.serialize_field(key, value)
+    }
+
+    fn skip_field(&mut self, key: &'static str) -> Result<(), Self::Error> {
+        self.inner.skip_field(key)
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        self.inner.serialize_field("alpha", self.alpha)?;
+        self.inner.end()
+    }
+}


### PR DESCRIPTION
This fixes a long-standing bug in how `Alpha` and `PreAlpha` are serialized. They used to be flattened to a map, which is fine in JSON but not in more expressive formats, such as RON. The replacement implementation will only handle a subset of possible values (structs, tuples and sequences), but they should be the most common ones. It should also be possible to extend it later.

I have also taken the opportunity to add some helpful utility functions for serializing and de-serializing.

## Closed Issues

* Fixes #130, using a custom implementation.

## Breaking Change

Technically breaking, since it changes the serialization format a bit, but the old behavior was buggy and not always usable. The serialized type and name for `Alpha` and `PreAlpha` is now inherited from the color's type. So, for example, `Srgba` will be serialized and de-serialized as an `Rgb` struct with an additional `alpha` field. Unit types get extended to newtypes, and newtypes get extended to tuples.