### PR TITLE
Add `EuclideanDistance` and `Ciede2000` traits, deprecate `ColorDifference`

### DIFF
--- a/palette/src/color_difference.rs
+++ b/palette/src/color_difference.rs
@@ -11,6 +11,10 @@ use crate::{
 };
 
 /// A trait for calculating the color difference between two colors.
+#[deprecated(
+    since = "0.7.2",
+    note = "replaced by `palette::color_difference::Ciede2000`"
+)]
 pub trait ColorDifference {
     /// The type of the calculated color difference.
     type Scalar;
@@ -18,6 +22,25 @@ pub trait ColorDifference {
     /// Return the difference or distance between two colors.
     #[must_use]
     fn get_color_difference(self, other: Self) -> Self::Scalar;
+}
+
+/// Calculate the CIEDE2000 color difference between two colors.
+///
+/// CIEDE2000 is a formula by the CIE that calculates a distance metric, ΔE\*
+/// (also known as Delta E), as an estimate of perceived color distance or
+/// difference.
+///
+/// There is a "just noticeable difference" between two colors when the ΔE\*
+/// (Delta E) is roughly greater than 1. Thus, the color difference is more
+/// suited for calculating small distances between colors as opposed to large
+/// differences.
+#[doc(alias = "ColorDifference")]
+pub trait Ciede2000 {
+    /// The type for the ΔE\* (Delta E).
+    type Scalar;
+
+    /// Calculate the CIEDE2000 ΔE\* (Delta E) color difference between `self` and `other`.
+    fn difference(self, other: Self) -> Self::Scalar;
 }
 
 /// Container of components necessary to calculate CIEDE color difference
@@ -69,7 +92,7 @@ where
 /// is roughly greater than 1. Thus, the color difference is more suited for
 /// calculating small distances between colors as opposed to large differences.
 #[rustfmt::skip]
-pub(crate) fn get_ciede_difference<T>(this: LabColorDiff<T>, other: LabColorDiff<T>) -> T
+pub(crate) fn get_ciede2000_difference<T>(this: LabColorDiff<T>, other: LabColorDiff<T>) -> T
 where
     T: Real
         + RealAngle

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -292,6 +292,7 @@ where
 impl_mix!(Lab<Wp>);
 impl_lighten!(Lab<Wp> increase {l => [Self::min_l(), Self::max_l()]} other {a, b} phantom: white_point);
 impl_premultiply!(Lab<Wp> {l, a, b} phantom: white_point);
+impl_euclidean_distance!(Lab<Wp> {l, a, b});
 
 impl<Wp, T> GetHue for Lab<Wp, T>
 where

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -19,11 +19,11 @@ use crate::{
     blend::{PreAlpha, Premultiply},
     bool_mask::{HasBoolMask, LazySelect},
     clamp, clamp_assign,
-    color_difference::{get_ciede_difference, ColorDifference, LabColorDiff},
+    color_difference::{get_ciede2000_difference, Ciede2000, LabColorDiff},
     contrast_ratio,
     convert::FromColorUnclamped,
     num::{
-        self, Abs, Arithmetics, Cbrt, Exp, FromScalarArray, IntoScalarArray, IsValidDivisor,
+        self, Abs, Arithmetics, Cbrt, Exp, FromScalarArray, Hypot, IntoScalarArray, IsValidDivisor,
         MinMax, One, PartialCmp, Powi, Real, Sqrt, Trigonometry, Zero,
     },
     stimulus::Stimulus,
@@ -305,7 +305,8 @@ where
     }
 }
 
-impl<Wp, T> ColorDifference for Lab<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::ColorDifference for Lab<Wp, T>
 where
     T: Real
         + RealAngle
@@ -326,7 +327,32 @@ where
 
     #[inline]
     fn get_color_difference(self, other: Lab<Wp, T>) -> Self::Scalar {
-        get_ciede_difference(self.into(), other.into())
+        get_ciede2000_difference(self.into(), other.into())
+    }
+}
+
+impl<Wp, T> Ciede2000 for Lab<Wp, T>
+where
+    T: Real
+        + RealAngle
+        + One
+        + Zero
+        + Powi
+        + Exp
+        + Trigonometry
+        + Abs
+        + Sqrt
+        + Arithmetics
+        + PartialCmp
+        + Hypot
+        + Clone,
+    T::Mask: LazySelect<T> + BitAnd<Output = T::Mask> + BitOr<Output = T::Mask>,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn difference(self, other: Self) -> Self::Scalar {
+        get_ciede2000_difference(self.into(), other.into())
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -18,9 +18,9 @@ use crate::{
     angle::{RealAngle, SignedAngle},
     bool_mask::{HasBoolMask, LazySelect},
     clamp, clamp_assign, clamp_min, clamp_min_assign,
-    color_difference::{get_ciede_difference, ColorDifference, LabColorDiff},
+    color_difference::{get_ciede2000_difference, Ciede2000, LabColorDiff},
     contrast_ratio,
-    convert::FromColorUnclamped,
+    convert::{FromColorUnclamped, IntoColorUnclamped},
     num::{
         self, Abs, Arithmetics, Exp, FromScalarArray, Hypot, IntoScalarArray, MinMax, One,
         PartialCmp, Powi, Real, Sqrt, Trigonometry, Zero,
@@ -325,7 +325,8 @@ where
 }
 
 /// CIEDE2000 distance metric for color difference.
-impl<Wp, T> ColorDifference for Lch<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::ColorDifference for Lch<Wp, T>
 where
     T: Real
         + RealAngle
@@ -346,7 +347,32 @@ where
 
     #[inline]
     fn get_color_difference(self, other: Lch<Wp, T>) -> Self::Scalar {
-        get_ciede_difference(self.into(), other.into())
+        get_ciede2000_difference(self.into(), other.into())
+    }
+}
+
+impl<Wp, T> Ciede2000 for Lch<Wp, T>
+where
+    T: Real
+        + RealAngle
+        + One
+        + Zero
+        + Powi
+        + Exp
+        + Trigonometry
+        + Abs
+        + Sqrt
+        + Arithmetics
+        + PartialCmp
+        + Clone,
+    T::Mask: LazySelect<T> + BitAnd<Output = T::Mask> + BitOr<Output = T::Mask>,
+    Self: IntoColorUnclamped<Lab<Wp, T>>,
+{
+    type Scalar = T;
+
+    #[inline]
+    fn difference(self, other: Self) -> Self::Scalar {
+        get_ciede2000_difference(self.into(), other.into())
     }
 }
 

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -276,6 +276,7 @@ pub use rgb::{GammaSrgb, GammaSrgba, LinSrgb, LinSrgba, Srgb, Srgba};
 pub use xyz::{Xyz, Xyza};
 pub use yxy::{Yxy, Yxya};
 
+#[allow(deprecated)]
 pub use color_difference::ColorDifference;
 pub use convert::{FromColor, FromColorMut, FromColorMutGuard, IntoColor, IntoColorMut};
 pub use hues::{LabHue, LuvHue, OklabHue, RgbHue};

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -456,7 +456,7 @@ pub mod blend;
 pub mod bool_mask;
 pub mod cast;
 pub mod chromatic_adaptation;
-mod color_difference;
+pub mod color_difference;
 pub mod convert;
 pub mod encoding;
 mod hsl;

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -643,6 +643,7 @@ where
 impl_mix!(Luma<S>);
 impl_lighten!(Luma<S> increase {luma => [Self::min_luma(), Self::max_luma()]} other {} phantom: standard where T: Stimulus);
 impl_premultiply!(Luma<S> {luma} phantom: standard);
+impl_euclidean_distance!(Luma<S> {luma});
 
 impl<S, T> StimulusColor for Luma<S, T> where T: Stimulus {}
 

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -299,6 +299,7 @@ where
 impl_mix!(Luv<Wp>);
 impl_lighten!(Luv<Wp> increase {l => [Self::min_l(), Self::max_l()]} other {u, v} phantom: white_point);
 impl_premultiply!(Luv<Wp> {l, u, v} phantom: white_point);
+impl_euclidean_distance!(Luv<Wp> {l, u, v});
 
 impl<Wp, T> GetHue for Luv<Wp, T>
 where

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -3,6 +3,13 @@ pub use self::{arithmetics::*, casting::*, mix::*};
 #[cfg(feature = "random")]
 pub use self::random::*;
 
+// From https://stackoverflow.com/questions/60187436/rust-macro-repetition-with-plus
+macro_rules! strip_plus {
+    (+ $($rest: tt)*) => {
+        $($rest)*
+    }
+}
+
 #[macro_use]
 mod arithmetics;
 #[macro_use]
@@ -23,6 +30,8 @@ mod simd;
 mod clamp;
 #[macro_use]
 mod convert;
+#[macro_use]
+mod color_difference;
 
 #[cfg(feature = "random")]
 #[macro_use]

--- a/palette/src/macros/color_difference.rs
+++ b/palette/src/macros/color_difference.rs
@@ -1,0 +1,31 @@
+macro_rules! impl_euclidean_distance {
+    (
+        $ty: ident
+        {$($component: ident),+}
+        $(where $($where: tt)+)?
+    ) => {
+        // add empty generics brackets
+        impl_euclidean_distance!($ty<> {$($component),+} $(where $($where)+)?);
+    };
+    (
+        $ty: ident <$($ty_param: ident),*>
+        {$($component: ident),+}
+        $(where $($where: tt)+)?
+    ) => {
+        impl<$($ty_param,)* T> crate::color_difference::EuclideanDistance for $ty<$($ty_param,)* T>
+        where
+            T: self::num::Real + core::ops::Sub<T, Output=T> + core::ops::Add<T, Output=T> + core::ops::Mul<T, Output=T> + Clone,
+            $($($where)+)?
+        {
+            type Scalar = T;
+
+            #[inline]
+            fn distance_squared(self, other: Self) -> Self::Scalar {
+                let difference = self - other;
+                let differece_squared = difference.clone() * difference;
+
+                strip_plus!($(+ differece_squared.$component)+)
+            }
+        }
+    };
+}

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -58,6 +58,7 @@ where
 impl_mix!(Oklab);
 impl_lighten!(Oklab increase {l => [Self::min_l(), Self::max_l()]} other {a, b} where T:  One);
 impl_premultiply!(Oklab { l, a, b });
+impl_euclidean_distance!(Oklab { l, a, b });
 
 impl<T> GetHue for Oklab<T>
 where

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -1,12 +1,7 @@
-use core::ops::BitOr;
-
 use core::ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
-
-use crate::color_difference::{get_ciede_difference, LabColorDiff};
-use crate::num::{Abs, Exp, Powi, Sqrt};
 
 use crate::{
     angle::RealAngle,
@@ -19,8 +14,8 @@ use crate::{
     },
     stimulus::Stimulus,
     white_point::D65,
-    Alpha, Clamp, ClampAssign, ColorDifference, FromColor, GetHue, IsWithinBounds, Lighten,
-    LightenAssign, Mix, MixAssign, OklabHue, RelativeContrast, Xyz,
+    Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lighten, LightenAssign, Mix,
+    MixAssign, OklabHue, RelativeContrast, Xyz,
 };
 
 use super::Oklab;
@@ -68,31 +63,6 @@ where
 
     fn get_hue(&self) -> OklabHue<T> {
         OklabHue::from_cartesian(self.a.clone(), self.b.clone())
-    }
-}
-
-impl<T> ColorDifference for Oklab<T>
-where
-    T: Real
-        + RealAngle
-        + One
-        + Zero
-        + Powi
-        + Exp
-        + Trigonometry
-        + Abs
-        + Sqrt
-        + Arithmetics
-        + PartialCmp
-        + Clone,
-    T::Mask: LazySelect<T> + BitAnd<Output = T::Mask> + BitOr<Output = T::Mask>,
-    Self: Into<LabColorDiff<T>>,
-{
-    type Scalar = T;
-
-    #[inline]
-    fn get_color_difference(self, other: Oklab<T>) -> Self::Scalar {
-        get_ciede_difference(self.into(), other.into())
     }
 }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -836,6 +836,7 @@ where
 }
 
 impl_premultiply!(Rgb<S> {red, green, blue} phantom: standard);
+impl_euclidean_distance!(Rgb<S> {red, green, blue});
 
 impl<S, T> StimulusColor for Rgb<S, T> where T: Stimulus {}
 

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -425,6 +425,7 @@ impl_lighten! {
     where Wp: WhitePoint<T>
 }
 impl_premultiply!(Xyz<Wp> {x, y, z} phantom: white_point);
+impl_euclidean_distance!(Xyz<Wp> {x, y, z});
 
 impl<Wp, T> StimulusColor for Xyz<Wp, T> where T: Stimulus {}
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -304,6 +304,7 @@ where
 impl_mix!(Yxy<Wp>);
 impl_lighten!(Yxy<Wp> increase {luma => [Self::min_luma(), Self::max_luma()]} other {x, y} phantom: white_point where T: One);
 impl_premultiply!(Yxy<Wp> {x, y, luma} phantom: white_point);
+impl_euclidean_distance!(Yxy<Wp> {x, y, luma});
 
 impl<Wp, T> HasBoolMask for Yxy<Wp, T>
 where

--- a/palette/tests/convert/data_ciede_2000.rs
+++ b/palette/tests/convert/data_ciede_2000.rs
@@ -14,9 +14,9 @@ use csv;
 use approx::assert_relative_eq;
 use serde_derive::Deserialize;
 
-use palette::convert::FromColorUnclamped;
-use palette::white_point::D65;
-use palette::{ColorDifference, Lab, Lch};
+use palette::{
+    color_difference::Ciede2000, convert::FromColorUnclamped, white_point::D65, Lab, Lch,
+};
 
 #[derive(Deserialize, PartialEq)]
 struct Cie2000Raw {
@@ -71,12 +71,12 @@ pub fn run_tests() {
     let data = load_data();
 
     for expected in data.iter() {
-        let result_lab = expected.c1.get_color_difference(expected.c2);
+        let result_lab = expected.c1.difference(expected.c2);
         check_equal_lab(result_lab, expected.delta_e);
 
         let lch1: Lch<_, f64> = Lch::from_color_unclamped(expected.c1);
         let lch2: Lch<_, f64> = Lch::from_color_unclamped(expected.c2);
-        let result_lch = lch1.get_color_difference(lch2);
+        let result_lch = lch1.difference(lch2);
         check_equal_lch(result_lch, expected.delta_e);
     }
 }


### PR DESCRIPTION
The `EuclideanDistance` and `Ciede2000` traits are added as more specific replacements for `ColorDifference`. The main reason why is that there are more than one measurement of difference, with different pros, cons and uses. That means there's not really any universally canonical color difference measurement for all uses.

## Closed Issues

* Closes #288
