### PR TITLE
Implement struct-of-arrays (SoA) utilities

### DIFF
--- a/palette/examples/struct_of_arrays.rs
+++ b/palette/examples/struct_of_arrays.rs
@@ -1,0 +1,50 @@
+use palette::{cast, color_difference::EuclideanDistance, IntoColor, Oklab, Srgb};
+
+fn main() {
+    let image = image::open("example-data/input/fruits.png")
+        .expect("could not open 'example-data/input/fruits.png'")
+        .to_rgb8();
+
+    let image = cast::from_component_slice::<Srgb<u8>>(image.as_raw());
+
+    // Convert and collect the colors in a struct-of-arrays (SoA) format, where
+    // each component is a Vec of all the pixels' component values.
+    let oklab_image: Oklab<Vec<f32>> = image
+        .iter()
+        .map(|rgb| rgb.into_linear::<f32>().into_color())
+        .collect();
+
+    // Find the min, max and average of each component. We are doing it by
+    // iterating over each component Vec separately, starting with l...
+    let (min_l, max_l, average_l) = get_min_max_average(oklab_image.l.iter().copied());
+    let (min_a, max_a, average_a) = get_min_max_average(oklab_image.a.iter().copied());
+    let (min_b, max_b, average_b) = get_min_max_average(oklab_image.b.iter().copied());
+
+    // Find out how far the colors in the image are from the average color. In
+    // this case, we can just iterate over all of the colors and consume the
+    // collection(s).
+    let average_color = Oklab::new(average_l, average_a, average_b);
+    let (min_d, max_d, average_d) = get_min_max_average(
+        oklab_image
+            .into_iter()
+            .map(|color| average_color.distance(color)),
+    );
+
+    // Print the stats.
+    println!("Oklab l: min {min_l}, average {average_l}, max {max_l}");
+    println!("Oklab a: min {min_a}, average {average_a}, max {max_a}");
+    println!("Oklab b: min {min_b}, average {average_b}, max {max_b}");
+    println!("Distance from average color: min {min_d}, average {average_d}, max {max_d}");
+}
+
+/// Calculates the min, max and average of the iterator's values.
+fn get_min_max_average(iter: impl ExactSizeIterator<Item = f32>) -> (f32, f32, f32) {
+    let length = iter.len();
+
+    let (min, max, sum) = iter.fold(
+        (f32::INFINITY, f32::NEG_INFINITY, 0.0),
+        |(min, max, sum), value| (min.min(value), max.max(value), sum + value),
+    );
+
+    (min, max, sum / length as f32)
+}

--- a/palette/src/alpha.rs
+++ b/palette/src/alpha.rs
@@ -1,9 +1,14 @@
+//! Types related to transparent colors.
+
 #[doc(hidden)]
 pub use palette_derive::WithAlpha;
 
 use crate::{num::Zero, stimulus::Stimulus};
 
 pub use self::alpha::*;
+
+#[doc(no_inline)]
+pub use crate::blend::PreAlpha; // Cross-link for visibility.
 
 mod alpha;
 

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -1,3 +1,5 @@
+//! Types for the HSL color space.
+
 use core::{
     any::TypeId,
     marker::PhantomData,
@@ -24,6 +26,7 @@ use crate::{
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
     encoding::Srgb,
+    hues::RgbHueIter,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, IsValidDivisor, MinMax, One,
         PartialCmp, Real, Zero,
@@ -275,6 +278,9 @@ impl<S, T, A> Alpha<Hsl<S, T>, A> {
         Self::new(hue, saturation, lightness, alpha)
     }
 }
+
+impl_reference_component_methods_hue!(Hsl<S>, [saturation, lightness], standard);
+impl_struct_of_arrays_methods_hue!(Hsl<S>, [saturation, lightness], standard);
 
 impl<S1, S2, T> FromColorUnclamped<Hsl<S1, T>> for Hsl<S2, T>
 where
@@ -628,6 +634,7 @@ impl_color_sub!(Hsl<S, T>, [hue, saturation, lightness], standard);
 
 impl_array_casts!(Hsl<S, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Hsl<S>, [saturation, lightness], standard);
+impl_struct_of_array_traits_hue!(Hsl<S>, RgbHueIter, [saturation, lightness], standard);
 
 impl_eq_hue!(Hsl<S>, RgbHue, [hue, saturation, lightness]);
 
@@ -661,6 +668,7 @@ where
     }
 }
 
+/// Sample HSL colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformHsl<S, T>
 where
@@ -833,6 +841,24 @@ mod test {
         assert_relative_eq!(Hsl::<Srgb>::min_lightness(), 0.0);
         assert_relative_eq!(Hsl::<Srgb>::max_saturation(), 1.0);
         assert_relative_eq!(Hsl::<Srgb>::max_lightness(), 1.0);
+    }
+
+    struct_of_arrays_tests!(
+        Hsl<Srgb>,
+        Hsl::new(0.1f32, 0.2, 0.3),
+        Hsl::new(0.2, 0.3, 0.4),
+        Hsl::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{encoding::Srgb, hsl::Hsla};
+
+        struct_of_arrays_tests!(
+            Hsla<Srgb>,
+            Hsla::new(0.1f32, 0.2, 0.3, 0.4),
+            Hsla::new(0.2, 0.3, 0.4, 0.5),
+            Hsla::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -1,3 +1,5 @@
+//! Types for the HSLuv color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, Sub, SubAssign},
@@ -23,6 +25,7 @@ use crate::{
     bool_mask::{HasBoolMask, LazySelect},
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
+    hues::LuvHueIter,
     luv_bounds::LuvBounds,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, MinMax, One, PartialCmp, Powi, Real,
@@ -179,6 +182,9 @@ impl<Wp, T, A> Alpha<Hsluv<Wp, T>, A> {
         Self::new(hue, saturation, l, alpha)
     }
 }
+
+impl_reference_component_methods_hue!(Hsluv<Wp>, [saturation, l], white_point);
+impl_struct_of_arrays_methods_hue!(Hsluv<Wp>, [saturation, l], white_point);
 
 impl<Wp, T> FromColorUnclamped<Hsluv<Wp, T>> for Hsluv<Wp, T> {
     fn from_color_unclamped(hsluv: Hsluv<Wp, T>) -> Self {
@@ -353,6 +359,7 @@ impl_color_sub!(Hsluv<Wp, T>, [hue, saturation, l], white_point);
 
 impl_array_casts!(Hsluv<Wp, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Hsluv<Wp>, [saturation, l], white_point);
+impl_struct_of_array_traits_hue!(Hsluv<Wp>, LuvHueIter, [saturation, l], white_point);
 
 impl_eq_hue!(Hsluv<Wp>, LuvHue, [hue, saturation, l]);
 
@@ -385,6 +392,7 @@ where
     }
 }
 
+/// Sample HSLuv colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformHsluv<Wp, T>
 where
@@ -555,6 +563,24 @@ mod test {
         assert_relative_eq!(Hsluv::<D65>::min_l(), 0.0);
         assert_relative_eq!(Hsluv::<D65>::max_saturation(), 100.0);
         assert_relative_eq!(Hsluv::<D65>::max_l(), 100.0);
+    }
+
+    struct_of_arrays_tests!(
+        Hsluv<D65>,
+        Hsluv::new(0.1f32, 0.2, 0.3),
+        Hsluv::new(0.2, 0.3, 0.4),
+        Hsluv::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{hsluv::Hsluva, white_point::D65};
+
+        struct_of_arrays_tests!(
+            Hsluva<D65>,
+            Hsluva::new(0.1f32, 0.2, 0.3, 0.4),
+            Hsluva::new(0.2, 0.3, 0.4, 0.5),
+            Hsluva::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -1,3 +1,5 @@
+//! Types for the HSV color space.
+
 use core::{
     any::TypeId,
     marker::PhantomData,
@@ -24,6 +26,7 @@ use crate::{
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
     encoding::Srgb,
+    hues::RgbHueIter,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, IsValidDivisor, MinMax, One,
         PartialCmp, Real, Zero,
@@ -278,6 +281,9 @@ impl<S, T, A> Alpha<Hsv<S, T>, A> {
         Self::new(hue, saturation, value, alpha)
     }
 }
+
+impl_reference_component_methods_hue!(Hsv<S>, [saturation, value], standard);
+impl_struct_of_arrays_methods_hue!(Hsv<S>, [saturation, value], standard);
 
 impl<S1, S2, T> FromColorUnclamped<Hsv<S1, T>> for Hsv<S2, T>
 where
@@ -634,6 +640,7 @@ impl_color_sub!(Hsv<S, T>, [hue, saturation, value], standard);
 
 impl_array_casts!(Hsv<S, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Hsv<S>, [saturation, value], standard);
+impl_struct_of_array_traits_hue!(Hsv<S>, RgbHueIter, [saturation, value], standard);
 
 impl_eq_hue!(Hsv<S>, RgbHue, [hue, saturation, value]);
 
@@ -666,6 +673,7 @@ where
     }
 }
 
+/// Sample HSV colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformHsv<S, T>
 where
@@ -832,6 +840,24 @@ mod test {
         assert_relative_eq!(Hsv::<Srgb>::min_value(), 0.0,);
         assert_relative_eq!(Hsv::<Srgb>::max_saturation(), 1.0,);
         assert_relative_eq!(Hsv::<Srgb>::max_value(), 1.0,);
+    }
+
+    struct_of_arrays_tests!(
+        Hsv<Srgb>,
+        Hsv::new(0.1f32, 0.2, 0.3),
+        Hsv::new(0.2, 0.3, 0.4),
+        Hsv::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{encoding::Srgb, hsv::Hsva};
+
+        struct_of_arrays_tests!(
+            Hsva<Srgb>,
+            Hsva::new(0.1f32, 0.2, 0.3, 0.4),
+            Hsva::new(0.2, 0.3, 0.4, 0.5),
+            Hsva::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -1,3 +1,5 @@
+//! Types for the HWB color space.
+
 use core::{
     any::TypeId,
     marker::PhantomData,
@@ -21,6 +23,7 @@ use crate::{
     clamp, clamp_min, clamp_min_assign, contrast_ratio,
     convert::FromColorUnclamped,
     encoding::Srgb,
+    hues::RgbHueIter,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, MinMax, One, PartialCmp, Real, Zero,
     },
@@ -295,6 +298,9 @@ impl<S, T, A> Alpha<Hwb<S, T>, A> {
         Self::new(hue, whiteness, blackness, alpha)
     }
 }
+
+impl_reference_component_methods_hue!(Hwb<S>, [whiteness, blackness], standard);
+impl_struct_of_arrays_methods_hue!(Hwb<S>, [whiteness, blackness], standard);
 
 impl<S1, S2, T> FromColorUnclamped<Hwb<S1, T>> for Hwb<S2, T>
 where
@@ -576,6 +582,7 @@ impl_color_sub!(Hwb<S, T>, [hue, whiteness, blackness], standard);
 
 impl_array_casts!(Hwb<S, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Hwb<S>, [whiteness, blackness], standard);
+impl_struct_of_array_traits_hue!(Hwb<S>, RgbHueIter, [whiteness, blackness], standard);
 
 #[cfg(feature = "approx")]
 impl<S, T> AbsDiffEq for Hwb<S, T>
@@ -697,6 +704,7 @@ where
     }
 }
 
+/// Sample HWB colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformHwb<S, T>
 where
@@ -861,6 +869,24 @@ mod test {
         assert_relative_eq!(Hwb::<Srgb>::min_blackness(), 0.0,);
         assert_relative_eq!(Hwb::<Srgb>::max_whiteness(), 1.0,);
         assert_relative_eq!(Hwb::<Srgb>::max_blackness(), 1.0,);
+    }
+
+    struct_of_arrays_tests!(
+        Hwb<Srgb>,
+        Hwb::new(0.1f32, 0.2, 0.3),
+        Hwb::new(0.2, 0.3, 0.4),
+        Hwb::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{encoding::Srgb, hwb::Hwba};
+
+        struct_of_arrays_tests!(
+            Hwba<Srgb>,
+            Hwba::new(0.1f32, 0.2, 0.3, 0.4),
+            Hwba::new(0.2, 0.3, 0.4, 0.5),
+            Hwba::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -1,3 +1,5 @@
+//! Types for the CIE L\*a\*b\* (CIELAB) color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, BitOr, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -173,6 +175,9 @@ impl<Wp, T, A> Alpha<Lab<Wp, T>, A> {
         Self::new(l, a, b, alpha)
     }
 }
+
+impl_reference_component_methods!(Lab<Wp>, [l, a, b], white_point);
+impl_struct_of_arrays_methods!(Lab<Wp>, [l, a, b], white_point);
 
 impl<Wp, T> FromColorUnclamped<Lab<Wp, T>> for Lab<Wp, T> {
     fn from_color_unclamped(color: Lab<Wp, T>) -> Self {
@@ -379,6 +384,7 @@ impl_color_div!(Lab<Wp, T>, [l, a, b], white_point);
 
 impl_array_casts!(Lab<Wp, T>, [T; 3]);
 impl_simd_array_conversion!(Lab<Wp>, [l, a, b], white_point);
+impl_struct_of_array_traits!(Lab<Wp>, [l, a, b], white_point);
 
 impl_eq!(Lab<Wp>, [l, a, b]);
 
@@ -416,6 +422,7 @@ where
     }
 }
 
+/// Sample CIE L\*a\*b\* (CIELAB) colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformLab<Wp, T>
 where
@@ -544,6 +551,24 @@ mod test {
         assert_relative_eq!(Lab::<D65, f32>::max_l(), 100.0);
         assert_relative_eq!(Lab::<D65, f32>::max_a(), 127.0);
         assert_relative_eq!(Lab::<D65, f32>::max_b(), 127.0);
+    }
+
+    struct_of_arrays_tests!(
+        Lab<D65>,
+        Lab::new(0.1f32, 0.2, 0.3),
+        Lab::new(0.2, 0.3, 0.4),
+        Lab::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{lab::Laba, white_point::D65};
+
+        struct_of_arrays_tests!(
+            Laba<D65>,
+            Laba::new(0.1f32, 0.2, 0.3, 0.4),
+            Laba::new(0.2, 0.3, 0.4, 0.5),
+            Laba::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -1,3 +1,5 @@
+//! Types for the CIE L\*C\*h° color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, BitOr, Sub, SubAssign},
@@ -21,6 +23,7 @@ use crate::{
     color_difference::{get_ciede2000_difference, Ciede2000, LabColorDiff},
     contrast_ratio,
     convert::{FromColorUnclamped, IntoColorUnclamped},
+    hues::LabHueIter,
     num::{
         self, Abs, Arithmetics, Exp, FromScalarArray, Hypot, IntoScalarArray, MinMax, One,
         PartialCmp, Powi, Real, Sqrt, Trigonometry, Zero,
@@ -178,6 +181,9 @@ impl<Wp, T, A> Alpha<Lch<Wp, T>, A> {
         Self::new(l, chroma, hue, alpha)
     }
 }
+
+impl_reference_component_methods_hue!(Lch<Wp>, [l, chroma], white_point);
+impl_struct_of_arrays_methods_hue!(Lch<Wp>, [l, chroma], white_point);
 
 impl<Wp, T> FromColorUnclamped<Lch<Wp, T>> for Lch<Wp, T> {
     fn from_color_unclamped(color: Lch<Wp, T>) -> Self {
@@ -398,6 +404,7 @@ impl_color_sub!(Lch<Wp, T>, [l, chroma, hue], white_point);
 
 impl_array_casts!(Lch<Wp, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Lch<Wp>, [l, chroma], white_point);
+impl_struct_of_array_traits_hue!(Lch<Wp>, LabHueIter, [l, chroma], white_point);
 
 impl_eq_hue!(Lch<Wp>, LabHue, [l, chroma, hue]);
 
@@ -434,6 +441,7 @@ where
     }
 }
 
+/// Sample CIE L\*C\*h° colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformLch<Wp, T>
 where
@@ -551,6 +559,24 @@ mod test {
         assert_relative_eq!(Lch::<D65, f32>::min_chroma(), 0.0);
         assert_relative_eq!(Lch::<D65, f32>::max_chroma(), 128.0);
         assert_relative_eq!(Lch::<D65, f32>::max_extended_chroma(), 181.01933598375618);
+    }
+
+    struct_of_arrays_tests!(
+        Lch<D65>,
+        Lch::new(0.1f32, 0.2, 0.3),
+        Lch::new(0.2, 0.3, 0.4),
+        Lch::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{lch::Lcha, white_point::D65};
+
+        struct_of_arrays_tests!(
+            Lcha<D65>,
+            Lcha::new(0.1f32, 0.2, 0.3, 0.4),
+            Lcha::new(0.2, 0.3, 0.4, 0.5),
+            Lcha::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -1,3 +1,5 @@
+//! Types for the CIE L\*C\*uv h°uv color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, Mul, Sub, SubAssign},
@@ -22,6 +24,7 @@ use crate::{
     bool_mask::{HasBoolMask, LazySelect},
     clamp, clamp_assign, contrast_ratio,
     convert::FromColorUnclamped,
+    hues::LuvHueIter,
     luv_bounds::LuvBounds,
     num::{
         self, Arithmetics, FromScalarArray, Hypot, IntoScalarArray, MinMax, One, PartialCmp, Powi,
@@ -173,6 +176,9 @@ impl<Wp, T, A> Alpha<Lchuv<Wp, T>, A> {
         Self::new(l, chroma, hue, alpha)
     }
 }
+
+impl_reference_component_methods_hue!(Lchuv<Wp>, [l, chroma], white_point);
+impl_struct_of_arrays_methods_hue!(Lchuv<Wp>, [l, chroma], white_point);
 
 impl<Wp, T> FromColorUnclamped<Lchuv<Wp, T>> for Lchuv<Wp, T> {
     fn from_color_unclamped(color: Lchuv<Wp, T>) -> Self {
@@ -354,6 +360,7 @@ impl_color_sub!(Lchuv<Wp, T>, [l, chroma, hue], white_point);
 
 impl_array_casts!(Lchuv<Wp, T>, [T; 3]);
 impl_simd_array_conversion_hue!(Lchuv<Wp>, [l, chroma], white_point);
+impl_struct_of_array_traits_hue!(Lchuv<Wp>, LuvHueIter, [l, chroma], white_point);
 
 impl_eq_hue!(Lchuv<Wp>, LuvHue, [l, chroma, hue]);
 
@@ -390,6 +397,7 @@ where
     }
 }
 
+/// Sample CIE L\*C\*uv h°uv colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformLchuv<Wp, T>
 where
@@ -523,6 +531,24 @@ mod test {
         assert_relative_eq!(Lchuv::<D65, f32>::max_l(), 100.0);
         assert_relative_eq!(Lchuv::<D65, f32>::min_chroma(), 0.0);
         assert_relative_eq!(Lchuv::<D65, f32>::max_chroma(), 180.0);
+    }
+
+    struct_of_arrays_tests!(
+        Lchuv<D65>,
+        Lchuv::new(0.1f32, 0.2, 0.3),
+        Lchuv::new(0.2, 0.3, 0.4),
+        Lchuv::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{lchuv::Lchuva, white_point::D65};
+
+        struct_of_arrays_tests!(
+            Lchuva<D65>,
+            Lchuva::new(0.1f32, 0.2, 0.3, 0.4),
+            Lchuva::new(0.2, 0.3, 0.4, 0.5),
+            Lchuva::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -256,30 +256,50 @@ use core::ops::{BitAndAssign, Neg};
 use bool_mask::{BoolMask, HasBoolMask};
 use luma::Luma;
 
+#[doc(inline)]
 pub use alpha::{Alpha, WithAlpha};
 
+#[doc(inline)]
 pub use hsl::{Hsl, Hsla};
+#[doc(inline)]
 pub use hsluv::{Hsluv, Hsluva};
+#[doc(inline)]
 pub use hsv::{Hsv, Hsva};
+#[doc(inline)]
 pub use hwb::{Hwb, Hwba};
+#[doc(inline)]
 pub use lab::{Lab, Laba};
+#[doc(inline)]
 pub use lch::{Lch, Lcha};
+#[doc(inline)]
 pub use lchuv::{Lchuv, Lchuva};
+#[doc(inline)]
 pub use luma::{GammaLuma, GammaLumaa, LinLuma, LinLumaa, SrgbLuma, SrgbLumaa};
+#[doc(inline)]
 pub use luv::{Luv, Luva};
+#[doc(inline)]
 pub use okhsl::{Okhsl, Okhsla};
+#[doc(inline)]
 pub use okhsv::{Okhsv, Okhsva};
+#[doc(inline)]
 pub use okhwb::{Okhwb, Okhwba};
+#[doc(inline)]
 pub use oklab::{Oklab, Oklaba};
+#[doc(inline)]
 pub use oklch::{Oklch, Oklcha};
+#[doc(inline)]
 pub use rgb::{GammaSrgb, GammaSrgba, LinSrgb, LinSrgba, Srgb, Srgba};
+#[doc(inline)]
 pub use xyz::{Xyz, Xyza};
+#[doc(inline)]
 pub use yxy::{Yxy, Yxya};
+
+#[doc(inline)]
+pub use hues::{LabHue, LuvHue, OklabHue, RgbHue};
 
 #[allow(deprecated)]
 pub use color_difference::ColorDifference;
 pub use convert::{FromColor, FromColorMut, FromColorMutGuard, IntoColor, IntoColorMut};
-pub use hues::{LabHue, LuvHue, OklabHue, RgbHue};
 pub use matrix::Mat3;
 pub use relative_contrast::{contrast_ratio, RelativeContrast};
 
@@ -451,7 +471,7 @@ mod random_sampling;
 #[cfg(feature = "serializing")]
 pub mod serde;
 
-mod alpha;
+pub mod alpha;
 pub mod angle;
 pub mod blend;
 pub mod bool_mask;
@@ -460,30 +480,30 @@ pub mod chromatic_adaptation;
 pub mod color_difference;
 pub mod convert;
 pub mod encoding;
-mod hsl;
-mod hsluv;
-mod hsv;
-mod hues;
-mod hwb;
-mod lab;
-mod lch;
-mod lchuv;
+pub mod hsl;
+pub mod hsluv;
+pub mod hsv;
+pub mod hues;
+pub mod hwb;
+pub mod lab;
+pub mod lch;
+pub mod lchuv;
 pub mod luma;
-mod luv;
+pub mod luv;
 mod luv_bounds;
 pub mod num;
 mod ok_utils;
-mod okhsl;
-mod okhsv;
-mod okhwb;
-mod oklab;
-mod oklch;
+pub mod okhsl;
+pub mod okhsv;
+pub mod okhwb;
+pub mod oklab;
+pub mod oklch;
 mod relative_contrast;
 pub mod rgb;
 pub mod stimulus;
 pub mod white_point;
-mod xyz;
-mod yxy;
+pub mod xyz;
+pub mod yxy;
 
 #[cfg(test)]
 #[cfg(feature = "approx")]

--- a/palette/src/luma.rs
+++ b/palette/src/luma.rs
@@ -1,4 +1,4 @@
-//! Luminance types.
+//! Types for luma and luminance (grayscale) values.
 
 pub mod channels;
 mod luma;
@@ -6,7 +6,7 @@ mod luma;
 use crate::encoding::{Gamma, Linear, Srgb};
 use crate::white_point::D65;
 
-pub use self::luma::{Luma, Lumaa};
+pub use self::luma::{Iter, Luma, Lumaa};
 
 /// sRGB encoded luminance.
 pub type SrgbLuma<T = f32> = Luma<Srgb, T>;

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -547,6 +547,9 @@ impl<Wp, T, A> Alpha<Luma<Linear<Wp>, T>, A> {
     }
 }
 
+impl_reference_component_methods!(Luma<S>, [luma], standard);
+impl_struct_of_arrays_methods!(Luma<S>, [luma], standard);
+
 impl<S1, S2, T> FromColorUnclamped<Luma<S2, T>> for Luma<S1, T>
 where
     S1: LumaStandard + 'static,
@@ -823,6 +826,7 @@ impl<S> From<Lumaa<S, u8>> for u16 {
 }
 
 impl_simd_array_conversion!(Luma<S>, [luma], standard);
+impl_struct_of_array_traits!(Luma<S>, [luma], standard);
 
 #[cfg(feature = "approx")]
 impl<S, T> AbsDiffEq for Luma<S, T>
@@ -1063,6 +1067,24 @@ mod test {
     fn check_min_max_components() {
         assert_relative_eq!(Luma::<Srgb, f32>::min_luma(), 0.0);
         assert_relative_eq!(Luma::<Srgb, f32>::max_luma(), 1.0);
+    }
+
+    struct_of_arrays_tests!(
+        Luma<Srgb>,
+        Luma::new(0.1f32),
+        Luma::new(0.2),
+        Luma::new(0.3)
+    );
+
+    mod alpha {
+        use crate::{encoding::Srgb, luma::Lumaa};
+
+        struct_of_arrays_tests!(
+            Lumaa<Srgb>,
+            Lumaa::new(0.1f32, 0.4),
+            Lumaa::new(0.2, 0.5),
+            Lumaa::new(0.3, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -1,3 +1,5 @@
+//! Types for the CIE L\*u\*v\* (CIELUV) color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -169,6 +171,9 @@ impl<Wp, T, A> Alpha<Luv<Wp, T>, A> {
     }
 }
 
+impl_reference_component_methods!(Luv<Wp>, [l, u, v], white_point);
+impl_struct_of_arrays_methods!(Luv<Wp>, [l, u, v], white_point);
+
 impl<Wp, T> FromColorUnclamped<Luv<Wp, T>> for Luv<Wp, T> {
     fn from_color_unclamped(color: Luv<Wp, T>) -> Self {
         color
@@ -335,6 +340,7 @@ impl_color_div!(Luv<Wp, T>, [l, u, v], white_point);
 
 impl_array_casts!(Luv<Wp, T>, [T; 3]);
 impl_simd_array_conversion!(Luv<Wp>, [l, u, v], white_point);
+impl_struct_of_array_traits!(Luv<Wp>, [l, u, v], white_point);
 
 impl_eq!(Luv<Wp>, [l, u, v]);
 
@@ -372,6 +378,7 @@ where
     }
 }
 
+/// Sample CIE L\*u\*v\* (CIELUV) colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformLuv<Wp, T>
 where
@@ -516,6 +523,24 @@ mod test {
         assert_relative_eq!(Luv::<D65, f32>::max_l(), 100.0);
         assert_relative_eq!(Luv::<D65, f32>::max_u(), 176.0);
         assert_relative_eq!(Luv::<D65, f32>::max_v(), 108.0);
+    }
+
+    struct_of_arrays_tests!(
+        Luv<D65>,
+        Luv::new(0.1f32, 0.2, 0.3),
+        Luv::new(0.2, 0.3, 0.4),
+        Luv::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{luv::Luva, white_point::D65};
+
+        struct_of_arrays_tests!(
+            Luva<D65>,
+            Luva::new(0.1f32, 0.2, 0.3, 0.4),
+            Luva::new(0.2, 0.3, 0.4, 0.5),
+            Luva::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -33,6 +33,12 @@ mod convert;
 #[macro_use]
 mod color_difference;
 
+#[macro_use]
+mod struct_of_arrays;
+
+#[macro_use]
+mod reference_component;
+
 #[cfg(feature = "random")]
 #[macro_use]
 mod random;

--- a/palette/src/macros/reference_component.rs
+++ b/palette/src/macros/reference_component.rs
@@ -1,0 +1,267 @@
+macro_rules! impl_reference_component_methods {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_reference_component_methods!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($phantom_ty: ident)? > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($phantom_ty,)? T> $self_ty<$($phantom_ty,)? &T> {
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Copy,
+            {
+                $self_ty {
+                    $($element: *self.$element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Clone,
+            {
+                $self_ty {
+                    $($element: self.$element.clone(),)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T> $self_ty<$($phantom_ty,)? &mut T> {
+            /// Update this color with new values.
+            #[inline]
+            pub fn set(&mut self, value: $self_ty<$($phantom_ty,)? T>) {
+                $(*self.$element = value.$element;)+
+            }
+
+            /// Borrow this color's components as shared references.
+            #[inline]
+            pub fn as_refs(&self) -> $self_ty<$($phantom_ty,)? &T> {
+                $self_ty {
+                    $($element: &*self.$element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Copy,
+            {
+                $self_ty {
+                    $($element: *self.$element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Clone,
+            {
+                $self_ty {
+                    $($element: self.$element.clone(),)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T, A> crate::Alpha<$self_ty<$($phantom_ty,)? &T>, &A> {
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Copy,
+                A: Copy,
+            {
+                crate::Alpha{color: self.color.copied(), alpha: *self.alpha}
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Clone,
+                A: Clone,
+            {
+                crate::Alpha{color: self.color.cloned(), alpha: self.alpha.clone()}
+            }
+        }
+
+        impl<$($phantom_ty,)? T, A> crate::Alpha<$self_ty<$($phantom_ty,)? &mut T>, &mut A> {
+            /// Update this color with new values.
+            #[inline]
+            pub fn set(&mut self, value: crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>) {
+                self.color.set(value.color);
+                *self.alpha = value.alpha;
+            }
+
+            /// Borrow this color's components as shared references.
+            #[inline]
+            pub fn as_refs(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? &T>, &A>{
+                crate::Alpha{color: self.color.as_refs(), alpha: &*self.alpha}
+            }
+
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Copy,
+                A: Copy,
+            {
+                crate::Alpha{color: self.color.copied(), alpha: *self.alpha}
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Clone,
+                A: Clone,
+            {
+                crate::Alpha{color: self.color.cloned(), alpha: self.alpha.clone()}
+            }
+        }
+    }
+}
+
+macro_rules! impl_reference_component_methods_hue {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_reference_component_methods_hue!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($phantom_ty: ident)? > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($phantom_ty,)? T> $self_ty<$($phantom_ty,)? &T> {
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Copy,
+            {
+                $self_ty {
+                    hue: self.hue.copied(),
+                    $($element: *self.$element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Clone,
+            {
+                $self_ty {
+                    hue: self.hue.cloned(),
+                    $($element: self.$element.clone(),)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T> $self_ty<$($phantom_ty,)? &mut T> {
+            /// Update this color with new values.
+            #[inline]
+            pub fn set(&mut self, value: $self_ty<$($phantom_ty,)? T>) {
+                self.hue.set(value.hue);
+                $(*self.$element = value.$element;)+
+            }
+
+            /// Borrow this color's components as shared references.
+            #[inline]
+            pub fn as_refs(&self) -> $self_ty<$($phantom_ty,)? &T> {
+                $self_ty {
+                    hue: self.hue.as_ref(),
+                    $($element: &*self.$element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Copy,
+            {
+                $self_ty {
+                    hue: self.hue.copied(),
+                    $($element: *self.$element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> $self_ty<$($phantom_ty,)? T>
+            where
+                T: Clone,
+            {
+                $self_ty {
+                    hue: self.hue.cloned(),
+                    $($element: self.$element.clone(),)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T, A> crate::Alpha<$self_ty<$($phantom_ty,)? &T>, &A> {
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Copy,
+                A: Copy,
+            {
+                crate::Alpha{color: self.color.copied(), alpha: *self.alpha}
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Clone,
+                A: Clone,
+            {
+                crate::Alpha{color: self.color.cloned(), alpha: self.alpha.clone()}
+            }
+        }
+
+        impl<$($phantom_ty,)? T, A> crate::Alpha<$self_ty<$($phantom_ty,)? &mut T>, &mut A> {
+            /// Update this color with new values.
+            #[inline]
+            pub fn set(&mut self, value: crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>) {
+                self.color.set(value.color);
+                *self.alpha = value.alpha;
+            }
+
+            /// Borrow this color's components as shared references.
+            #[inline]
+            pub fn as_refs(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? &T>, &A>{
+                crate::Alpha{color: self.color.as_refs(), alpha: &*self.alpha}
+            }
+
+            /// Get an owned, copied version of this color.
+            #[inline]
+            pub fn copied(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Copy,
+                A: Copy,
+            {
+                crate::Alpha{color: self.color.copied(), alpha: *self.alpha}
+            }
+
+            /// Get an owned, cloned version of this color.
+            #[inline]
+            pub fn cloned(&self) -> crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>
+            where
+                T: Clone,
+                A: Clone,
+            {
+                crate::Alpha{color: self.color.cloned(), alpha: self.alpha.clone()}
+            }
+        }
+    }
+}

--- a/palette/src/macros/struct_of_arrays.rs
+++ b/palette/src/macros/struct_of_arrays.rs
@@ -1,0 +1,835 @@
+macro_rules! first {
+    (($($first: tt)+) $(, ($($rest: tt)+))*) => {
+        $($first)+
+    };
+}
+
+macro_rules! skip_first {
+    (($($first: tt)+) $(, ($($rest: tt)+))*) => {
+        $($($rest)+)*
+    };
+}
+
+macro_rules! impl_struct_of_array_traits {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_struct_of_array_traits!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($phantom_ty: ident)? > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($phantom_ty,)? T, C> Extend<$self_ty<$($phantom_ty,)? T>> for $self_ty<$($phantom_ty,)? C>
+        where
+            C: Extend<T>,
+        {
+            #[inline(always)]
+            fn extend<I: IntoIterator<Item = $self_ty<$($phantom_ty,)? T>>>(&mut self, iter: I) {
+                let iter = iter.into_iter();
+
+                for color in iter {
+                    $(self.$element.extend(core::iter::once(color.$element));)+
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T, C> core::iter::FromIterator<$self_ty<$($phantom_ty,)? T>> for $self_ty<$($phantom_ty,)? C>
+        where
+            Self: Extend<$self_ty<$($phantom_ty,)? T>>,
+            C: Default,
+        {
+            #[inline(always)]
+            fn from_iter<I: IntoIterator<Item = $self_ty<$($phantom_ty,)? T>>>(iter: I) -> Self {
+                let mut result = Self {
+                    $($element: C::default(),)+
+                    $($phantom: PhantomData)?
+                };
+                result.extend(iter);
+
+                result
+            }
+        }
+
+        impl<$($phantom_ty,)? C> IntoIterator for $self_ty<$($phantom_ty,)? C>
+        where
+            C: IntoIterator,
+        {
+            type Item = $self_ty<$($phantom_ty,)? C::Item>;
+
+            type IntoIter = Iter<C::IntoIter $(,$phantom_ty)?>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                Iter {
+                    $($element: self.$element.into_iter(),)+
+                    $($phantom: PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? C> IntoIterator for &'a $self_ty<$($phantom_ty,)? C>
+        where
+            &'a C: IntoIterator,
+        {
+            type Item = $self_ty<$($phantom_ty,)? <&'a C as IntoIterator>::Item>;
+
+            type IntoIter = Iter<<&'a C as IntoIterator>::IntoIter $(,$phantom_ty)?>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                Iter {
+                    $($element: (&self.$element).into_iter(),)+
+                    $($phantom: PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? C> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? C>
+        where
+            &'a mut C: IntoIterator,
+        {
+            type Item = $self_ty<$($phantom_ty,)? <&'a mut C as IntoIterator>::Item>;
+
+            type IntoIter = Iter<<&'a mut C as IntoIterator>::IntoIter $(,$phantom_ty)?>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                Iter {
+                    $($element: (&mut self.$element).into_iter(),)+
+                    $($phantom: PhantomData)?
+                }
+            }
+        }
+
+        #[doc = concat!("An iterator for [`", stringify!($self_ty), "`] values.")]
+        pub struct Iter<I $(,$phantom_ty)?> {
+            $(pub(crate) $element: I,)+
+            $(pub(crate) $phantom: PhantomData<$phantom_ty>)?
+        }
+
+        impl<I $(,$phantom_ty)?> Iterator for Iter<I $(,$phantom_ty)?>
+        where
+            I: Iterator,
+        {
+            type Item = $self_ty<$($phantom_ty,)? I::Item>;
+
+            #[inline(always)]
+            fn next(&mut self) -> Option<Self::Item> {
+                $(let $element = self.$element.next();)+
+
+                if let ($(Some($element),)+) = ($($element,)+) {
+                    Some($self_ty {
+                        $($element,)+
+                        $($phantom: PhantomData,)?
+                    })
+                } else {
+                    None
+                }
+            }
+
+            #[inline(always)]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                let hint = first!($((self.$element)),+).size_hint();
+                skip_first!($((debug_assert_eq!(self.$element.size_hint(), hint, "the component iterators have different size hints");)),+);
+
+                hint
+            }
+
+            #[inline(always)]
+            fn count(self) -> usize {
+                let count = first!($((self.$element)),+).count();
+                skip_first!($((debug_assert_eq!(self.$element.count(), count, "the component iterators have different counts");)),+);
+
+                count
+            }
+        }
+
+        impl<I $(,$phantom_ty)?> DoubleEndedIterator for Iter<I $(,$phantom_ty)?>
+        where
+            I: DoubleEndedIterator,
+        {
+            #[inline(always)]
+            fn next_back(&mut self) -> Option<Self::Item> {
+                $(let $element = self.$element.next_back();)+
+
+                if let ($(Some($element),)+) = ($($element,)+) {
+                    Some($self_ty {
+                        $($element,)+
+                        $($phantom: PhantomData,)?
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl<I $(,$phantom_ty)?> ExactSizeIterator for Iter<I $(,$phantom_ty)?>
+        where
+            I: ExactSizeIterator,
+        {
+            #[inline(always)]
+            fn len(&self) -> usize {
+                let len = first!($((self.$element)),+).len();
+                skip_first!($((debug_assert_eq!(self.$element.len(), len, "the component iterators have different lengths");)),+);
+
+                len
+            }
+        }
+    }
+}
+
+macro_rules! impl_struct_of_array_traits_hue {
+    (  $self_ty: ident, $hue_iter_ty: ident, [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_struct_of_array_traits_hue!($self_ty<>, $hue_iter_ty, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($phantom_ty: ident)? > , $hue_iter_ty: ident, [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($phantom_ty,)? T, C> Extend<$self_ty<$($phantom_ty,)? T>> for $self_ty<$($phantom_ty,)? C>
+        where
+            C: Extend<T>,
+        {
+            #[inline(always)]
+            fn extend<I: IntoIterator<Item = $self_ty<$($phantom_ty,)? T>>>(&mut self, iter: I) {
+                let iter = iter.into_iter();
+
+                for color in iter {
+                    self.hue.extend(core::iter::once(color.hue.into_inner()));
+                    $(self.$element.extend(core::iter::once(color.$element));)+
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T, C> core::iter::FromIterator<$self_ty<$($phantom_ty,)? T>> for $self_ty<$($phantom_ty,)? C>
+        where
+            Self: Extend<$self_ty<$($phantom_ty,)? T>>,
+            C: Default,
+        {
+            #[inline(always)]
+            fn from_iter<I: IntoIterator<Item = $self_ty<$($phantom_ty,)? T>>>(iter: I) -> Self {
+                let mut result = Self {
+                    hue: C::default().into(),
+                    $($element: C::default(),)+
+                    $($phantom: PhantomData)?
+                };
+                result.extend(iter);
+
+                result
+            }
+        }
+
+        impl<$($phantom_ty,)? C> IntoIterator for $self_ty<$($phantom_ty,)? C>
+        where
+            C: IntoIterator,
+        {
+            type Item = $self_ty<$($phantom_ty,)? C::Item>;
+
+            type IntoIter = Iter<C::IntoIter $(,$phantom_ty)?>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                Iter {
+                    hue: self.hue.into_iter(),
+                    $($element: self.$element.into_iter(),)+
+                    $($phantom: PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? C> IntoIterator for &'a $self_ty<$($phantom_ty,)? C>
+        where
+            &'a C: IntoIterator + 'a,
+        {
+            type Item = $self_ty<$($phantom_ty,)? <&'a C as IntoIterator>::Item>;
+
+            type IntoIter = Iter<<&'a C as IntoIterator>::IntoIter $(,$phantom_ty)?>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                Iter {
+                    hue: (&self.hue).into_iter(),
+                    $($element: (&self.$element).into_iter(),)+
+                    $($phantom: PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? C> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? C>
+        where
+            &'a mut C: IntoIterator + 'a,
+        {
+            type Item = $self_ty<$($phantom_ty,)? <&'a mut C as IntoIterator>::Item>;
+
+            type IntoIter = Iter<<&'a mut C as IntoIterator>::IntoIter $(,$phantom_ty)?>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                Iter {
+                    hue: (&mut self.hue).into_iter(),
+                    $($element: (&mut self.$element).into_iter(),)+
+                    $($phantom: PhantomData)?
+                }
+            }
+        }
+
+        #[doc = concat!("An iterator for [`", stringify!($self_ty), "`] values.")]
+        pub struct Iter<I $(,$phantom_ty)?> {
+            pub(crate) hue: $hue_iter_ty<I>,
+            $(pub(crate) $element: I,)+
+            $(pub(crate) $phantom: PhantomData<$phantom_ty>)?
+        }
+
+        impl<I $(,$phantom_ty)?> Iterator for Iter<I $(,$phantom_ty)?>
+        where
+            I: Iterator,
+        {
+            type Item = $self_ty<$($phantom_ty,)? I::Item>;
+
+            #[inline(always)]
+            fn next(&mut self) -> Option<Self::Item> {
+                let hue = self.hue.next();
+                $(let $element = self.$element.next();)+
+
+                if let (Some(hue), $(Some($element),)+) = (hue, $($element,)+) {
+                    Some($self_ty {hue $(, $element)+ $(, $phantom: PhantomData)?})
+                } else {
+                    None
+                }
+            }
+
+            #[inline(always)]
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                let hint = self.hue.size_hint();
+                $(debug_assert_eq!(self.$element.size_hint(), hint, "the component iterators have different size hints");)+
+
+                hint
+            }
+
+            #[inline(always)]
+            fn count(self) -> usize {
+                let count = self.hue.count();
+                $(debug_assert_eq!(self.$element.count(), count, "the component iterators have different counts");)+
+
+                count
+            }
+        }
+
+        impl<I $(,$phantom_ty)?> DoubleEndedIterator for Iter<I $(,$phantom_ty)?>
+        where
+            I: DoubleEndedIterator,
+        {
+            #[inline(always)]
+            fn next_back(&mut self) -> Option<Self::Item> {
+                let hue = self.hue.next_back();
+                $(let $element = self.$element.next_back();)+
+
+                if let (Some(hue), $(Some($element),)+) = (hue, $($element,)+) {
+                    Some($self_ty {hue $(, $element)+ $(, $phantom: PhantomData)?})
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl<I $(,$phantom_ty)?> ExactSizeIterator for Iter<I $(,$phantom_ty)?>
+        where
+            I: ExactSizeIterator,
+        {
+            #[inline(always)]
+            fn len(&self) -> usize {
+                let len = self.hue.len();
+                $(debug_assert_eq!(self.$element.len(), len, "the component iterators have different lengths");)+
+
+                len
+            }
+        }
+    }
+}
+
+macro_rules! impl_struct_of_arrays_methods {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_struct_of_arrays_methods!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($phantom_ty: ident)? > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($phantom_ty,)? C> $self_ty<$($phantom_ty,)? C> {
+            /// Return an iterator over the colors in the wrapped collections.
+            #[inline(always)]
+            pub fn iter<'a>(&'a self) -> <&'a Self as IntoIterator>::IntoIter where &'a Self: IntoIterator {
+                self.into_iter()
+            }
+
+            /// Return an iterator that allows modifying the colors in the wrapped collections.
+            #[inline(always)]
+            pub fn iter_mut<'a>(&'a mut self) -> <&'a mut Self as IntoIterator>::IntoIter where &'a mut Self: IntoIterator {
+                self.into_iter()
+            }
+
+            /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
+            #[inline(always)]
+            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>>
+            where
+                T: 'a,
+                C: AsRef<[T]>,
+                I: core::slice::SliceIndex<[T]> + Clone,
+            {
+                $(let $element = self.$element.as_ref().get(index.clone());)+
+
+                if let ($(Some($element),)+) = ($($element,)+) {
+                    Some($self_ty {
+                        $($element,)+
+                        $($phantom: PhantomData,)?
+                    })
+                } else {
+                    None
+                }
+            }
+
+            /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
+            #[inline(always)]
+            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>>
+            where
+                T: 'a,
+                C: AsMut<[T]>,
+                I: core::slice::SliceIndex<[T]> + Clone,
+            {
+                $(let $element = self.$element.as_mut().get_mut(index.clone());)+
+
+                if let ($(Some($element),)+) = ($($element,)+) {
+                    Some($self_ty {
+                        $($element,)+
+                        $($phantom: PhantomData,)?
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<$($phantom_ty,)? T> $self_ty<$($phantom_ty,)? Vec<T>> {
+            /// Create a struct of vectors with a minimum capacity. See [`Vec::with_capacity`] for details.
+            #[inline(always)]
+            pub fn with_capacity(capacity: usize) -> Self {
+                $(let $element = Vec::with_capacity(capacity);)+
+
+                Self {
+                    $($element,)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+
+            /// Push an additional color's components onto the component vectors. See [`Vec::push`] for details.
+            #[inline(always)]
+            pub fn push(&mut self, value: $self_ty<$($phantom_ty,)? T>) {
+                $(self.$element.push(value.$element);)+
+            }
+
+            /// Pop a color's components from the component vectors. See [`Vec::pop`] for details.
+            #[inline(always)]
+            pub fn pop(&mut self) -> Option<$self_ty<$($phantom_ty,)? T>> {
+                $(let $element = self.$element.pop();)+
+
+                Some($self_ty {
+                    $($element: $element?,)+
+                    $($phantom: PhantomData,)?
+                })
+            }
+
+            /// Clear the component vectors. See [`Vec::clear`] for details.
+            #[inline(always)]
+            pub fn clear(&mut self) {
+                $(self.$element.clear();)+
+            }
+
+            /// Return an iterator that moves colors out of the specified range.
+            #[inline(always)]
+            pub fn drain<R>(&mut self, range: R) -> Iter<std::vec::Drain<T> $(, $phantom_ty)?>
+            where
+                R: core::ops::RangeBounds<usize> + Clone,
+            {
+                Iter {
+                    $($element: self.$element.drain(range.clone()),)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? Ct, Ca> crate::Alpha<$self_ty<$($phantom_ty,)? Ct>, Ca> {
+            /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
+            #[inline(always)]
+            pub fn get<'a, I, T, A>(&'a self, index: I) -> Option<crate::Alpha<
+                $self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>,
+                &<I as core::slice::SliceIndex<[A]>>::Output
+            >>
+            where
+                T: 'a,
+                A: 'a,
+                Ct: AsRef<[T]>,
+                Ca: AsRef<[A]>,
+                I: core::slice::SliceIndex<[T]> + core::slice::SliceIndex<[A]> + Clone
+            {
+                let color = self.color.get(index.clone());
+                let alpha = self.alpha.as_ref().get(index);
+
+                if let (Some(color), Some(alpha)) = (color, alpha) {
+                    Some(crate::Alpha{color, alpha})
+                } else {
+                    None
+                }
+            }
+
+            /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
+            #[inline(always)]
+            pub fn get_mut<'a, I, T, A>(&'a mut self, index: I) -> Option<crate::Alpha<
+                $self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>,
+                &mut <I as core::slice::SliceIndex<[A]>>::Output
+            >>
+            where
+                T: 'a,
+                A: 'a,
+                Ct: AsMut<[T]>,
+                Ca: AsMut<[A]>,
+                I: core::slice::SliceIndex<[T]> + core::slice::SliceIndex<[A]> + Clone
+            {
+                let color = self.color.get_mut(index.clone());
+                let alpha = self.alpha.as_mut().get_mut(index);
+
+                if let (Some(color), Some(alpha)) = (color, alpha) {
+                    Some(crate::Alpha{color, alpha})
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<$($phantom_ty,)? T, A> crate::Alpha<$self_ty<$($phantom_ty,)? Vec<T>>, Vec<A>> {
+            /// Create a struct of vectors with a minimum capacity. See [`Vec::with_capacity`] for details.
+            #[inline(always)]
+            pub fn with_capacity(capacity: usize) -> Self {
+                crate::Alpha {
+                    color: $self_ty::with_capacity(capacity),
+                    alpha: Vec::with_capacity(capacity),
+                }
+            }
+
+            /// Push an additional color's components onto the component vectors. See [`Vec::push`] for details.
+            #[inline(always)]
+            pub fn push(&mut self, value: crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>) {
+                self.color.push(value.color);
+                self.alpha.push(value.alpha);
+            }
+
+            /// Pop a color's components from the component vectors. See [`Vec::pop`] for details.
+            #[inline(always)]
+            pub fn pop(&mut self) -> Option<crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>> {
+                let color = self.color.pop();
+                let alpha = self.alpha.pop();
+
+                Some(crate::Alpha {
+                    color: color?,
+                    alpha: alpha?,
+                })
+            }
+
+            /// Clear the component vectors. See [`Vec::clear`] for details.
+            #[inline(always)]
+            pub fn clear(&mut self) {
+                self.color.clear();
+                self.alpha.clear();
+            }
+
+            /// Return an iterator that moves colors out of the specified range.
+            #[inline(always)]
+            pub fn drain<R>(&mut self, range: R) -> crate::alpha::Iter<Iter<std::vec::Drain<T> $(, $phantom_ty)?>, std::vec::Drain<A>>
+            where
+                R: core::ops::RangeBounds<usize> + Clone,
+            {
+                crate::alpha::Iter {
+                    color: self.color.drain(range.clone()),
+                    alpha: self.alpha.drain(range),
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_struct_of_arrays_methods_hue {
+    (  $self_ty: ident , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl_struct_of_arrays_methods_hue!($self_ty<>, [$($element),+] $(, $phantom)?);
+    };
+    (  $self_ty: ident < $($phantom_ty: ident)? > , [$($element: ident),+] $(, $phantom: ident)?) => {
+        impl<$($phantom_ty,)? C> $self_ty<$($phantom_ty,)? C> {
+            /// Return an iterator over the colors in the wrapped collections.
+            #[inline(always)]
+            pub fn iter<'a>(&'a self) -> <&'a Self as IntoIterator>::IntoIter where &'a Self: IntoIterator {
+                self.into_iter()
+            }
+
+            /// Return an iterator that allows modifying the colors in the wrapped collections.
+            #[inline(always)]
+            pub fn iter_mut<'a>(&'a mut self) -> <&'a mut Self as IntoIterator>::IntoIter where &'a mut Self: IntoIterator {
+                self.into_iter()
+            }
+
+            /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
+            #[inline(always)]
+            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>>
+            where
+                T: 'a,
+                C: AsRef<[T]>,
+                I: core::slice::SliceIndex<[T]> + Clone,
+            {
+                let hue = self.hue.get(index.clone());
+                $(let $element = self.$element.as_ref().get(index.clone());)+
+
+                if let (Some(hue) $(, Some($element))+) = (hue $(,$element)+) {
+                    Some($self_ty {hue $(, $element)+ $(, $phantom: PhantomData)?})
+                } else {
+                    None
+                }
+            }
+
+            /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
+            #[inline(always)]
+            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>>
+            where
+                T: 'a,
+                C: AsMut<[T]>,
+                I: core::slice::SliceIndex<[T]> + Clone,
+            {
+                let hue = self.hue.get_mut(index.clone());
+                $(let $element = self.$element.as_mut().get_mut(index.clone());)+
+
+                if let (Some(hue) $(, Some($element))+) = (hue $(,$element)+) {
+                    Some($self_ty {hue $(, $element)+ $(, $phantom: PhantomData)?})
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<$($phantom_ty,)? T> $self_ty<$($phantom_ty,)? Vec<T>> {
+            /// Create a struct of vectors with a minimum capacity. See [`Vec::with_capacity`] for details.
+            #[inline(always)]
+            pub fn with_capacity(capacity: usize) -> Self {
+                let hue = Vec::with_capacity(capacity);
+                $(let $element = Vec::with_capacity(capacity);)+
+
+                Self {hue: hue.into() $(, $element)+ $(, $phantom: PhantomData)?}
+            }
+
+            /// Push an additional color's components onto the component vectors. See [`Vec::push`] for details.
+            #[inline(always)]
+            pub fn push(&mut self, value: $self_ty<$($phantom_ty,)? T>) {
+                self.hue.push(value.hue);
+                $(self.$element.push(value.$element);)+
+            }
+
+            /// Pop a color's components from the component vectors. See [`Vec::pop`] for details.
+            #[inline(always)]
+            pub fn pop(&mut self) -> Option<$self_ty<$($phantom_ty,)? T>> {
+                let hue = self.hue.pop();
+                $(let $element = self.$element.pop();)+
+
+                Some($self_ty {
+                    hue: hue?,
+                    $($element: $element?,)+
+                    $($phantom: PhantomData,)?
+                })
+            }
+
+            /// Clear the component vectors. See [`Vec::clear`] for details.
+            #[inline(always)]
+            pub fn clear(&mut self) {
+                self.hue.clear();
+                $(self.$element.clear();)+
+            }
+
+            /// Return an iterator that moves colors out of the specified range.
+            #[inline(always)]
+            pub fn drain<R>(&mut self, range: R) -> Iter<std::vec::Drain<T> $(, $phantom_ty)?>
+            where
+                R: core::ops::RangeBounds<usize> + Clone,
+            {
+                Iter {
+                    hue: self.hue.drain(range.clone()),
+                    $($element: self.$element.drain(range.clone()),)+
+                    $($phantom: PhantomData,)?
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? Ct, Ca> crate::Alpha<$self_ty<$($phantom_ty,)? Ct>, Ca> {
+            /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
+            #[inline(always)]
+            pub fn get<'a, I, T, A>(&'a self, index: I) -> Option<crate::Alpha<
+                $self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>,
+                &<I as core::slice::SliceIndex<[A]>>::Output
+            >>
+            where
+                T: 'a,
+                A: 'a,
+                Ct: AsRef<[T]>,
+                Ca: AsRef<[A]>,
+                I: core::slice::SliceIndex<[T]> + core::slice::SliceIndex<[A]> + Clone
+            {
+                let color = self.color.get(index.clone());
+                let alpha = self.alpha.as_ref().get(index);
+
+                if let (Some(color), Some(alpha)) = (color, alpha) {
+                    Some(crate::Alpha{color, alpha})
+                } else {
+                    None
+                }
+            }
+
+            /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
+            #[inline(always)]
+            pub fn get_mut<'a, I, T, A>(&'a mut self, index: I) -> Option<crate::Alpha<
+                $self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>,
+                &mut <I as core::slice::SliceIndex<[A]>>::Output
+            >>
+            where
+                T: 'a,
+                A: 'a,
+                Ct: AsMut<[T]>,
+                Ca: AsMut<[A]>,
+                I: core::slice::SliceIndex<[T]> + core::slice::SliceIndex<[A]> + Clone
+            {
+                let color = self.color.get_mut(index.clone());
+                let alpha = self.alpha.as_mut().get_mut(index);
+
+                if let (Some(color), Some(alpha)) = (color, alpha) {
+                    Some(crate::Alpha{color, alpha})
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[cfg(feature = "std")]
+        impl<$($phantom_ty,)? T, A> crate::Alpha<$self_ty<$($phantom_ty,)? Vec<T>>, Vec<A>> {
+            /// Create a struct of vectors with a minimum capacity. See [`Vec::with_capacity`] for details.
+            #[inline(always)]
+            pub fn with_capacity(capacity: usize) -> Self {
+                crate::Alpha {
+                    color: $self_ty::with_capacity(capacity),
+                    alpha: Vec::with_capacity(capacity),
+                }
+            }
+
+            /// Push an additional color's components onto the component vectors. See [`Vec::push`] for details.
+            #[inline(always)]
+            pub fn push(&mut self, value: crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>) {
+                self.color.push(value.color);
+                self.alpha.push(value.alpha);
+            }
+
+            /// Pop a color's components from the component vectors. See [`Vec::pop`] for details.
+            #[inline(always)]
+            pub fn pop(&mut self) -> Option<crate::Alpha<$self_ty<$($phantom_ty,)? T>, A>> {
+                let color = self.color.pop();
+                let alpha = self.alpha.pop();
+
+                Some(crate::Alpha {
+                    color: color?,
+                    alpha: alpha?,
+                })
+            }
+
+            /// Clear the component vectors. See [`Vec::clear`] for details.
+            #[inline(always)]
+            pub fn clear(&mut self) {
+                self.color.clear();
+                self.alpha.clear();
+            }
+
+            /// Return an iterator that moves colors out of the specified range.
+            #[inline(always)]
+            pub fn drain<R>(&mut self, range: R) -> crate::alpha::Iter<Iter<std::vec::Drain<T> $(, $phantom_ty)?>, std::vec::Drain<A>>
+            where
+                R: core::ops::RangeBounds<usize> + Clone,
+            {
+                crate::alpha::Iter {
+                    color: self.color.drain(range.clone()),
+                    alpha: self.alpha.drain(range),
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+macro_rules! struct_of_arrays_tests {
+    ($color_ty: ident $(<$phantom_ty:ident>)?, $($values:expr),+) => {
+        #[test]
+        fn collect() {
+            let vec_of_colors = vec![$($values),+];
+            let color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values),+]);
+        }
+
+        #[test]
+        fn extend() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = $color_ty::with_capacity(vec_of_colors.len());
+            color_of_vecs.extend(vec_of_colors);
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values),+]);
+        }
+
+        #[test]
+        fn pop_push() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+            let last = color_of_vecs.pop().unwrap();
+            color_of_vecs.push(last);
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values),+]);
+        }
+
+        #[test]
+        fn clear() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+            color_of_vecs.clear();
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![]);
+        }
+
+        #[test]
+        fn drain() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+
+            let vec_of_colors1: Vec<_> = color_of_vecs.drain(..).collect();
+            let vec_of_colors2: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors1, vec![$($values),+]);
+            assert_eq!(vec_of_colors2, vec![]);
+        }
+
+        #[test]
+        fn modify() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+
+            for mut color in &mut color_of_vecs {
+                color.set(color.copied() + 2.0);
+            }
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values + 2.0),+]);
+        }
+    }
+}

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -1,3 +1,5 @@
+//! Types for the Okhsl color space.
+
 pub use alpha::Okhsla;
 
 use crate::{
@@ -9,6 +11,11 @@ use crate::{
     white_point::D65,
     GetHue, HasBoolMask, LinSrgb, Oklab, OklabHue,
 };
+
+pub use self::properties::Iter;
+
+#[cfg(feature = "random")]
+pub use self::random::UniformOkhsl;
 
 mod alpha;
 mod properties;
@@ -145,6 +152,9 @@ where
         T::max_intensity()
     }
 }
+
+impl_reference_component_methods_hue!(Okhsl, [saturation, lightness]);
+impl_struct_of_arrays_methods_hue!(Okhsl, [saturation, lightness]);
 
 /// # See
 /// See [`srgb_to_okhsl`](https://bottosson.github.io/posts/colorpicker/#hsl-2)
@@ -378,5 +388,23 @@ mod tests {
         let rgb8: Rgb<encoding::Srgb, u8> = rgb.into_format();
         let hex_str = format!("{:x}", rgb8);
         assert_eq!(hex_str, "aa5a74");
+    }
+
+    struct_of_arrays_tests!(
+        Okhsl,
+        Okhsl::new(0.1f32, 0.2, 0.3),
+        Okhsl::new(0.2, 0.3, 0.4),
+        Okhsl::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::okhsl::Okhsla;
+
+        struct_of_arrays_tests!(
+            Okhsla,
+            Okhsla::new(0.1f32, 0.2, 0.3, 0.4),
+            Okhsla::new(0.2, 0.3, 0.4, 0.5),
+            Okhsla::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 }

--- a/palette/src/okhsl/properties.rs
+++ b/palette/src/okhsl/properties.rs
@@ -3,7 +3,7 @@ use core::ops::{Add, AddAssign, BitAnd, Sub, SubAssign};
 #[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-use crate::white_point::D65;
+use crate::{hues::OklabHueIter, white_point::D65};
 
 use crate::{
     angle::{RealAngle, SignedAngle},
@@ -135,6 +135,7 @@ impl_color_sub!(Okhsl<T>, [hue, saturation, lightness]);
 
 impl_array_casts!(Okhsl<T>, [T; 3]);
 impl_simd_array_conversion_hue!(Okhsl, [saturation, lightness]);
+impl_struct_of_array_traits_hue!(Okhsl, OklabHueIter, [saturation, lightness]);
 
 impl_eq_hue!(Okhsl, OklabHue, [hue, saturation, lightness]);
 

--- a/palette/src/okhsl/random.rs
+++ b/palette/src/okhsl/random.rs
@@ -26,6 +26,7 @@ where
     }
 }
 
+/// Sample Okhsl colors uniformly.
 pub struct UniformOkhsl<T>
 where
     T: SampleUniform,

--- a/palette/src/okhsv.rs
+++ b/palette/src/okhsv.rs
@@ -1,3 +1,5 @@
+//! Types for the Okhsv color space.
+
 use core::fmt::Debug;
 
 pub use alpha::Okhsva;
@@ -16,6 +18,8 @@ use crate::{
     white_point::D65,
     GetHue, HasBoolMask, LinSrgb, Okhwb, Oklab, OklabHue,
 };
+
+pub use self::properties::Iter;
 
 mod alpha;
 mod properties;
@@ -125,6 +129,9 @@ where
         T::max_intensity()
     }
 }
+
+impl_reference_component_methods_hue!(Okhsv, [saturation, value]);
+impl_struct_of_arrays_methods_hue!(Okhsv, [saturation, value]);
 
 impl<T> Okhsv<T> {
     /// Create an `Okhsv` color.
@@ -534,5 +541,23 @@ mod tests {
                 linsrgb
             );
         }
+    }
+
+    struct_of_arrays_tests!(
+        Okhsv,
+        Okhsv::new(0.1f32, 0.2, 0.3),
+        Okhsv::new(0.2, 0.3, 0.4),
+        Okhsv::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::okhsv::Okhsva;
+
+        struct_of_arrays_tests!(
+            Okhsva,
+            Okhsva::new(0.1f32, 0.2, 0.3, 0.4),
+            Okhsva::new(0.2, 0.3, 0.4, 0.5),
+            Okhsva::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 }

--- a/palette/src/okhsv/properties.rs
+++ b/palette/src/okhsv/properties.rs
@@ -3,10 +3,10 @@ use core::ops::{Add, AddAssign, BitAnd, Sub, SubAssign};
 #[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-use crate::angle::SignedAngle;
 use crate::num::{
     self, Arithmetics, FromScalarArray, IntoScalarArray, MinMax, One, PartialCmp, Real, Zero,
 };
+use crate::{angle::SignedAngle, hues::OklabHueIter};
 
 use crate::{angle::RealAngle, clamp_assign, ok_utils, Alpha, IsWithinBounds, OklabHue};
 use crate::{
@@ -125,5 +125,6 @@ impl_color_sub!(Okhsv<T>, [hue, saturation, value]);
 
 impl_array_casts!(Okhsv<T>, [T; 3]);
 impl_simd_array_conversion_hue!(Okhsv, [saturation, value]);
+impl_struct_of_array_traits_hue!(Okhsv, OklabHueIter, [saturation, value]);
 
 impl_eq_hue!(Okhsv, OklabHue, [hue, saturation, value]);

--- a/palette/src/okhsv/random.rs
+++ b/palette/src/okhsv/random.rs
@@ -23,6 +23,7 @@ where
     }
 }
 
+/// Sample Okhsv colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformOkhsv<T>
 where

--- a/palette/src/okhwb.rs
+++ b/palette/src/okhwb.rs
@@ -1,3 +1,5 @@
+//! Types for the Okhwb color space.
+
 use core::fmt::Debug;
 
 pub use alpha::Okhwba;
@@ -10,6 +12,11 @@ use crate::{
     white_point::D65,
     HasBoolMask, Okhsv, OklabHue,
 };
+
+pub use self::properties::Iter;
+
+#[cfg(feature = "random")]
+pub use self::random::UniformOkhwb;
 
 mod alpha;
 mod properties;
@@ -118,6 +125,9 @@ where
         T::max_intensity()
     }
 }
+
+impl_reference_component_methods_hue!(Okhwb, [whiteness, blackness]);
+impl_struct_of_arrays_methods_hue!(Okhwb, [whiteness, blackness]);
 
 impl<T> FromColorUnclamped<Okhsv<T>> for Okhwb<T>
 where
@@ -263,5 +273,23 @@ mod tests {
                 color
             );
         }
+    }
+
+    struct_of_arrays_tests!(
+        Okhwb,
+        Okhwb::new(0.1f32, 0.2, 0.3),
+        Okhwb::new(0.2, 0.3, 0.4),
+        Okhwb::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::okhwb::Okhwba;
+
+        struct_of_arrays_tests!(
+            Okhwba,
+            Okhwba::new(0.1f32, 0.2, 0.3, 0.4),
+            Okhwba::new(0.2, 0.3, 0.4, 0.5),
+            Okhwba::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 }

--- a/palette/src/okhwb/properties.rs
+++ b/palette/src/okhwb/properties.rs
@@ -1,9 +1,12 @@
 use core::ops::{Add, AddAssign, BitAnd, DivAssign, Sub, SubAssign};
 
-use crate::angle::{RealAngle, SignedAngle};
 use crate::stimulus::Stimulus;
 use crate::white_point::D65;
 use crate::HasBoolMask;
+use crate::{
+    angle::{RealAngle, SignedAngle},
+    hues::OklabHueIter,
+};
 use crate::{
     bool_mask::{LazySelect, Select},
     clamp, clamp_min, clamp_min_assign, contrast_ratio, ClampAssign, FromColor, GetHue,
@@ -221,6 +224,7 @@ impl_color_sub!(Okhwb<T>, [hue, whiteness, blackness]);
 
 impl_array_casts!(Okhwb<T>, [T; 3]);
 impl_simd_array_conversion_hue!(Okhwb, [whiteness, blackness]);
+impl_struct_of_array_traits_hue!(Okhwb, OklabHueIter, [whiteness, blackness]);
 
 impl<T> RelativeContrast for Okhwb<T>
 where

--- a/palette/src/okhwb/random.rs
+++ b/palette/src/okhwb/random.rs
@@ -21,6 +21,7 @@ where
     }
 }
 
+/// Sample Okhwb colors uniformly.
 pub struct UniformOkhwb<T>
 where
     T: SampleUniform,

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -1,3 +1,5 @@
+//! Types for the Oklab color space.
+
 use core::{any::TypeId, fmt::Debug, ops::Mul};
 
 pub use alpha::Oklaba;
@@ -14,6 +16,11 @@ use crate::{
     white_point::D65,
     LinSrgb, Mat3, Okhsl, Okhsv, Oklch, Xyz,
 };
+
+pub use self::properties::Iter;
+
+#[cfg(feature = "random")]
+pub use self::random::UniformOklab;
 
 mod alpha;
 mod properties;
@@ -232,6 +239,9 @@ where
         T::one()
     }
 }
+
+impl_reference_component_methods!(Oklab, [l, a, b]);
+impl_struct_of_arrays_methods!(Oklab, [l, a, b]);
 
 impl<T> Oklab<T>
 where
@@ -666,6 +676,24 @@ mod test {
     fn check_min_max_components() {
         assert_eq!(Oklab::<f32>::min_l(), 0.0);
         assert_eq!(Oklab::<f32>::max_l(), 1.0);
+    }
+
+    struct_of_arrays_tests!(
+        Oklab,
+        Oklab::new(0.1f32, 0.2, 0.3),
+        Oklab::new(0.2, 0.3, 0.4),
+        Oklab::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::oklab::Oklaba;
+
+        struct_of_arrays_tests!(
+            Oklaba,
+            Oklaba::new(0.1f32, 0.2, 0.3, 0.4),
+            Oklaba::new(0.2, 0.3, 0.4, 0.5),
+            Oklaba::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -73,6 +73,7 @@ impl_color_div!(Oklab<T>, [l, a, b]);
 
 impl_array_casts!(Oklab<T>, [T; 3]);
 impl_simd_array_conversion!(Oklab, [l, a, b]);
+impl_struct_of_array_traits!(Oklab, [l, a, b]);
 
 impl_eq!(Oklab, [l, a, b]);
 

--- a/palette/src/oklab/random.rs
+++ b/palette/src/oklab/random.rs
@@ -21,6 +21,7 @@ where {
     }
 }
 
+/// Sample Oklab colors uniformly.
 pub struct UniformOklab<T>
 where
     T: SampleUniform,

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -1,3 +1,5 @@
+//! Types for the Oklch color space.
+
 pub use alpha::Oklcha;
 
 use crate::{
@@ -7,6 +9,11 @@ use crate::{
     white_point::D65,
     GetHue, Oklab, OklabHue,
 };
+
+pub use self::properties::Iter;
+
+#[cfg(feature = "random")]
+pub use self::random::UniformOklch;
 
 mod alpha;
 mod properties;
@@ -94,6 +101,9 @@ where
         T::zero()
     }
 }
+
+impl_reference_component_methods_hue!(Oklch, [l, chroma]);
+impl_struct_of_arrays_methods_hue!(Oklch, [l, chroma]);
 
 impl<T> FromColorUnclamped<Oklch<T>> for Oklch<T> {
     fn from_color_unclamped(color: Oklch<T>) -> Self {
@@ -191,6 +201,24 @@ mod test {
             ::serde_json::from_str(r#"{"l":0.3,"chroma":0.8,"hue":0.1}"#).unwrap();
 
         assert_eq!(deserialized, Oklch::new(0.3, 0.8, 0.1));
+    }
+
+    struct_of_arrays_tests!(
+        Oklch,
+        Oklch::new(0.1f32, 0.2, 0.3),
+        Oklch::new(0.2, 0.3, 0.4),
+        Oklch::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::oklch::Oklcha;
+
+        struct_of_arrays_tests!(
+            Oklcha,
+            Oklcha::new(0.1f32, 0.2, 0.3, 0.4),
+            Oklcha::new(0.2, 0.3, 0.4, 0.5),
+            Oklcha::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "random")]

--- a/palette/src/oklch/properties.rs
+++ b/palette/src/oklch/properties.rs
@@ -7,6 +7,7 @@ use crate::{
     angle::{RealAngle, SignedAngle},
     bool_mask::LazySelect,
     clamp, clamp_assign, clamp_min, clamp_min_assign, contrast_ratio,
+    hues::OklabHueIter,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, MinMax, One, PartialCmp, Real, Zero,
     },
@@ -116,6 +117,7 @@ impl_color_sub!(Oklch<T>, [l, chroma, hue]);
 
 impl_array_casts!(Oklch<T>, [T; 3]);
 impl_simd_array_conversion_hue!(Oklch, [l, chroma]);
+impl_struct_of_array_traits_hue!(Oklch, OklabHueIter, [l, chroma]);
 
 impl_eq_hue!(Oklch, OklabHue, [l, chroma, hue]);
 

--- a/palette/src/oklch/random.rs
+++ b/palette/src/oklch/random.rs
@@ -24,6 +24,7 @@ where
     }
 }
 
+/// Sample Oklch colors uniformly.
 pub struct UniformOklch<T>
 where
     T: SampleUniform,

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -1,4 +1,4 @@
-//! RGB types, spaces and standards.
+//! Types for the RGB color space, including spaces and standards.
 //!
 //! # Linear And Non-linear RGB
 //!
@@ -67,7 +67,7 @@ use crate::{
     Mat3, Yxy,
 };
 
-pub use self::rgb::{FromHexError, Rgb, Rgba};
+pub use self::rgb::{FromHexError, Iter, Rgb, Rgba};
 
 pub mod channels;
 mod rgb;

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -560,6 +560,9 @@ impl<S: RgbSpace, T, A> Alpha<Rgb<Linear<S>, T>, A> {
     }
 }
 
+impl_reference_component_methods!(Rgb<S>, [red, green, blue], standard);
+impl_struct_of_arrays_methods!(Rgb<S>, [red, green, blue], standard);
+
 impl<S1, S2, T> FromColorUnclamped<Rgb<S2, T>> for Rgb<S1, T>
 where
     S1: RgbStandard + 'static,
@@ -887,6 +890,7 @@ impl<S, T, A> From<Alpha<Rgb<S, T>, A>> for (T, T, T, A) {
 
 impl_array_casts!(Rgb<S, T>, [T; 3]);
 impl_simd_array_conversion!(Rgb<S>, [red, green, blue], standard);
+impl_struct_of_array_traits!(Rgb<S>, [red, green, blue], standard);
 
 impl_eq!(Rgb<S>, [red, green, blue]);
 
@@ -1383,6 +1387,24 @@ mod test {
         assert_relative_eq!(Rgb::<Srgb, f32>::max_red(), 1.0);
         assert_relative_eq!(Rgb::<Srgb, f32>::max_green(), 1.0);
         assert_relative_eq!(Rgb::<Srgb, f32>::max_blue(), 1.0);
+    }
+
+    struct_of_arrays_tests!(
+        Rgb<Srgb>,
+        Rgb::new(0.1f32, 0.2, 0.3),
+        Rgb::new(0.2, 0.3, 0.4),
+        Rgb::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{encoding::Srgb, rgb::Rgba};
+
+        struct_of_arrays_tests!(
+            Rgba<Srgb>,
+            Rgba::new(0.1f32, 0.2, 0.3, 0.4),
+            Rgba::new(0.2, 0.3, 0.4, 0.5),
+            Rgba::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "random")]

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -1,3 +1,5 @@
+//! Types for the CIE 1931 XYZ color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
@@ -199,6 +201,9 @@ impl<Wp, T, A> Alpha<Xyz<Wp, T>, A> {
         Alpha::<Xyz<NewWp, T>, A>::new(self.color.x, self.color.y, self.color.z, self.alpha)
     }
 }
+
+impl_reference_component_methods!(Xyz<Wp>, [x, y, z], white_point);
+impl_struct_of_arrays_methods!(Xyz<Wp>, [x, y, z], white_point);
 
 impl<Wp, T> FromColorUnclamped<Xyz<Wp, T>> for Xyz<Wp, T> {
     fn from_color_unclamped(color: Xyz<Wp, T>) -> Self {
@@ -452,6 +457,7 @@ impl_color_div!(Xyz<Wp, T>, [x, y, z], white_point);
 
 impl_array_casts!(Xyz<Wp, T>, [T; 3]);
 impl_simd_array_conversion!(Xyz<Wp>, [x, y, z], white_point);
+impl_struct_of_array_traits!(Xyz<Wp>, [x, y, z], white_point);
 
 impl_eq!(Xyz<Wp>, [x, y, z]);
 
@@ -486,6 +492,7 @@ where
     }
 }
 
+/// Sample CIE 1931 XYZ colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformXyz<Wp, T>
 where
@@ -628,6 +635,24 @@ mod test {
         assert_relative_eq!(Xyz::<D65, f64>::max_x(), X_N);
         assert_relative_eq!(Xyz::<D65, f64>::max_y(), Y_N);
         assert_relative_eq!(Xyz::<D65, f64>::max_z(), Z_N);
+    }
+
+    struct_of_arrays_tests!(
+        Xyz<D65>,
+        Xyz::new(0.1f32, 0.2, 0.3),
+        Xyz::new(0.2, 0.3, 0.4),
+        Xyz::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{white_point::D65, xyz::Xyza};
+
+        struct_of_arrays_tests!(
+            Xyza<D65>,
+            Xyza::new(0.1f32, 0.2, 0.3, 0.4),
+            Xyza::new(0.2, 0.3, 0.4, 0.5),
+            Xyza::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -1,3 +1,5 @@
+//! Types for the CIE 1931 Yxy (xyY) color space.
+
 use core::{
     marker::PhantomData,
     ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
@@ -35,7 +37,7 @@ use crate::{
 /// in `Alpha`](crate::Alpha#Yxya).
 pub type Yxya<Wp = D65, T = f32> = Alpha<Yxy<Wp, T>, T>;
 
-/// The CIE 1931 Yxy (xyY)  color space.
+/// The CIE 1931 Yxy (xyY) color space.
 ///
 /// Yxy is a luminance-chromaticity color space derived from the CIE XYZ
 /// color space. It is widely used to define colors. The chromaticity diagrams
@@ -195,6 +197,9 @@ impl<Wp, T, A> Alpha<Yxy<Wp, T>, A> {
     }
 }
 
+impl_reference_component_methods!(Yxy<Wp>, [x, y, luma], white_point);
+impl_struct_of_arrays_methods!(Yxy<Wp>, [x, y, luma], white_point);
+
 impl<Wp, T> From<(T, T, T)> for Yxy<Wp, T> {
     fn from(components: (T, T, T)) -> Self {
         Self::from_components(components)
@@ -338,6 +343,7 @@ impl_color_div!(Yxy<Wp, T>, [x, y, luma], white_point);
 
 impl_array_casts!(Yxy<Wp, T>, [T; 3]);
 impl_simd_array_conversion!(Yxy<Wp>, [x, y, luma], white_point);
+impl_struct_of_array_traits!(Yxy<Wp>, [x, y, luma], white_point);
 
 impl_eq!(Yxy<Wp>, [y, x, luma]);
 
@@ -369,6 +375,7 @@ where
     }
 }
 
+/// Sample CIE 1931 Yxy (xyY) colors uniformly.
 #[cfg(feature = "random")]
 pub struct UniformYxy<Wp, T>
 where
@@ -504,6 +511,24 @@ mod test {
         assert_relative_eq!(Yxy::<D65>::max_x(), 1.0);
         assert_relative_eq!(Yxy::<D65>::max_y(), 1.0);
         assert_relative_eq!(Yxy::<D65>::max_luma(), 1.0);
+    }
+
+    struct_of_arrays_tests!(
+        Yxy<D65>,
+        Yxy::new(0.1f32, 0.2, 0.3),
+        Yxy::new(0.2, 0.3, 0.4),
+        Yxy::new(0.3, 0.4, 0.5)
+    );
+
+    mod alpha {
+        use crate::{white_point::D65, yxy::Yxya};
+
+        struct_of_arrays_tests!(
+            Yxya<D65>,
+            Yxya::new(0.1f32, 0.2, 0.3, 0.4),
+            Yxya::new(0.2, 0.3, 0.4, 0.5),
+            Yxya::new(0.3, 0.4, 0.5, 0.6)
+        );
     }
 
     #[cfg(feature = "serializing")]


### PR DESCRIPTION
This adds a set of iterators and utilities for converting between arrays of structs and structs of arrays. There's definitely more that can be done, but it's a start. This pull request includes:

* Creating  and extending`ColorType<Collection<T>>` from any `IntoIterator<Item=ColorType<T>>`.
* Iterating over `ColorType<Collection<T>>`.
* Some `Vec` functions are available for `ColorType<Vec<T>>`, with more that can be added.
* Slicing and indexing with `get` and `get_mut`.
* Working with `ColorType<&T>` and `ColorType<&mut T>`, using `copied`, `cloned` and `set`.

See the discussion in #303 for some background.

## Closed Issues

* Closes #305.
