### PR TITLE
Add saturating_add and saturating_sub for integer based colors

### DIFF
--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -22,7 +22,7 @@ use crate::{
     cast::ArrayCast,
     clamp, clamp_assign,
     convert::{FromColorUnclamped, IntoColorUnclamped},
-    num::{self, Arithmetics, One, PartialCmp, Zero},
+    num::{self, Arithmetics, One, PartialCmp, SaturatingAdd, SaturatingSub, Zero},
     stimulus::Stimulus,
     ArrayExt, Clamp, ClampAssign, GetHue, IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign,
     NextArray, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign, WithAlpha, WithHue,
@@ -455,6 +455,36 @@ where
     }
 }
 
+impl<C, T> SaturatingAdd for Alpha<C, T>
+where
+    C: SaturatingAdd,
+    T: SaturatingAdd,
+{
+    type Output = Alpha<C::Output, <T as SaturatingAdd>::Output>;
+
+    fn saturating_add(self, other: Alpha<C, T>) -> Self::Output {
+        Alpha {
+            color: self.color.saturating_add(other.color),
+            alpha: self.alpha.saturating_add(other.alpha),
+        }
+    }
+}
+
+impl<T, C> SaturatingAdd<T> for Alpha<C, T>
+where
+    T: SaturatingAdd + Clone,
+    C: SaturatingAdd<T>,
+{
+    type Output = Alpha<C::Output, <T as SaturatingAdd>::Output>;
+
+    fn saturating_add(self, c: T) -> Self::Output {
+        Alpha {
+            color: self.color.saturating_add(c.clone()),
+            alpha: self.alpha.saturating_add(c),
+        }
+    }
+}
+
 impl<C, T> Sub for Alpha<C, T>
 where
     C: Sub,
@@ -504,6 +534,36 @@ where
     fn sub_assign(&mut self, c: T) {
         self.color -= c.clone();
         self.alpha -= c;
+    }
+}
+
+impl<C, T> SaturatingSub for Alpha<C, T>
+where
+    C: SaturatingSub,
+    T: SaturatingSub,
+{
+    type Output = Alpha<C::Output, <T as SaturatingSub>::Output>;
+
+    fn saturating_sub(self, other: Alpha<C, T>) -> Self::Output {
+        Alpha {
+            color: self.color.saturating_sub(other.color),
+            alpha: self.alpha.saturating_sub(other.alpha),
+        }
+    }
+}
+
+impl<T, C> SaturatingSub<T> for Alpha<C, T>
+where
+    T: SaturatingSub + Clone,
+    C: SaturatingSub<T>,
+{
+    type Output = Alpha<C::Output, <T as SaturatingSub>::Output>;
+
+    fn saturating_sub(self, c: T) -> Self::Output {
+        Alpha {
+            color: self.color.saturating_sub(c.clone()),
+            alpha: self.alpha.saturating_sub(c),
+        }
     }
 }
 

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -347,6 +347,24 @@ macro_rules! make_hues {
             }
         }
 
+        impl<T: $crate::num::SaturatingAdd<Output=T>> $crate::num::SaturatingAdd<$name<T>> for $name<T> {
+            type Output = $name<T>;
+
+            #[inline]
+            fn saturating_add(self, other: $name<T>) -> $name<T> {
+                $name(self.0.saturating_add(other.0))
+            }
+        }
+
+        impl<T: $crate::num::SaturatingAdd<Output=T>> $crate::num::SaturatingAdd<T> for $name<T> {
+            type Output = $name<T>;
+
+            #[inline]
+            fn saturating_add(self, other: T) -> $name<T> {
+                $name(self.0.saturating_add(other))
+            }
+        }
+
         impl<T: Sub<Output=T>> Sub<$name<T>> for $name<T> {
             type Output = $name<T>;
 
@@ -408,6 +426,24 @@ macro_rules! make_hues {
             #[inline]
             fn sub_assign(&mut self, other: $name<f64>){
                 *self -= other.0;
+            }
+        }
+
+        impl<T: $crate::num::SaturatingSub<Output=T>> $crate::num::SaturatingSub<$name<T>> for $name<T> {
+            type Output = $name<T>;
+
+            #[inline]
+            fn saturating_sub(self, other: $name<T>) -> $name<T> {
+                $name(self.0.saturating_sub(other.0))
+            }
+        }
+
+        impl<T: $crate::num::SaturatingSub<Output=T>> $crate::num::SaturatingSub<T> for $name<T> {
+            type Output = $name<T>;
+
+            #[inline]
+            fn saturating_sub(self, other: T) -> $name<T> {
+                $name(self.0.saturating_sub(other))
             }
         }
 

--- a/palette/src/macros/arithmetics.rs
+++ b/palette/src/macros/arithmetics.rs
@@ -39,10 +39,38 @@ macro_rules! impl_color_add {
 
         impl<$phantom_ty, $component_ty> AddAssign<$component_ty> for $self_ty<$phantom_ty, $component_ty>
         where
-            T:  AddAssign + Clone
+            T: AddAssign + Clone
         {
             fn add_assign(&mut self, c: $component_ty) {
                 $( self.$element += c.clone(); )+
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> $crate::num::SaturatingAdd<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: $crate::num::SaturatingAdd<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn saturating_add(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element.saturating_add(other.$element), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> $crate::num::SaturatingAdd<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: $crate::num::SaturatingAdd<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn saturating_add(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element.saturating_add(c.clone()), )+
+                    $phantom: PhantomData,
+                }
             }
         }
     };
@@ -84,10 +112,36 @@ macro_rules! impl_color_add {
 
         impl<$component_ty> AddAssign<$component_ty> for $self_ty<$component_ty>
         where
-            T:  AddAssign + Clone
+            T: AddAssign + Clone
         {
             fn add_assign(&mut self, c: $component_ty) {
                 $( self.$element += c.clone(); )+
+            }
+        }
+
+        impl<$component_ty> $crate::num::SaturatingAdd<Self> for $self_ty<$component_ty>
+        where
+            T: $crate::num::SaturatingAdd<Output=T>
+        {
+            type Output = Self;
+
+            fn saturating_add(self, other: Self) -> Self {
+                $self_ty {
+                    $( $element: self.$element.saturating_add(other.$element), )+
+                }
+            }
+        }
+
+        impl<$component_ty> $crate::num::SaturatingAdd<$component_ty> for $self_ty<$component_ty>
+        where
+            T: $crate::num::SaturatingAdd<Output=T> + Clone
+        {
+            type Output = Self;
+
+            fn saturating_add(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element.saturating_add(c.clone()), )+
+                }
             }
         }
     };
@@ -143,6 +197,34 @@ macro_rules! impl_color_sub {
                 $( self.$element -= c.clone(); )+
             }
         }
+
+        impl<$phantom_ty, $component_ty> $crate::num::SaturatingSub<Self> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: $crate::num::SaturatingSub<Output=$component_ty>
+        {
+            type Output = Self;
+
+            fn saturating_sub(self, other: Self) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element.saturating_sub(other.$element), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
+
+        impl<$phantom_ty, $component_ty> $crate::num::SaturatingSub<$component_ty> for $self_ty<$phantom_ty, $component_ty>
+        where
+            T: $crate::num::SaturatingSub<Output=$component_ty> + Clone
+        {
+            type Output = Self;
+
+            fn saturating_sub(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element.saturating_sub(c.clone()), )+
+                    $phantom: PhantomData,
+                }
+            }
+        }
     };
 
     ($self_ty: ident < $component_ty: ident > , [$($element: ident),+]) => {
@@ -187,6 +269,32 @@ macro_rules! impl_color_sub {
         {
             fn sub_assign(&mut self, c: $component_ty) {
                 $( self.$element -= c.clone(); )+
+            }
+        }
+
+        impl<$component_ty> $crate::num::SaturatingSub<Self> for $self_ty<$component_ty>
+        where
+            T: $crate::num::SaturatingSub<Output=T>
+        {
+            type Output = Self;
+
+            fn saturating_sub(self, other: Self) -> Self {
+                $self_ty {
+                    $( $element: self.$element.saturating_sub(other.$element), )+
+                }
+            }
+        }
+
+        impl<$component_ty> $crate::num::SaturatingSub<$component_ty> for $self_ty<$component_ty>
+        where
+            T: $crate::num::SaturatingSub<Output=T> + Clone
+        {
+            type Output = Self;
+
+            fn saturating_sub(self, c: $component_ty) -> Self::Output {
+                $self_ty {
+                    $( $element: self.$element.saturating_sub(c.clone()), )+
+                }
             }
         }
     };

--- a/palette/src/num.rs
+++ b/palette/src/num.rs
@@ -286,6 +286,26 @@ pub trait MulSub {
     fn mul_sub(self, m: Self, s: Self) -> Self;
 }
 
+/// Saturating addition operation.
+pub trait SaturatingAdd<Rhs = Self> {
+    /// The resulting type.
+    type Output;
+
+    /// Returns the sum of `self` and `other`, but saturates instead of overflowing.
+    #[must_use]
+    fn saturating_add(self, other: Rhs) -> Self::Output;
+}
+
+/// Saturating subtraction operation.
+pub trait SaturatingSub<Rhs = Self> {
+    /// The resulting type.
+    type Output;
+
+    /// Returns the difference of `self` and `other`, but saturates instead of overflowing.
+    #[must_use]
+    fn saturating_sub(self, other: Rhs) -> Self::Output;
+}
+
 macro_rules! impl_uint {
     ($($ty: ident),+) => {
         $(
@@ -407,6 +427,22 @@ macro_rules! impl_uint {
                 #[inline]
                 fn mul_sub(self, m: Self, s: Self) -> Self {
                     (self * m) - s
+                }
+            }
+
+            impl SaturatingAdd for $ty {
+                type Output = $ty;
+                #[inline]
+                fn saturating_add(self, other: Self) -> Self{
+                    <$ty>::saturating_add(self, other)
+                }
+            }
+
+            impl SaturatingSub for $ty {
+                type Output = $ty;
+                #[inline]
+                fn saturating_sub(self, other: Self) -> Self{
+                    <$ty>::saturating_sub(self, other)
                 }
             }
         )+


### PR DESCRIPTION
- Add `crate::num::SaturatingAdd` and `crate::num::SaturatingSub` traits
- Implement them for all unsigned integers
- Implement them for unsigned integer based hues
- Implement them for unsigned integer based colors
- Implement them for unsigned integer based alpha

Example:
```rust
use palette::{
    num::{SaturatingAdd, SaturatingSub},
    Srgb,
};

fn main() {
    let color1 = Srgb::<u8>::new(200, 20, 20);
    let color2 = Srgb::<u8>::new(100, 10, 10);

    let color_sum = color1.saturating_add(color2);
    println!("{:?}", color_sum);

    let color_diff = color2.saturating_sub(30);
    println!("{:?}", color_diff);
}
```
```
Rgb { red: 255, green: 30, blue: 30, standard: PhantomData<palette::encoding::srgb::Srgb> }
Rgb { red: 70, green: 0, blue: 0, standard: PhantomData<palette::encoding::srgb::Srgb> }
```

## Closed Issues

* Closes #322, by implementing the proposed functionality.