### PR TITLE
Add a `Wcag21RelativeContrast` trait and deprecate `RelativeContrast`

### DIFF
--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -23,7 +23,7 @@ use crate::num::{Cbrt, Powi, Sqrt};
 use crate::{
     angle::{FromAngle, RealAngle, SignedAngle},
     bool_mask::{BitOps, BoolMask, HasBoolMask, LazySelect, Select},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::FromColorUnclamped,
     encoding::Srgb,
     hues::RgbHueIter,
@@ -34,8 +34,7 @@ use crate::{
     rgb::{Rgb, RgbSpace, RgbStandard},
     stimulus::{FromStimulus, Stimulus},
     Alpha, Clamp, ClampAssign, FromColor, GetHue, Hsv, IsWithinBounds, Lighten, LightenAssign, Mix,
-    MixAssign, RelativeContrast, RgbHue, Saturate, SaturateAssign, SetHue, ShiftHue,
-    ShiftHueAssign, WithHue, Xyz,
+    MixAssign, RgbHue, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
 };
 
 /// Linear HSL with an alpha component. See the [`Hsla` implementation in
@@ -638,7 +637,8 @@ impl_struct_of_array_traits_hue!(Hsl<S>, RgbHueIter, [saturation, lightness], st
 
 impl_eq_hue!(Hsl<S>, RgbHue, [hue, saturation, lightness]);
 
-impl<S, T> RelativeContrast for Hsl<S, T>
+#[allow(deprecated)]
+impl<S, T> crate::RelativeContrast for Hsl<S, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -652,7 +652,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -23,7 +23,7 @@ use crate::num::{Cbrt, Sqrt};
 use crate::{
     angle::{RealAngle, SignedAngle},
     bool_mask::{HasBoolMask, LazySelect},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::FromColorUnclamped,
     hues::LuvHueIter,
     luv_bounds::LuvBounds,
@@ -33,8 +33,8 @@ use crate::{
     },
     white_point::D65,
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lchuv, Lighten, LightenAssign,
-    LuvHue, Mix, MixAssign, RelativeContrast, Saturate, SaturateAssign, SetHue, ShiftHue,
-    ShiftHueAssign, WithHue, Xyz,
+    LuvHue, Mix, MixAssign, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign, WithHue,
+    Xyz,
 };
 
 /// HSLuv with an alpha component. See the [`Hsluva` implementation in
@@ -363,7 +363,8 @@ impl_struct_of_array_traits_hue!(Hsluv<Wp>, LuvHueIter, [saturation, l], white_p
 
 impl_eq_hue!(Hsluv<Wp>, LuvHue, [hue, saturation, l]);
 
-impl<Wp, T> RelativeContrast for Hsluv<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Hsluv<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -376,7 +377,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -23,7 +23,7 @@ use crate::num::{Cbrt, Powi, Sqrt};
 use crate::{
     angle::{FromAngle, RealAngle, SignedAngle},
     bool_mask::{BitOps, BoolMask, HasBoolMask, LazySelect, Select},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::FromColorUnclamped,
     encoding::Srgb,
     hues::RgbHueIter,
@@ -34,8 +34,8 @@ use crate::{
     rgb::{Rgb, RgbSpace, RgbStandard},
     stimulus::{FromStimulus, Stimulus},
     Alpha, Clamp, ClampAssign, FromColor, GetHue, Hsl, Hwb, IsWithinBounds, Lighten, LightenAssign,
-    Mix, MixAssign, RelativeContrast, RgbHue, Saturate, SaturateAssign, SetHue, ShiftHue,
-    ShiftHueAssign, WithHue, Xyz,
+    Mix, MixAssign, RgbHue, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign, WithHue,
+    Xyz,
 };
 
 /// Linear HSV with an alpha component. See the [`Hsva` implementation in
@@ -644,7 +644,8 @@ impl_struct_of_array_traits_hue!(Hsv<S>, RgbHueIter, [saturation, value], standa
 
 impl_eq_hue!(Hsv<S>, RgbHue, [hue, saturation, value]);
 
-impl<S, T> RelativeContrast for Hsv<S, T>
+#[allow(deprecated)]
+impl<S, T> crate::RelativeContrast for Hsv<S, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -658,7 +659,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -20,7 +20,7 @@ use rand::{
 use crate::{
     angle::{FromAngle, RealAngle, SignedAngle},
     bool_mask::{HasBoolMask, LazySelect, Select},
-    clamp, clamp_min, clamp_min_assign, contrast_ratio,
+    clamp, clamp_min, clamp_min_assign,
     convert::FromColorUnclamped,
     encoding::Srgb,
     hues::RgbHueIter,
@@ -30,7 +30,7 @@ use crate::{
     rgb::{RgbSpace, RgbStandard},
     stimulus::{FromStimulus, Stimulus},
     Alpha, Clamp, ClampAssign, FromColor, GetHue, Hsv, IsWithinBounds, Lighten, LightenAssign, Mix,
-    MixAssign, RelativeContrast, RgbHue, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
+    MixAssign, RgbHue, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
 };
 
 /// Linear HWB with an alpha component. See the [`Hwba` implementation in
@@ -675,7 +675,8 @@ where
     }
 }
 
-impl<S, T> RelativeContrast for Hwb<S, T>
+#[allow(deprecated)]
+impl<S, T> crate::RelativeContrast for Hwb<S, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -689,7 +690,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -22,7 +22,6 @@ use crate::{
     bool_mask::{HasBoolMask, LazySelect},
     clamp, clamp_assign,
     color_difference::{get_ciede2000_difference, Ciede2000, LabColorDiff},
-    contrast_ratio,
     convert::FromColorUnclamped,
     num::{
         self, Abs, Arithmetics, Cbrt, Exp, FromScalarArray, Hypot, IntoScalarArray, IsValidDivisor,
@@ -31,7 +30,7 @@ use crate::{
     stimulus::Stimulus,
     white_point::{WhitePoint, D65},
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, LabHue, Lch, Lighten,
-    LightenAssign, Mix, MixAssign, RelativeContrast, Xyz,
+    LightenAssign, Mix, MixAssign, Xyz,
 };
 
 /// CIE L\*a\*b\* (CIELAB) with an alpha component. See the [`Laba`
@@ -388,7 +387,8 @@ impl_struct_of_array_traits!(Lab<Wp>, [l, a, b], white_point);
 
 impl_eq!(Lab<Wp>, [l, a, b]);
 
-impl<Wp, T> RelativeContrast for Lab<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Lab<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -401,7 +401,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -21,7 +21,6 @@ use crate::{
     bool_mask::{HasBoolMask, LazySelect},
     clamp, clamp_assign, clamp_min, clamp_min_assign,
     color_difference::{get_ciede2000_difference, Ciede2000, LabColorDiff},
-    contrast_ratio,
     convert::{FromColorUnclamped, IntoColorUnclamped},
     hues::LabHueIter,
     num::{
@@ -30,8 +29,8 @@ use crate::{
     },
     white_point::D65,
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lab, LabHue, Lighten,
-    LightenAssign, Mix, MixAssign, RelativeContrast, Saturate, SaturateAssign, SetHue, ShiftHue,
-    ShiftHueAssign, WithHue, Xyz,
+    LightenAssign, Mix, MixAssign, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign,
+    WithHue, Xyz,
 };
 
 /// CIE L\*C\*h° with an alpha component. See the [`Lcha` implementation in
@@ -408,7 +407,8 @@ impl_struct_of_array_traits_hue!(Lch<Wp>, LabHueIter, [l, chroma], white_point);
 
 impl_eq_hue!(Lch<Wp>, LabHue, [l, chroma, hue]);
 
-impl<Wp, T> RelativeContrast for Lch<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Lch<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -421,7 +421,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -22,7 +22,7 @@ use crate::num::Sqrt;
 use crate::{
     angle::{RealAngle, SignedAngle},
     bool_mask::{HasBoolMask, LazySelect},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::FromColorUnclamped,
     hues::LuvHueIter,
     luv_bounds::LuvBounds,
@@ -32,8 +32,8 @@ use crate::{
     },
     white_point::D65,
     Alpha, Clamp, ClampAssign, FromColor, GetHue, Hsluv, IsWithinBounds, Lighten, LightenAssign,
-    Luv, LuvHue, Mix, MixAssign, RelativeContrast, Saturate, SaturateAssign, SetHue, ShiftHue,
-    ShiftHueAssign, WithHue, Xyz,
+    Luv, LuvHue, Mix, MixAssign, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign,
+    WithHue, Xyz,
 };
 
 /// CIE L\*C\*uv h°uv with an alpha component. See the [`Lchuva` implementation in
@@ -364,7 +364,8 @@ impl_struct_of_array_traits_hue!(Lchuv<Wp>, LuvHueIter, [l, chroma], white_point
 
 impl_eq_hue!(Lchuv<Wp>, LuvHue, [l, chroma, hue]);
 
-impl<Wp, T> RelativeContrast for Lchuv<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Lchuv<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -377,7 +378,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -301,6 +301,7 @@ pub use hues::{LabHue, LuvHue, OklabHue, RgbHue};
 pub use color_difference::ColorDifference;
 pub use convert::{FromColor, FromColorMut, FromColorMutGuard, IntoColor, IntoColorMut};
 pub use matrix::Mat3;
+#[allow(deprecated)]
 pub use relative_contrast::{contrast_ratio, RelativeContrast};
 
 //Helper macro for checking ranges and clamping.

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -20,7 +20,7 @@ use crate::{
     angle::RealAngle,
     blend::{PreAlpha, Premultiply},
     bool_mask::{HasBoolMask, LazySelect},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::FromColorUnclamped,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, IsValidDivisor, MinMax, One,
@@ -29,7 +29,7 @@ use crate::{
     stimulus::Stimulus,
     white_point::{WhitePoint, D65},
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lchuv, Lighten, LightenAssign,
-    LuvHue, Mix, MixAssign, RelativeContrast, Xyz,
+    LuvHue, Mix, MixAssign, Xyz,
 };
 
 /// CIE L\*u\*v\* (CIELUV) with an alpha component. See the [`Luva`
@@ -344,7 +344,8 @@ impl_struct_of_array_traits!(Luv<Wp>, [l, u, v], white_point);
 
 impl_eq!(Luv<Wp>, [l, u, v]);
 
-impl<Wp, T> RelativeContrast for Luv<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Luv<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -358,7 +359,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/okhsl/properties.rs
+++ b/palette/src/okhsl/properties.rs
@@ -8,14 +8,13 @@ use crate::{hues::OklabHueIter, white_point::D65};
 use crate::{
     angle::{RealAngle, SignedAngle},
     bool_mask::LazySelect,
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, MinMax, One, PartialCmp, Real, Zero,
     },
     stimulus::Stimulus,
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lighten, LightenAssign, Mix,
-    MixAssign, OklabHue, RelativeContrast, Saturate, SaturateAssign, SetHue, ShiftHue,
-    ShiftHueAssign, WithHue, Xyz,
+    MixAssign, OklabHue, Saturate, SaturateAssign, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
 };
 
 use super::Okhsl;
@@ -139,7 +138,8 @@ impl_struct_of_array_traits_hue!(Okhsl, OklabHueIter, [saturation, lightness]);
 
 impl_eq_hue!(Okhsl, OklabHue, [hue, saturation, lightness]);
 
-impl<T> RelativeContrast for Okhsl<T>
+#[allow(deprecated)]
+impl<T> crate::RelativeContrast for Okhsl<T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -152,6 +152,6 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }

--- a/palette/src/okhwb/properties.rs
+++ b/palette/src/okhwb/properties.rs
@@ -9,9 +9,8 @@ use crate::{
 };
 use crate::{
     bool_mask::{LazySelect, Select},
-    clamp, clamp_min, clamp_min_assign, contrast_ratio, ClampAssign, FromColor, GetHue,
-    IsWithinBounds, Lighten, LightenAssign, Mix, MixAssign, OklabHue, RelativeContrast, SetHue,
-    ShiftHue, ShiftHueAssign, WithHue, Xyz,
+    clamp, clamp_min, clamp_min_assign, ClampAssign, FromColor, GetHue, IsWithinBounds, Lighten,
+    LightenAssign, Mix, MixAssign, OklabHue, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
 };
 use crate::{
     num::{
@@ -226,7 +225,8 @@ impl_array_casts!(Okhwb<T>, [T; 3]);
 impl_simd_array_conversion_hue!(Okhwb, [whiteness, blackness]);
 impl_struct_of_array_traits_hue!(Okhwb, OklabHueIter, [whiteness, blackness]);
 
-impl<T> RelativeContrast for Okhwb<T>
+#[allow(deprecated)]
+impl<T> crate::RelativeContrast for Okhwb<T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -239,7 +239,7 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }
 

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -7,7 +7,7 @@ use crate::{
     angle::RealAngle,
     blend::{PreAlpha, Premultiply},
     bool_mask::LazySelect,
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, IsValidDivisor, MinMax, One,
         PartialCmp, Real, Trigonometry, Zero,
@@ -15,7 +15,7 @@ use crate::{
     stimulus::Stimulus,
     white_point::D65,
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lighten, LightenAssign, Mix,
-    MixAssign, OklabHue, RelativeContrast, Xyz,
+    MixAssign, OklabHue, Xyz,
 };
 
 use super::Oklab;
@@ -77,7 +77,8 @@ impl_struct_of_array_traits!(Oklab, [l, a, b]);
 
 impl_eq!(Oklab, [l, a, b]);
 
-impl<T> RelativeContrast for Oklab<T>
+#[allow(deprecated)]
+impl<T> crate::RelativeContrast for Oklab<T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -90,6 +91,6 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }

--- a/palette/src/oklch/properties.rs
+++ b/palette/src/oklch/properties.rs
@@ -6,14 +6,14 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use crate::{
     angle::{RealAngle, SignedAngle},
     bool_mask::LazySelect,
-    clamp, clamp_assign, clamp_min, clamp_min_assign, contrast_ratio,
+    clamp, clamp_assign, clamp_min, clamp_min_assign,
     hues::OklabHueIter,
     num::{
         self, Arithmetics, FromScalarArray, IntoScalarArray, MinMax, One, PartialCmp, Real, Zero,
     },
     white_point::D65,
     Alpha, Clamp, ClampAssign, FromColor, GetHue, IsWithinBounds, Lighten, LightenAssign, Mix,
-    MixAssign, OklabHue, RelativeContrast, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
+    MixAssign, OklabHue, SetHue, ShiftHue, ShiftHueAssign, WithHue, Xyz,
 };
 
 use super::Oklch;
@@ -121,7 +121,8 @@ impl_struct_of_array_traits_hue!(Oklch, OklabHueIter, [l, chroma]);
 
 impl_eq_hue!(Oklch, OklabHue, [l, chroma, hue]);
 
-impl<T> RelativeContrast for Oklch<T>
+#[allow(deprecated)]
+impl<T> crate::RelativeContrast for Oklch<T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -134,6 +135,6 @@ where
         let xyz1 = Xyz::from_color(self);
         let xyz2 = Xyz::from_color(other);
 
-        contrast_ratio(xyz1.y, xyz2.y)
+        crate::contrast_ratio(xyz1.y, xyz2.y)
     }
 }

--- a/palette/src/relative_contrast.rs
+++ b/palette/src/relative_contrast.rs
@@ -51,6 +51,10 @@ use crate::{
 ///
 /// [Success Criterion 1.4.11 Non-text Contrast (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html)
 #[doc(alias = "wcag")]
+#[deprecated(
+    since = "0.7.2",
+    note = "replaced by `palette::color_difference::Wcag21RelativeContrast`"
+)]
 pub trait RelativeContrast: Sized {
     /// The type of the contrast ratio.
     type Scalar: Real + PartialCmp;
@@ -105,6 +109,10 @@ pub trait RelativeContrast: Sized {
 
 /// Calculate the ratio between two `luma` values.
 #[inline]
+#[deprecated(
+    since = "0.7.2",
+    note = "replaced by `LinLuma::relative_contrast`, via `Wcag21RelativeContrast`"
+)]
 pub fn contrast_ratio<T>(luma1: T, luma2: T) -> T
 where
     T: Real + Arithmetics + PartialCmp,
@@ -117,6 +125,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
     use core::str::FromStr;
 

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -19,7 +19,7 @@ use rand::{
 use crate::{
     blend::{PreAlpha, Premultiply},
     bool_mask::{HasBoolMask, LazySelect},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::{FromColorUnclamped, IntoColorUnclamped},
     encoding::IntoLinear,
     luma::LumaStandard,
@@ -33,7 +33,7 @@ use crate::{
     stimulus::{Stimulus, StimulusColor},
     white_point::{Any, WhitePoint, D65},
     Alpha, Clamp, ClampAssign, IsWithinBounds, Lab, Lighten, LightenAssign, Luma, Luv, Mix,
-    MixAssign, Oklab, RelativeContrast, Yxy,
+    MixAssign, Oklab, Yxy,
 };
 
 /// CIE 1931 XYZ with an alpha component. See the [`Xyza` implementation in
@@ -461,7 +461,8 @@ impl_struct_of_array_traits!(Xyz<Wp>, [x, y, z], white_point);
 
 impl_eq!(Xyz<Wp>, [x, y, z]);
 
-impl<Wp, T> RelativeContrast for Xyz<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Xyz<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -470,7 +471,7 @@ where
 
     #[inline]
     fn get_contrast_ratio(self, other: Self) -> T {
-        contrast_ratio(self.y, other.y)
+        crate::contrast_ratio(self.y, other.y)
     }
 }
 

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -19,7 +19,7 @@ use rand::{
 use crate::{
     blend::{PreAlpha, Premultiply},
     bool_mask::{HasBoolMask, LazySelect},
-    clamp, clamp_assign, contrast_ratio,
+    clamp, clamp_assign,
     convert::{FromColorUnclamped, IntoColorUnclamped},
     encoding::IntoLinear,
     luma::LumaStandard,
@@ -29,8 +29,7 @@ use crate::{
     },
     stimulus::Stimulus,
     white_point::{WhitePoint, D65},
-    Alpha, Clamp, ClampAssign, IsWithinBounds, Lighten, LightenAssign, Luma, Mix, MixAssign,
-    RelativeContrast, Xyz,
+    Alpha, Clamp, ClampAssign, IsWithinBounds, Lighten, LightenAssign, Luma, Mix, MixAssign, Xyz,
 };
 
 /// CIE 1931 Yxy (xyY) with an alpha component. See the [`Yxya` implementation
@@ -347,7 +346,8 @@ impl_struct_of_array_traits!(Yxy<Wp>, [x, y, luma], white_point);
 
 impl_eq!(Yxy<Wp>, [y, x, luma]);
 
-impl<Wp, T> RelativeContrast for Yxy<Wp, T>
+#[allow(deprecated)]
+impl<Wp, T> crate::RelativeContrast for Yxy<Wp, T>
 where
     T: Real + Arithmetics + PartialCmp,
     T::Mask: LazySelect<T>,
@@ -356,7 +356,7 @@ where
 
     #[inline]
     fn get_contrast_ratio(self, other: Self) -> T {
-        contrast_ratio(self.luma, other.luma)
+        crate::contrast_ratio(self.luma, other.luma)
     }
 }
 


### PR DESCRIPTION
Similar to #316, this replaces the unspecific `RelativeContrast` trait with the more specific `Wcag21RelativeContrast` under the `color_difference` module. I did also try to make it a bit more straight forward to implement, but also implemented it for a more limited set of color spaces (essentially sRGB and D65 grayscale). The new trait is almost a drop-in replacement of the old.