### PR TITLE
Add the HyAB color difference metric

### DIFF
--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -297,6 +297,7 @@ impl_mix!(Lab<Wp>);
 impl_lighten!(Lab<Wp> increase {l => [Self::min_l(), Self::max_l()]} other {a, b} phantom: white_point);
 impl_premultiply!(Lab<Wp> {l, a, b} phantom: white_point);
 impl_euclidean_distance!(Lab<Wp> {l, a, b});
+impl_hyab!(Lab<Wp> {lightness: l, chroma1: a, chroma2: b});
 
 impl<Wp, T> GetHue for Lab<Wp, T>
 where

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -305,6 +305,7 @@ impl_mix!(Luv<Wp>);
 impl_lighten!(Luv<Wp> increase {l => [Self::min_l(), Self::max_l()]} other {u, v} phantom: white_point);
 impl_premultiply!(Luv<Wp> {l, u, v} phantom: white_point);
 impl_euclidean_distance!(Luv<Wp> {l, u, v});
+impl_hyab!(Luv<Wp> {lightness: l, chroma1: u, chroma2: v});
 
 impl<Wp, T> GetHue for Luv<Wp, T>
 where

--- a/palette/src/macros/color_difference.rs
+++ b/palette/src/macros/color_difference.rs
@@ -29,3 +29,36 @@ macro_rules! impl_euclidean_distance {
         }
     };
 }
+
+macro_rules! impl_hyab {
+    (
+        $ty: ident
+        {$($components: tt)+}
+        $(where $($where: tt)+)?
+    ) => {
+        // add empty generics brackets
+        impl_hyab!($ty<> {$($components)+} $(where $($where)+)?);
+    };
+    (
+        $ty: ident <$($ty_param: ident),*>
+        {lightness: $lightness:ident, chroma1: $chroma1:ident, chroma2: $chroma2:ident $(,)? }
+        $(where $($where: tt)+)?
+    ) => {
+        impl<$($ty_param,)* T> crate::color_difference::HyAb for $ty<$($ty_param,)* T>
+        where
+            T: self::num::Real + self::num::Abs + self::num::Sqrt + core::ops::Sub<T, Output=T> + core::ops::Add<T, Output=T> + core::ops::Mul<T, Output=T> + Clone,
+            $($($where)+)?
+        {
+            type Scalar = T;
+
+            #[inline]
+            fn hybrid_distance(self, other: Self) -> Self::Scalar {
+                let lightness = self.$lightness - other.$lightness;
+                let chroma1 = self.$chroma1 - other.$chroma1;
+                let chroma2 = self.$chroma2 - other.$chroma2;
+
+                lightness.abs() + (chroma1.clone() * chroma1 + chroma2.clone() * chroma2).sqrt()
+            }
+        }
+    };
+}

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -54,6 +54,11 @@ impl_mix!(Oklab);
 impl_lighten!(Oklab increase {l => [Self::min_l(), Self::max_l()]} other {a, b} where T:  One);
 impl_premultiply!(Oklab { l, a, b });
 impl_euclidean_distance!(Oklab { l, a, b });
+impl_hyab!(Oklab {
+    lightness: l,
+    chroma1: a,
+    chroma2: b
+});
 
 impl<T> GetHue for Oklab<T>
 where


### PR DESCRIPTION
Adds the HyAB color distance metric for `Lab`, `Oklab` and `Luv`. It's primarily only meant for CIELAB, but I figured it may translate well to the other two as well, since they have similar semantics.

I have also added a summary of the available difference metrics in the module description. It's not exactly precise or scientific, but may still be helpful.

## Closed Issues

* Closes #318.
