### PR TITLE
Fix NaN values from `Okhsv` when `saturation` is > 0 and `value` == 0

### DIFF
--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -383,11 +383,17 @@ mod tests {
     #[test]
     fn test_okhsl_to_srgb() {
         let okhsl = Okhsl::new(0.0_f32, 0.5, 0.5);
-        let oklab = Oklab::from_color_unclamped(okhsl);
-        let rgb = Srgb::from_color_unclamped(oklab);
+        let rgb = Srgb::from_color_unclamped(okhsl);
         let rgb8: Rgb<encoding::Srgb, u8> = rgb.into_format();
         let hex_str = format!("{:x}", rgb8);
         assert_eq!(hex_str, "aa5a74");
+    }
+
+    #[test]
+    fn test_okhsl_to_srgb_saturated_black() {
+        let okhsl = Okhsl::new(0.0_f32, 1.0, 0.0);
+        let rgb = Srgb::from_color_unclamped(okhsl);
+        assert_relative_eq!(rgb, Srgb::new(0.0, 0.0, 0.0));
     }
 
     struct_of_arrays_tests!(

--- a/palette/src/okhsv.rs
+++ b/palette/src/okhsv.rs
@@ -408,8 +408,7 @@ mod tests {
         let rgb: Srgb = Rgb::<encoding::Srgb, _>::from_str(red_hex)
             .unwrap()
             .into_format();
-        let oklab = Oklab::from_color_unclamped(rgb);
-        let okhsv = Okhsv::from_color_unclamped(oklab);
+        let okhsv = Okhsv::from_color_unclamped(rgb);
         assert_relative_eq!(okhsv.saturation, 1.0, epsilon = 1e-3);
         assert_relative_eq!(okhsv.value, 1.0, epsilon = 1e-3);
         assert_relative_eq!(
@@ -423,11 +422,17 @@ mod tests {
     #[test]
     fn test_okhsv_to_srgb() {
         let okhsv = Okhsv::new(0.0_f32, 0.5, 0.5);
-        let oklab = Oklab::from_color_unclamped(okhsv);
-        let rgb = Srgb::from_color_unclamped(oklab);
+        let rgb = Srgb::from_color_unclamped(okhsv);
         let rgb8: Rgb<encoding::Srgb, u8> = rgb.into_format();
         let hex_str = format!("{:x}", rgb8);
         assert_eq!(hex_str, "7a4355");
+    }
+
+    #[test]
+    fn test_okhsv_to_srgb_saturated_black() {
+        let okhsv = Okhsv::new(0.0_f32, 1.0, 0.0);
+        let rgb = Srgb::from_color_unclamped(okhsv);
+        assert_relative_eq!(rgb, Srgb::new(0.0, 0.0, 0.0));
     }
 
     #[test]

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -447,16 +447,17 @@ where
     Oklab<T>: IntoColorUnclamped<LinSrgb<T>>,
 {
     fn from_color_unclamped(hsv: Okhsv<T>) -> Self {
+        if hsv.value == T::zero() {
+            // pure black
+            return Self {
+                l: T::zero(),
+                a: T::zero(),
+                b: T::zero(),
+            };
+        }
+
         if hsv.saturation == T::zero() {
             // totally desaturated color -- the triangle is just the 0-chroma-line
-            if hsv.value == T::zero() {
-                // pure black
-                return Self {
-                    l: T::zero(),
-                    a: T::zero(),
-                    b: T::zero(),
-                };
-            }
             let l = toe_inv(hsv.value);
             return Self {
                 l,


### PR DESCRIPTION
Changes the check so it looks for `value == 0`, regardless of saturation.

## Closed Issues

* Fixes #330