### PR TITLE
Add traits for casting collections of colors to and from other data types

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,18 +1,17 @@
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - '**.rs'
 name: Benchmark pull requests
 jobs:
   runBenchmark:
     name: Run benchmark
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
+      - uses: dtolnay/rust-toolchain@stable
       - uses: boa-dev/criterion-compare-action@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,42 +21,37 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          override: true
-          target: thumbv6m-none-eabi
-          profile: minimal
+          targets: thumbv6m-none-eabi
       - name: Minimal check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -v -p palette --no-default-features --features std
+        run: cargo check -v -p palette --no-default-features --features std
       - name: find-crate check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -v -p palette --no-default-features --features "std find-crate"
+        run: cargo check -v -p palette --no-default-features --features "std find-crate"
       - name: Default check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -v --workspace --exclude no_std_test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -v
+        run: cargo check -v --workspace --exclude no_std_test
+      - run: cargo test -v
       - name: Test features
         shell: bash
         working-directory: palette
         run: bash ../scripts/test_features.sh
       - name: "Test #[no_std]"
         if: ${{ runner.os == 'Linux' && matrix.toolchain == 'nightly' }}
-        uses: actions-rs/cargo@v1
+        run: cargo build -v --package no_std_test --features nightly --target thumbv6m-none-eabi
+  miri:
+    name: Miri tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          command: build
-          args: -v --package no_std_test --features nightly --target thumbv6m-none-eabi
+          components: miri
+      - name: Unit tests
+        run: cargo miri test --lib --features "bytemuck" -- -Z unstable-options --report-time
+      - name: Documentation tests
+        run: cargo miri test --doc --features "bytemuck" -- -Z unstable-options --report-time
 
   # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   #
@@ -67,6 +62,7 @@ jobs:
     if: success()
     needs:
       - compile_and_test
+      - miri
     runs-on: ubuntu-latest
     steps:
       - name: Mark the job as a success

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update version and release notes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # We want the full history and all tags
       - name: Increment version for palette_derive

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -10,17 +10,10 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          toolchain: stable
-          override: true
-          profile: minimal
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
       - name: Generate
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --package palette --no-deps
+        run: cargo doc --package palette --no-deps
       - name: Upload
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/palette/README.md
+++ b/palette/README.md
@@ -89,16 +89,16 @@ A longer and more advanced example that shows how to implement the conversion tr
 
 ### Pixels And Buffers
 
-When working with image or pixel buffers, or any color type that can be converted to a slice of components (ex. `&[u8]`), the `cast` module provides functions for turning them into slices of Palette colors without cloning the whole buffer:
+When working with image or pixel buffers, or any color type that can be converted to a slice of components (ex. `&[u8]`), the `cast` module provides traits and functions for turning them into slices of Palette colors without cloning the whole buffer:
 
 ```rust
-use palette::{cast, Srgb};
+use palette::{cast::ComponentsInto, Srgb};
 
 // The input to this function could be data from an image file or
 // maybe a texture in a game.
 fn swap_red_and_blue(my_rgb_image: &mut [u8]) {
     // Convert `my_rgb_image` into `&mut [Srgb<u8>]` without copying.
-    let my_rgb_image: &mut [Srgb<u8>] = cast::from_component_slice_mut(my_rgb_image);
+    let my_rgb_image: &mut [Srgb<u8>] = my_rgb_image.components_into();
 
     for color in my_rgb_image {
         std::mem::swap(&mut color.red, &mut color.blue);
@@ -152,13 +152,13 @@ This image shows the transition from the color to `new_color` in HSL and HSV:
 In addition to the operator traits, the SVG blend and composition functions have also been implemented.
 
 ```rust
-use palette::{blend::Compose, cast, Srgb, WithAlpha};
+use palette::{blend::Compose, cast::ComponentsInto, Srgb, WithAlpha};
 
 // The input to this function could be data from image files.
 fn alpha_blend_images(image1: &mut [u8], image2: &[u8]) {
     // Convert the images into `&mut [Srgb<u8>]` and `&[Srgb<u8>]` without copying.
-    let image1: &mut [Srgb<u8>] = cast::from_component_slice_mut(image1);
-    let image2: &[Srgb<u8>] = cast::from_component_slice(image2);
+    let image1: &mut [Srgb<u8>] = image1.components_into();
+    let image2: &[Srgb<u8>] = image2.components_into();
 
     for (color1, color2) in image1.iter_mut().zip(image2) {
         // Convert the colors to linear floating point format and give them transparency values.

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -26,13 +26,13 @@ fn converting() {
 }
 
 fn pixels_and_buffers() {
-    use palette::{cast, Srgb};
+    use palette::{cast::ComponentsInto, Srgb};
 
     // The input to this function could be data from an image file or
     // maybe a texture in a game.
     fn swap_red_and_blue(my_rgb_image: &mut [u8]) {
         // Convert `my_rgb_image` into `&mut [Srgb<u8>]` without copying.
-        let my_rgb_image: &mut [Srgb<u8>] = cast::from_component_slice_mut(my_rgb_image);
+        let my_rgb_image: &mut [Srgb<u8>] = my_rgb_image.components_into();
 
         for color in my_rgb_image {
             std::mem::swap(&mut color.red, &mut color.blue);
@@ -91,13 +91,13 @@ fn color_operations_1() {
 }
 
 fn color_operations_2() {
-    use palette::{blend::Compose, cast, Srgb, WithAlpha};
+    use palette::{blend::Compose, cast::ComponentsInto, Srgb, WithAlpha};
 
     // The input to this function could be data from image files.
     fn alpha_blend_images(image1: &mut [u8], image2: &[u8]) {
         // Convert the images into `&mut [Srgb<u8>]` and `&[Srgb<u8>]` without copying.
-        let image1: &mut [Srgb<u8>] = cast::from_component_slice_mut(image1);
-        let image2: &[Srgb<u8>] = cast::from_component_slice(image2);
+        let image1: &mut [Srgb<u8>] = image1.components_into();
+        let image2: &[Srgb<u8>] = image2.components_into();
 
         for (color1, color2) in image1.iter_mut().zip(image2) {
             // Convert the colors to linear floating point format and give them transparency values.

--- a/palette/examples/struct_of_arrays.rs
+++ b/palette/examples/struct_of_arrays.rs
@@ -1,11 +1,11 @@
-use palette::{cast, color_difference::EuclideanDistance, IntoColor, Oklab, Srgb};
+use palette::{cast::ComponentsInto, color_difference::EuclideanDistance, IntoColor, Oklab, Srgb};
 
 fn main() {
     let image = image::open("example-data/input/fruits.png")
         .expect("could not open 'example-data/input/fruits.png'")
         .to_rgb8();
 
-    let image = cast::from_component_slice::<Srgb<u8>>(image.as_raw());
+    let image: &[Srgb<u8>] = image.as_raw().components_into();
 
     // Convert and collect the colors in a struct-of-arrays (SoA) format, where
     // each component is a Vec of all the pixels' component values.

--- a/palette/src/cast/array_traits.rs
+++ b/palette/src/cast/array_traits.rs
@@ -1,0 +1,1174 @@
+use core::{convert::Infallible, fmt::Debug};
+
+use crate::ArrayExt;
+
+use super::{
+    from_array_array, from_array_slice, from_array_slice_mut, from_component_array,
+    into_array_array, into_array_slice, into_array_slice_mut, into_component_array,
+    into_component_slice, into_component_slice_mut, try_from_component_slice,
+    try_from_component_slice_mut, ArrayCast, SliceCastError,
+};
+
+#[cfg(feature = "std")]
+use super::{
+    from_array_slice_box, from_array_vec, into_array_slice_box, into_array_vec,
+    into_component_slice_box, into_component_vec, try_from_component_slice_box,
+    try_from_component_vec, BoxedSliceCastError, VecCastError,
+};
+
+/// Trait for trying to cast a collection of colors from a collection of color
+/// components without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Errors
+///
+/// The cast will return an error if the cast fails, such as when the length of
+/// the input is not a multiple of the color's array length.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::TryFromComponents, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let slice: &[_] = &[64, 139, 10, 93, 18, 214];
+/// let slice_mut: &mut [_] = &mut [64, 139, 10, 93, 18, 214];
+/// let vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// assert_eq!(
+///     <[Srgb<u8>; 2]>::try_from_components(array),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)])
+/// );
+///
+/// assert_eq!(
+///     <&[Srgb<u8>]>::try_from_components(slice),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_ref())
+/// );
+///
+/// assert_eq!(
+///     <&mut [Srgb<u8>]>::try_from_components(slice_mut),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_mut())
+/// );
+///
+/// assert_eq!(
+///     Vec::<Srgb<u8>>::try_from_components(vec),
+///     Ok(vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)])
+/// );
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::TryFromComponents, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let mut vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// assert_eq!(
+///     <&[Srgb<u8>]>::try_from_components(&array),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_ref())
+/// );
+///
+/// assert_eq!(
+///     <&mut [Srgb<u8>]>::try_from_components(&mut vec),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_mut())
+/// );
+/// ```
+///
+/// This produces an error:
+///
+/// ```
+/// use palette::{cast::TryFromComponents, Srgb};
+///
+/// let components = &[64, 139, 10, 93, 18]; // Not a multiple of 3
+/// assert!(<&[Srgb<u8>]>::try_from_components(components).is_err());
+/// ```
+pub trait TryFromComponents<C>: Sized {
+    /// The error for when `try_from_components` fails to cast.
+    type Error;
+
+    /// Try to cast a collection of color components into an collection of
+    /// colors of type `Self::Color`.
+    ///
+    /// Return an error if the conversion can't be done, such as when the number
+    /// of items in `components` isn't a multiple of the number of components in
+    /// `Self::Color`.
+    fn try_from_components(components: C) -> Result<Self, Self::Error>;
+}
+
+impl<T, C, const N: usize, const M: usize> TryFromComponents<[T; N]> for [C; M]
+where
+    C: ArrayCast,
+    C::Array: ArrayExt<Item = T>,
+{
+    type Error = Infallible; // We don't provide a `try_*` option for arrays.
+
+    #[inline]
+    fn try_from_components(components: [T; N]) -> Result<Self, Self::Error> {
+        Ok(from_component_array(components))
+    }
+}
+
+macro_rules! impl_try_from_components_slice {
+    ($($owning:ty $(where ($($ty_input:tt)+))?),*) => {
+        $(
+            impl<'a, T, C $(, $($ty_input)+)?> TryFromComponents<&'a $owning> for &'a [C]
+            where
+                T: 'a,
+                C: ArrayCast,
+                C::Array: ArrayExt<Item = T>,
+            {
+                type Error = SliceCastError;
+
+                #[inline]
+                fn try_from_components(components: &'a $owning) -> Result<Self, Self::Error> {
+                    try_from_component_slice(components)
+                }
+            }
+
+            impl<'a, T, C $(, $($ty_input)+)?> TryFromComponents<&'a mut $owning> for &'a mut [C]
+            where
+                T: 'a,
+                C: ArrayCast,
+                C::Array: ArrayExt<Item = T>,
+            {
+                type Error = SliceCastError;
+
+                #[inline]
+                fn try_from_components(components: &'a mut $owning) -> Result<Self, Self::Error> {
+                    try_from_component_slice_mut(components)
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_components_slice!([T], [T; N] where (const N: usize));
+
+#[cfg(feature = "std")]
+impl_try_from_components_slice!(Box<[T]>, Vec<T>);
+
+#[cfg(feature = "std")]
+impl<T, C> TryFromComponents<Box<[T]>> for Box<[C]>
+where
+    C: ArrayCast,
+    C::Array: ArrayExt<Item = T>,
+{
+    type Error = BoxedSliceCastError<T>;
+
+    #[inline]
+    fn try_from_components(components: Box<[T]>) -> Result<Self, Self::Error> {
+        try_from_component_slice_box(components)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, C> TryFromComponents<Vec<T>> for Vec<C>
+where
+    C: ArrayCast,
+    C::Array: ArrayExt<Item = T>,
+{
+    type Error = VecCastError<T>;
+
+    #[inline]
+    fn try_from_components(components: Vec<T>) -> Result<Self, Self::Error> {
+        try_from_component_vec(components)
+    }
+}
+
+/// Trait for casting a collection of colors from a collection of color
+/// components without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Panics
+///
+/// The cast will panic if the cast fails, such as when the length of the input
+/// is not a multiple of the color's array length.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::FromComponents, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let slice: &[_] = &[64, 139, 10, 93, 18, 214];
+/// let slice_mut: &mut [_] = &mut [64, 139, 10, 93, 18, 214];
+/// let vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// assert_eq!(
+///     <[Srgb<u8>; 2]>::from_components(array),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     <&[Srgb<u8>]>::from_components(slice),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     <&mut [Srgb<u8>]>::from_components(slice_mut),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     Vec::<Srgb<u8>>::from_components(vec),
+///     vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::FromComponents, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let mut vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// assert_eq!(
+///     <&[Srgb<u8>]>::from_components(&array),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     <&mut [Srgb<u8>]>::from_components(&mut vec),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+/// ```
+///
+/// This panics:
+///
+/// ```should_panic
+/// use palette::{cast::FromComponents, Srgb};
+///
+/// let components = &[64, 139, 10, 93, 18, 214, 0, 123]; // Not a multiple of 3
+/// <&[Srgb<u8>]>::from_components(components);
+/// ```
+pub trait FromComponents<C> {
+    /// Cast a collection of color components into an collection of colors of
+    /// type `Self::Color`.
+    ///
+    /// ## Panics
+    /// If the conversion can't be done, such as when the number of items in
+    /// `components` isn't a multiple of the number of components in
+    /// `Self::Color`.
+    fn from_components(components: C) -> Self;
+}
+
+impl<T, C> FromComponents<C> for T
+where
+    T: TryFromComponents<C>,
+    T::Error: Debug,
+{
+    #[inline]
+    fn from_components(components: C) -> Self {
+        Self::try_from_components(components).unwrap()
+    }
+}
+
+/// Trait for casting a collection of colors into a collection of color
+/// components without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::IntoComponents, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice: &[_] = &[Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice_mut: &mut [_] = &mut [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!(array.into_components(), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(slice.into_components(), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(slice_mut.into_components(), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(vec.into_components(), vec![64, 139, 10, 93, 18, 214]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::IntoComponents, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let mut vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!((&array).into_components(), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!((&mut vec).into_components(), [64, 139, 10, 93, 18, 214]);
+/// ```
+pub trait IntoComponents<C> {
+    /// Cast this collection of colors into a collection of color components.
+    fn into_components(self) -> C;
+}
+
+impl<T, C, const N: usize, const M: usize> IntoComponents<[T; M]> for [C; N]
+where
+    C: ArrayCast,
+    C::Array: ArrayExt<Item = T>,
+{
+    #[inline]
+    fn into_components(self) -> [T; M] {
+        into_component_array(self)
+    }
+}
+
+macro_rules! impl_into_components_slice {
+    ($($owning:ty $(where ($($ty_input:tt)+))?),*) => {
+        $(
+            impl<'a, T, C $(, $($ty_input)+)?> IntoComponents<&'a [T]> for &'a $owning
+            where
+                T: 'a,
+                C: ArrayCast,
+                C::Array: ArrayExt<Item = T>,
+            {
+                #[inline]
+                fn into_components(self) -> &'a [T]  {
+                    into_component_slice(self)
+                }
+            }
+
+            impl<'a, T, C $(, $($ty_input)+)?> IntoComponents<&'a mut [T]> for &'a mut $owning
+            where
+                T: 'a,
+                C: ArrayCast,
+                C::Array: ArrayExt<Item = T>,
+            {
+                #[inline]
+                fn into_components(self) -> &'a mut [T] {
+                    into_component_slice_mut(self)
+                }
+            }
+        )*
+    };
+}
+
+impl_into_components_slice!([C], [C; N] where (const N: usize));
+
+#[cfg(feature = "std")]
+impl_into_components_slice!(Box<[C]>, Vec<C>);
+
+#[cfg(feature = "std")]
+impl<T, C> IntoComponents<Box<[T]>> for Box<[C]>
+where
+    C: ArrayCast,
+    C::Array: ArrayExt<Item = T>,
+{
+    #[inline]
+    fn into_components(self) -> Box<[T]> {
+        into_component_slice_box(self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, C> IntoComponents<Vec<T>> for Vec<C>
+where
+    C: ArrayCast,
+    C::Array: ArrayExt<Item = T>,
+{
+    #[inline]
+    fn into_components(self) -> Vec<T> {
+        into_component_vec(self)
+    }
+}
+
+/// Trait for casting a collection of colors from a collection of arrays without
+/// copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::FromArrays, Srgb};
+///
+/// let array: [_; 2] = [[64, 139, 10], [93, 18, 214]];
+/// let slice: &[_] = &[[64, 139, 10], [93, 18, 214]];
+/// let slice_mut: &mut [_] = &mut [[64, 139, 10], [93, 18, 214]];
+/// let vec: Vec<_> = vec![[64, 139, 10], [93, 18, 214]];
+///
+/// assert_eq!(
+///     <[Srgb<u8>; 2]>::from_arrays(array),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     <&[Srgb<u8>]>::from_arrays(slice),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     <&mut [Srgb<u8>]>::from_arrays(slice_mut),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     Vec::<Srgb<u8>>::from_arrays(vec),
+///     vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::FromArrays, Srgb};
+///
+/// let array: [_; 2] = [[64, 139, 10], [93, 18, 214]];
+/// let mut vec: Vec<_> = vec![[64, 139, 10], [93, 18, 214]];
+///
+/// assert_eq!(
+///     <&[Srgb<u8>]>::from_arrays(&array),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+///
+/// assert_eq!(
+///     <&mut [Srgb<u8>]>::from_arrays(&mut vec),
+///     [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]
+/// );
+/// ```
+pub trait FromArrays<A> {
+    /// Cast a collection of arrays into an collection of colors of type
+    /// `Self::Color`.
+    fn from_arrays(arrays: A) -> Self;
+}
+
+impl<T, C, const N: usize, const M: usize> FromArrays<[[T; N]; M]> for [C; M]
+where
+    C: ArrayCast<Array = [T; N]>,
+{
+    #[inline]
+    fn from_arrays(arrays: [[T; N]; M]) -> Self {
+        from_array_array(arrays)
+    }
+}
+
+macro_rules! impl_from_arrays_slice {
+    ($($owning:ty $(where ($($ty_input:tt)+))?),*) => {
+        $(
+            impl<'a, T, C, const N: usize $(, $($ty_input)+)?> FromArrays<&'a $owning> for &'a [C]
+            where
+                C: ArrayCast<Array = [T; N]>,
+            {
+                #[inline]
+                fn from_arrays(arrays: &'a $owning) -> Self {
+                    from_array_slice(arrays)
+                }
+            }
+
+            impl<'a, T, C, const N: usize $(, $($ty_input)+)?> FromArrays<&'a mut $owning> for &'a mut [C]
+            where
+                C: ArrayCast<Array = [T; N]>,
+            {
+                #[inline]
+                fn from_arrays(arrays: &'a mut $owning) -> Self {
+                    from_array_slice_mut(arrays)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_arrays_slice!([[T; N]], [[T; N]; M] where (const M: usize));
+
+#[cfg(feature = "std")]
+impl_from_arrays_slice!(Box<[[T; N]]>, Vec<[T; N]>);
+
+#[cfg(feature = "std")]
+impl<T, C, const N: usize> FromArrays<Box<[[T; N]]>> for Box<[C]>
+where
+    C: ArrayCast<Array = [T; N]>,
+{
+    #[inline]
+    fn from_arrays(arrays: Box<[[T; N]]>) -> Self {
+        from_array_slice_box(arrays)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, C, const N: usize> FromArrays<Vec<[T; N]>> for Vec<C>
+where
+    C: ArrayCast<Array = [T; N]>,
+{
+    #[inline]
+    fn from_arrays(arrays: Vec<[T; N]>) -> Self {
+        from_array_vec(arrays)
+    }
+}
+
+/// Trait for casting a collection of colors into a collection of arrays without
+/// copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::IntoArrays, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice: &[_] = &[Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice_mut: &mut [_] = &mut [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!(array.into_arrays(), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(slice.into_arrays(), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(slice_mut.into_arrays(), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(vec.into_arrays(), vec![[64, 139, 10], [93, 18, 214]]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::IntoArrays, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let mut vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!((&array).into_arrays(), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!((&mut vec).into_arrays(), [[64, 139, 10], [93, 18, 214]]);
+/// ```
+pub trait IntoArrays<A> {
+    /// Cast this collection of colors into a collection of arrays.
+    fn into_arrays(self) -> A;
+}
+
+impl<T, C, const N: usize, const M: usize> IntoArrays<[[T; N]; M]> for [C; M]
+where
+    C: ArrayCast<Array = [T; N]>,
+{
+    #[inline]
+    fn into_arrays(self) -> [[T; N]; M] {
+        into_array_array(self)
+    }
+}
+
+macro_rules! impl_into_arrays_slice {
+    ($($owning:ty $(where ($($ty_input:tt)+))?),*) => {
+        $(
+            impl<'a, T, C, const N: usize $(, $($ty_input)+)?> IntoArrays<&'a [[T; N]]> for &'a $owning
+            where
+                C: ArrayCast<Array = [T; N]>,
+            {
+                #[inline]
+                fn into_arrays(self) -> &'a [[T; N]]  {
+                    into_array_slice(self)
+                }
+            }
+
+            impl<'a, T, C, const N: usize $(, $($ty_input)+)?> IntoArrays<&'a mut [[T; N]]> for &'a mut $owning
+            where
+                C: ArrayCast<Array = [T; N]>,
+            {
+                #[inline]
+                fn into_arrays(self) -> &'a mut [[T; N]] {
+                    into_array_slice_mut(self)
+                }
+            }
+        )*
+    };
+}
+
+impl_into_arrays_slice!([C], [C; M] where (const M: usize));
+
+#[cfg(feature = "std")]
+impl_into_arrays_slice!(Box<[C]>, Vec<C>);
+
+#[cfg(feature = "std")]
+impl<T, C, const N: usize> IntoArrays<Box<[[T; N]]>> for Box<[C]>
+where
+    C: ArrayCast<Array = [T; N]>,
+{
+    #[inline]
+    fn into_arrays(self) -> Box<[[T; N]]> {
+        into_array_slice_box(self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, C, const N: usize> IntoArrays<Vec<[T; N]>> for Vec<C>
+where
+    C: ArrayCast<Array = [T; N]>,
+{
+    #[inline]
+    fn into_arrays(self) -> Vec<[T; N]> {
+        into_array_vec(self)
+    }
+}
+
+/// Trait for casting a collection of color components into a collection of
+/// colors without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::ComponentsFrom, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice: &[_] = &[Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice_mut: &mut [_] = &mut [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!(<[_; 6]>::components_from(array), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(<&[_]>::components_from(slice), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(<&mut [_]>::components_from(slice_mut), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(Vec::<_>::components_from(vec), vec![64, 139, 10, 93, 18, 214]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::ComponentsFrom, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let mut vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!(<&[_]>::components_from(&array), [64, 139, 10, 93, 18, 214]);
+/// assert_eq!(<&mut [_]>::components_from(&mut vec), [64, 139, 10, 93, 18, 214]);
+/// ```
+pub trait ComponentsFrom<C> {
+    /// Cast a collection of colors of type `C` into a collection of color
+    /// components.
+    fn components_from(colors: C) -> Self;
+}
+
+impl<T, C> ComponentsFrom<C> for T
+where
+    C: IntoComponents<T>,
+{
+    #[inline]
+    fn components_from(colors: C) -> Self {
+        colors.into_components()
+    }
+}
+
+/// Trait for trying to cast a collection of color components from a collection
+/// of colors without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Errors
+///
+/// The cast will return an error if the cast fails, such as when the length of
+/// the input is not a multiple of the color's array length.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::TryComponentsInto, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let slice: &[_] = &[64, 139, 10, 93, 18, 214];
+/// let slice_mut: &mut [_] = &mut [64, 139, 10, 93, 18, 214];
+/// let vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// assert_eq!(
+///     array.try_components_into(),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)])
+/// );
+///
+/// assert_eq!(
+///     slice.try_components_into(),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_ref())
+/// );
+///
+/// assert_eq!(
+///     slice_mut.try_components_into(),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_mut())
+/// );
+///
+/// assert_eq!(
+///     vec.try_components_into(),
+///     Ok(vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)])
+/// );
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::TryComponentsInto, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let mut vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// assert_eq!(
+///     (&array).try_components_into(),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_ref())
+/// );
+///
+/// assert_eq!(
+///     (&mut vec).try_components_into(),
+///     Ok([Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)].as_mut())
+/// );
+/// ```
+///
+/// This produces an error:
+///
+/// ```
+/// use palette::{cast::TryComponentsInto, Srgb};
+///
+/// let components = &[64, 139, 10, 93, 18]; // Not a multiple of 3
+/// let colors: Result<&[Srgb<u8>], _> = components.try_components_into();
+/// assert!(colors.is_err());
+/// ```
+pub trait TryComponentsInto<C>: Sized {
+    /// The error for when `try_into_colors` fails to cast.
+    type Error;
+
+    /// Try to cast this collection of color components into a collection of
+    /// colors of type `C`.
+    ///
+    /// Return an error if the conversion can't be done, such as when the number
+    /// of items in `self` isn't a multiple of the number of components in `C`.
+    fn try_components_into(self) -> Result<C, Self::Error>;
+}
+
+/// Trait for casting a collection of color components from a collection of
+/// colors without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Panics
+///
+/// The cast will panic if the cast fails, such as when the length of the input
+/// is not a multiple of the color's array length.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::ComponentsInto, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let slice: &[_] = &[64, 139, 10, 93, 18, 214];
+/// let slice_mut: &mut [_] = &mut [64, 139, 10, 93, 18, 214];
+/// let vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// let colors: [Srgb<u8>; 2] = array.components_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: &[Srgb<u8>] = slice.components_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: &mut [Srgb<u8>] = slice_mut.components_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: Vec<Srgb<u8>> = vec.components_into();
+/// assert_eq!(colors, vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::ComponentsInto, Srgb};
+///
+/// let array: [_; 6] = [64, 139, 10, 93, 18, 214];
+/// let mut vec: Vec<_> = vec![64, 139, 10, 93, 18, 214];
+///
+/// let colors: &[Srgb<u8>] = (&array).components_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: &mut [Srgb<u8>] = (&mut vec).components_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+/// ```
+///
+/// This panics:
+///
+/// ```should_panic
+/// use palette::{cast::ComponentsInto, Srgb};
+///
+/// let components = &[64, 139, 10, 93, 18, 214, 0, 123]; // Not a multiple of 3
+/// let colors: &[Srgb<u8>] = components.components_into();
+/// ```
+pub trait ComponentsInto<C> {
+    /// Cast this collection of color components into a collection of colors of
+    /// type `C`.
+    ///
+    /// ## Panics
+    /// If the conversion can't be done, such as when the number of items in
+    /// `self` isn't a multiple of the number of components in `C`.
+    fn components_into(self) -> C;
+}
+
+impl<T, C> ComponentsInto<C> for T
+where
+    T: TryComponentsInto<C>,
+    T::Error: Debug,
+{
+    #[inline]
+    fn components_into(self) -> C {
+        self.try_components_into().unwrap()
+    }
+}
+
+impl<'a, T, C> TryComponentsInto<C> for T
+where
+    C: TryFromComponents<T>,
+{
+    type Error = C::Error;
+
+    #[inline]
+    fn try_components_into(self) -> Result<C, Self::Error> {
+        C::try_from_components(self)
+    }
+}
+
+/// Trait for casting a collection of arrays from a collection of colors without
+/// copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::ArraysFrom, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice: &[_] = &[Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let slice_mut: &mut [_] = &mut [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!(<[_; 2]>::arrays_from(array), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(<&[_]>::arrays_from(slice), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(<&mut [_]>::arrays_from(slice_mut), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(Vec::<_>::arrays_from(vec), vec![[64, 139, 10], [93, 18, 214]]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::ArraysFrom, Srgb};
+///
+/// let array: [_; 2] = [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+/// let mut vec: Vec<_> = vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)];
+///
+/// assert_eq!(<&[_]>::arrays_from(&array), [[64, 139, 10], [93, 18, 214]]);
+/// assert_eq!(<&mut [_]>::arrays_from(&mut vec), [[64, 139, 10], [93, 18, 214]]);
+/// ```
+pub trait ArraysFrom<C> {
+    /// Cast a collection of colors into a collection of arrays.
+    fn arrays_from(colors: C) -> Self;
+}
+
+impl<T, C> ArraysFrom<C> for T
+where
+    C: IntoArrays<T>,
+{
+    #[inline]
+    fn arrays_from(colors: C) -> Self {
+        colors.into_arrays()
+    }
+}
+
+/// Trait for casting a collection of arrays into a collection of colors
+/// without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::ArraysInto, Srgb};
+///
+/// let array: [_; 2] = [[64, 139, 10], [93, 18, 214]];
+/// let slice: &[_] = &[[64, 139, 10], [93, 18, 214]];
+/// let slice_mut: &mut [_] = &mut [[64, 139, 10], [93, 18, 214]];
+/// let vec: Vec<_> = vec![[64, 139, 10], [93, 18, 214]];
+///
+/// let colors: [Srgb<u8>; 2] = array.arrays_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: &[Srgb<u8>] = slice.arrays_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: &mut [Srgb<u8>] = slice_mut.arrays_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: Vec<Srgb<u8>> = vec.arrays_into();
+/// assert_eq!(colors, vec![Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::ArraysInto, Srgb};
+///
+/// let array: [_; 2] = [[64, 139, 10], [93, 18, 214]];
+/// let mut vec: Vec<_> = vec![[64, 139, 10], [93, 18, 214]];
+///
+/// let colors: &[Srgb<u8>] = (&array).arrays_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+///
+/// let colors: &mut [Srgb<u8>] = (&mut vec).arrays_into();
+/// assert_eq!(colors, [Srgb::new(64u8, 139, 10), Srgb::new(93, 18, 214)]);
+/// ```
+pub trait ArraysInto<C> {
+    /// Cast this collection of arrays into a collection of colors of type `C`.
+    fn arrays_into(self) -> C;
+}
+
+impl<T, C> ArraysInto<C> for T
+where
+    C: FromArrays<T>,
+{
+    #[inline]
+    fn arrays_into(self) -> C {
+        C::from_arrays(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Srgb;
+
+    use super::{
+        ArraysFrom, ArraysInto, ComponentsFrom, ComponentsInto, FromArrays, FromComponents,
+        IntoArrays, IntoComponents, TryComponentsInto, TryFromComponents,
+    };
+
+    #[test]
+    fn try_from_components() {
+        let slice: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let slice_mut: &mut [u8] = &mut [1, 2, 3, 4, 5, 6];
+        let mut slice_box: Box<[u8]> = vec![1, 2, 3, 4, 5, 6].into_boxed_slice();
+        let mut vec: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
+        let mut array: [u8; 6] = [1, 2, 3, 4, 5, 6];
+
+        let _ = <&[Srgb<u8>]>::try_from_components(slice).unwrap();
+        let _ = <&[Srgb<u8>]>::try_from_components(&slice_box).unwrap();
+        let _ = <&[Srgb<u8>]>::try_from_components(&vec).unwrap();
+        let _ = <&[Srgb<u8>]>::try_from_components(&array).unwrap();
+
+        let _ = <&mut [Srgb<u8>]>::try_from_components(slice_mut).unwrap();
+        let _ = <&mut [Srgb<u8>]>::try_from_components(&mut slice_box).unwrap();
+        let _ = <&mut [Srgb<u8>]>::try_from_components(&mut vec).unwrap();
+        let _ = <&mut [Srgb<u8>]>::try_from_components(&mut array).unwrap();
+
+        let _ = Box::<[Srgb<u8>]>::try_from_components(slice_box).unwrap();
+        let _ = Vec::<Srgb<u8>>::try_from_components(vec).unwrap();
+        let _ = <[Srgb<u8>; 2]>::try_from_components(array).unwrap();
+    }
+
+    #[test]
+    fn try_components_into() {
+        let slice: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let slice_mut: &mut [u8] = &mut [1, 2, 3, 4, 5, 6];
+        let mut slice_box: Box<[u8]> = vec![1, 2, 3, 4, 5, 6].into_boxed_slice();
+        let mut vec: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
+        let mut array: [u8; 6] = [1, 2, 3, 4, 5, 6];
+
+        let _: &[Srgb<u8>] = slice.try_components_into().unwrap();
+        let _: &[Srgb<u8>] = (&slice_box).try_components_into().unwrap();
+        let _: &[Srgb<u8>] = (&vec).try_components_into().unwrap();
+        let _: &[Srgb<u8>] = (&array).try_components_into().unwrap();
+
+        let _: &mut [Srgb<u8>] = slice_mut.try_components_into().unwrap();
+        let _: &mut [Srgb<u8>] = (&mut slice_box).try_components_into().unwrap();
+        let _: &mut [Srgb<u8>] = (&mut vec).try_components_into().unwrap();
+        let _: &mut [Srgb<u8>] = (&mut array).try_components_into().unwrap();
+
+        let _: Box<[Srgb<u8>]> = slice_box.try_components_into().unwrap();
+        let _: Vec<Srgb<u8>> = vec.try_components_into().unwrap();
+        let _: [Srgb<u8>; 2] = array.try_components_into().unwrap();
+    }
+
+    #[test]
+    fn from_components() {
+        let slice: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let slice_mut: &mut [u8] = &mut [1, 2, 3, 4, 5, 6];
+        let mut slice_box: Box<[u8]> = vec![1, 2, 3, 4, 5, 6].into_boxed_slice();
+        let mut vec: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
+        let mut array: [u8; 6] = [1, 2, 3, 4, 5, 6];
+
+        let _ = <&[Srgb<u8>]>::from_components(slice);
+        let _ = <&[Srgb<u8>]>::from_components(&slice_box);
+        let _ = <&[Srgb<u8>]>::from_components(&vec);
+        let _ = <&[Srgb<u8>]>::from_components(&array);
+
+        let _ = <&mut [Srgb<u8>]>::from_components(slice_mut);
+        let _ = <&mut [Srgb<u8>]>::from_components(&mut slice_box);
+        let _ = <&mut [Srgb<u8>]>::from_components(&mut vec);
+        let _ = <&mut [Srgb<u8>]>::from_components(&mut array);
+
+        let _ = Box::<[Srgb<u8>]>::from_components(slice_box);
+        let _ = Vec::<Srgb<u8>>::from_components(vec);
+        let _ = <[Srgb<u8>; 2]>::from_components(array);
+    }
+
+    #[test]
+    fn components_into() {
+        let slice: &[u8] = &[1, 2, 3, 4, 5, 6];
+        let slice_mut: &mut [u8] = &mut [1, 2, 3, 4, 5, 6];
+        let mut slice_box: Box<[u8]> = vec![1, 2, 3, 4, 5, 6].into_boxed_slice();
+        let mut vec: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
+        let mut array: [u8; 6] = [1, 2, 3, 4, 5, 6];
+
+        let _: &[Srgb<u8>] = slice.components_into();
+        let _: &[Srgb<u8>] = (&slice_box).components_into();
+        let _: &[Srgb<u8>] = (&vec).components_into();
+        let _: &[Srgb<u8>] = (&array).components_into();
+
+        let _: &mut [Srgb<u8>] = slice_mut.components_into();
+        let _: &mut [Srgb<u8>] = (&mut slice_box).components_into();
+        let _: &mut [Srgb<u8>] = (&mut vec).components_into();
+        let _: &mut [Srgb<u8>] = (&mut array).components_into();
+
+        let _: Box<[Srgb<u8>]> = slice_box.components_into();
+        let _: Vec<Srgb<u8>> = vec.components_into();
+        let _: [Srgb<u8>; 2] = array.components_into();
+    }
+
+    #[test]
+    fn into_components() {
+        let slice: &[Srgb<u8>] = &[Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let slice_mut: &mut [Srgb<u8>] = &mut [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut slice_box: Box<[Srgb<u8>]> =
+            vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)].into_boxed_slice();
+        let mut vec: Vec<Srgb<u8>> = vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut array: [Srgb<u8>; 2] = [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+
+        let _: &[u8] = slice.into_components();
+        let _: &[u8] = (&slice_box).into_components();
+        let _: &[u8] = (&vec).into_components();
+        let _: &[u8] = (&array).into_components();
+
+        let _: &mut [u8] = slice_mut.into_components();
+        let _: &mut [u8] = (&mut slice_box).into_components();
+        let _: &mut [u8] = (&mut vec).into_components();
+        let _: &mut [u8] = (&mut array).into_components();
+
+        let _: Box<[u8]> = slice_box.into_components();
+        let _: Vec<u8> = vec.into_components();
+        let _: [u8; 6] = array.into_components();
+    }
+
+    #[test]
+    fn components_from() {
+        let slice: &[Srgb<u8>] = &[Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let slice_mut: &mut [Srgb<u8>] = &mut [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut slice_box: Box<[Srgb<u8>]> =
+            vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)].into_boxed_slice();
+        let mut vec: Vec<Srgb<u8>> = vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut array: [Srgb<u8>; 2] = [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+
+        let _ = <&[u8]>::components_from(slice);
+        let _ = <&[u8]>::components_from(&slice_box);
+        let _ = <&[u8]>::components_from(&vec);
+        let _ = <&[u8]>::components_from(&array);
+
+        let _ = <&mut [u8]>::components_from(slice_mut);
+        let _ = <&mut [u8]>::components_from(&mut slice_box);
+        let _ = <&mut [u8]>::components_from(&mut vec);
+        let _ = <&mut [u8]>::components_from(&mut array);
+
+        let _ = Box::<[u8]>::components_from(slice_box);
+        let _ = Vec::<u8>::components_from(vec);
+        let _ = <[u8; 6]>::components_from(array);
+    }
+
+    #[test]
+    fn from_arrays() {
+        let slice: &[[u8; 3]] = &[[1, 2, 3], [4, 5, 6]];
+        let slice_mut: &mut [[u8; 3]] = &mut [[1, 2, 3], [4, 5, 6]];
+        let mut slice_box: Box<[[u8; 3]]> = vec![[1, 2, 3], [4, 5, 6]].into_boxed_slice();
+        let mut vec: Vec<[u8; 3]> = vec![[1, 2, 3], [4, 5, 6]];
+        let mut array: [[u8; 3]; 2] = [[1, 2, 3], [4, 5, 6]];
+
+        let _ = <&[Srgb<u8>]>::from_arrays(slice);
+        let _ = <&[Srgb<u8>]>::from_arrays(&slice_box);
+        let _ = <&[Srgb<u8>]>::from_arrays(&vec);
+        let _ = <&[Srgb<u8>]>::from_arrays(&array);
+
+        let _ = <&mut [Srgb<u8>]>::from_arrays(slice_mut);
+        let _ = <&mut [Srgb<u8>]>::from_arrays(&mut slice_box);
+        let _ = <&mut [Srgb<u8>]>::from_arrays(&mut vec);
+        let _ = <&mut [Srgb<u8>]>::from_arrays(&mut array);
+
+        let _ = Box::<[Srgb<u8>]>::from_arrays(slice_box);
+        let _ = Vec::<Srgb<u8>>::from_arrays(vec);
+        let _ = <[Srgb<u8>; 2]>::from_arrays(array);
+    }
+
+    #[test]
+    fn arrays_into() {
+        let slice: &[[u8; 3]] = &[[1, 2, 3], [4, 5, 6]];
+        let slice_mut: &mut [[u8; 3]] = &mut [[1, 2, 3], [4, 5, 6]];
+        let mut slice_box: Box<[[u8; 3]]> = vec![[1, 2, 3], [4, 5, 6]].into_boxed_slice();
+        let mut vec: Vec<[u8; 3]> = vec![[1, 2, 3], [4, 5, 6]];
+        let mut array: [[u8; 3]; 2] = [[1, 2, 3], [4, 5, 6]];
+
+        let _: &[Srgb<u8>] = slice.arrays_into();
+        let _: &[Srgb<u8>] = (&slice_box).arrays_into();
+        let _: &[Srgb<u8>] = (&vec).arrays_into();
+        let _: &[Srgb<u8>] = (&array).arrays_into();
+
+        let _: &mut [Srgb<u8>] = slice_mut.arrays_into();
+        let _: &mut [Srgb<u8>] = (&mut slice_box).arrays_into();
+        let _: &mut [Srgb<u8>] = (&mut vec).arrays_into();
+        let _: &mut [Srgb<u8>] = (&mut array).arrays_into();
+
+        let _: Box<[Srgb<u8>]> = slice_box.arrays_into();
+        let _: Vec<Srgb<u8>> = vec.arrays_into();
+        let _: [Srgb<u8>; 2] = array.arrays_into();
+    }
+
+    #[test]
+    fn into_arrays() {
+        let slice: &[Srgb<u8>] = &[Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let slice_mut: &mut [Srgb<u8>] = &mut [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut slice_box: Box<[Srgb<u8>]> =
+            vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)].into_boxed_slice();
+        let mut vec: Vec<Srgb<u8>> = vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut array: [Srgb<u8>; 2] = [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+
+        let _: &[[u8; 3]] = slice.into_arrays();
+        let _: &[[u8; 3]] = (&slice_box).into_arrays();
+        let _: &[[u8; 3]] = (&vec).into_arrays();
+        let _: &[[u8; 3]] = (&array).into_arrays();
+
+        let _: &mut [[u8; 3]] = slice_mut.into_arrays();
+        let _: &mut [[u8; 3]] = (&mut slice_box).into_arrays();
+        let _: &mut [[u8; 3]] = (&mut vec).into_arrays();
+        let _: &mut [[u8; 3]] = (&mut array).into_arrays();
+
+        let _: Box<[[u8; 3]]> = slice_box.into_arrays();
+        let _: Vec<[u8; 3]> = vec.into_arrays();
+        let _: [[u8; 3]; 2] = array.into_arrays();
+    }
+
+    #[test]
+    fn arrays_from() {
+        let slice: &[Srgb<u8>] = &[Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let slice_mut: &mut [Srgb<u8>] = &mut [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut slice_box: Box<[Srgb<u8>]> =
+            vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)].into_boxed_slice();
+        let mut vec: Vec<Srgb<u8>> = vec![Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+        let mut array: [Srgb<u8>; 2] = [Srgb::new(1, 2, 3), Srgb::new(4, 5, 6)];
+
+        let _ = <&[[u8; 3]]>::arrays_from(slice);
+        let _ = <&[[u8; 3]]>::arrays_from(&slice_box);
+        let _ = <&[[u8; 3]]>::arrays_from(&vec);
+        let _ = <&[[u8; 3]]>::arrays_from(&array);
+
+        let _ = <&mut [[u8; 3]]>::arrays_from(slice_mut);
+        let _ = <&mut [[u8; 3]]>::arrays_from(&mut slice_box);
+        let _ = <&mut [[u8; 3]]>::arrays_from(&mut vec);
+        let _ = <&mut [[u8; 3]]>::arrays_from(&mut array);
+
+        let _ = Box::<[[u8; 3]]>::arrays_from(slice_box);
+        let _ = Vec::<[u8; 3]>::arrays_from(vec);
+        let _ = <[[u8; 3]; 2]>::arrays_from(array);
+    }
+}

--- a/palette/src/cast/packed.rs
+++ b/palette/src/cast/packed.rs
@@ -12,10 +12,10 @@ use super::ArrayCast;
 ///
 /// ```
 /// // `PackedArgb` is an alias for `Packed<rgb::channels::Argb, P = u32>`.
-/// use palette::{rgb::PackedArgb, cast};
+/// use palette::{rgb::PackedArgb, cast::UintsInto};
 ///
 /// let raw = &[0x7F0080u32, 0x60BBCC];
-/// let colors = cast::from_uint_slice::<PackedArgb>(raw);
+/// let colors: &[PackedArgb] = raw.uints_into();
 ///
 /// assert_eq!(colors.len(), 2);
 /// assert_eq!(colors[0].color, 0x7F0080);

--- a/palette/src/cast/uint.rs
+++ b/palette/src/cast/uint.rs
@@ -193,6 +193,56 @@ where
     unsafe { &mut *value.cast::<T>() }
 }
 
+/// Cast from an array of colors to an array of unsigned integers.
+///
+/// ```
+/// use palette::{cast, rgb::PackedArgb, Srgba};
+///
+/// let colors: [PackedArgb; 2] = [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// assert_eq!(cast::into_uint_array(colors), [0xFF17C64C, 0xFF5D12D6])
+/// ```
+#[inline]
+pub fn into_uint_array<T, const N: usize>(values: [T; N]) -> [T::Uint; N]
+where
+    T: UintCast,
+{
+    assert_eq!(core::mem::size_of::<T::Uint>(), core::mem::size_of::<T>());
+    assert_eq!(core::mem::align_of::<T::Uint>(), core::mem::align_of::<T>());
+
+    // Safety: The requirements of implementing `UintCast`, as well as the size
+    // and alignment asserts, ensures transmuting `T` into `T::Uint` is safe.
+    // The length is the same because the size is the same.
+    unsafe { transmute_copy(&ManuallyDrop::new(values)) }
+}
+
+/// Cast from an array of unsigned integers to an array of colors.
+///
+/// ```
+/// use palette::{cast, rgb::PackedArgb, Srgba};
+///
+/// let colors: [PackedArgb; 2] = [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// assert_eq!(cast::from_uint_array::<PackedArgb, 2>([0xFF17C64C, 0xFF5D12D6]), colors)
+/// ```
+#[inline]
+pub fn from_uint_array<T, const N: usize>(values: [T::Uint; N]) -> [T; N]
+where
+    T: UintCast,
+{
+    assert_eq!(core::mem::size_of::<T::Uint>(), core::mem::size_of::<T>());
+    assert_eq!(core::mem::align_of::<T::Uint>(), core::mem::align_of::<T>());
+
+    // Safety: The requirements of implementing `UintCast`, as well as the size
+    // and alignment asserts, ensures transmuting `T::Uint` into `T` is safe.
+    // The length is the same because the size is the same.
+    unsafe { transmute_copy(&ManuallyDrop::new(values)) }
+}
+
 /// Cast from a slice of colors to a slice of unsigned integers.
 ///
 /// ```

--- a/palette/src/cast/uint_traits.rs
+++ b/palette/src/cast/uint_traits.rs
@@ -1,0 +1,516 @@
+use super::{
+    from_uint_array, from_uint_slice, from_uint_slice_mut, into_uint_array, into_uint_slice,
+    into_uint_slice_mut, UintCast,
+};
+
+#[cfg(feature = "std")]
+use super::{from_uint_slice_box, from_uint_vec, into_uint_slice_box, into_uint_vec};
+
+/// Trait for casting a collection of colors from a collection of unsigned
+/// integers without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::FromUints, rgb::PackedArgb, Srgba};
+///
+/// let array: [_; 2] = [0xFF17C64C, 0xFF5D12D6];
+/// let slice: &[_] = &[0xFF17C64C, 0xFF5D12D6];
+/// let slice_mut: &mut [_] = &mut [0xFF17C64C, 0xFF5D12D6];
+/// let vec: Vec<_> = vec![0xFF17C64C, 0xFF5D12D6];
+///
+/// assert_eq!(
+///     <[PackedArgb; 2]>::from_uints(array),
+///     [
+///         Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///         Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+///     ]
+/// );
+///
+/// assert_eq!(
+///     <&[PackedArgb]>::from_uints(slice),
+///     [
+///         Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///         Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+///     ]
+/// );
+///
+/// assert_eq!(
+///     <&mut [PackedArgb]>::from_uints(slice_mut),
+///     [
+///         Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///         Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+///     ]
+/// );
+///
+/// assert_eq!(
+///     Vec::<PackedArgb>::from_uints(vec),
+///     vec![
+///         Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///         Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+///     ]
+/// );
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::FromUints, rgb::PackedArgb, Srgba};
+///
+/// let array: [_; 2] = [0xFF17C64C, 0xFF5D12D6];
+/// let mut vec: Vec<_> = vec![0xFF17C64C, 0xFF5D12D6];
+///
+/// assert_eq!(
+///     <&[PackedArgb]>::from_uints(&array),
+///     [
+///         Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///         Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+///     ]
+/// );
+///
+/// assert_eq!(
+///     <&mut [PackedArgb]>::from_uints(&mut vec),
+///     [
+///         Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///         Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+///     ]
+/// );
+/// ```
+pub trait FromUints<U> {
+    /// Cast a collection of unsigned integers into an collection of colors.
+    fn from_uints(uints: U) -> Self;
+}
+
+impl<C, const N: usize> FromUints<[C::Uint; N]> for [C; N]
+where
+    C: UintCast,
+{
+    #[inline]
+    fn from_uints(uints: [C::Uint; N]) -> Self {
+        from_uint_array(uints)
+    }
+}
+
+macro_rules! impl_from_uints_slice {
+    ($($owning:ty $(where ($($ty_input:tt)+))?),*) => {
+        $(
+            impl<'a, C $(, $($ty_input)+)?> FromUints<&'a $owning> for &'a [C]
+            where
+                C: UintCast,
+            {
+                #[inline]
+                fn from_uints(uints: &'a $owning) -> Self {
+                    from_uint_slice(uints)
+                }
+            }
+
+            impl<'a, C $(, $($ty_input)+)?> FromUints<&'a mut $owning> for &'a mut [C]
+            where
+                C: UintCast,
+            {
+                #[inline]
+                fn from_uints(uints: &'a mut $owning) -> Self {
+                    from_uint_slice_mut(uints)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_uints_slice!([C::Uint], [C::Uint; N] where (const N: usize));
+
+#[cfg(feature = "std")]
+impl_from_uints_slice!(Box<[C::Uint]>, Vec<C::Uint>);
+
+#[cfg(feature = "std")]
+impl<C> FromUints<Box<[C::Uint]>> for Box<[C]>
+where
+    C: UintCast,
+{
+    #[inline]
+    fn from_uints(uints: Box<[C::Uint]>) -> Self {
+        from_uint_slice_box(uints)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<C> FromUints<Vec<C::Uint>> for Vec<C>
+where
+    C: UintCast,
+{
+    #[inline]
+    fn from_uints(uints: Vec<C::Uint>) -> Self {
+        from_uint_vec(uints)
+    }
+}
+
+/// Trait for casting a collection of colors into a collection of unsigned
+/// integers without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::IntoUints, rgb::PackedArgb, Srgba};
+///
+/// let array: [PackedArgb; 2] = [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let slice: &[PackedArgb] = &[
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let slice_mut: &mut [PackedArgb] = &mut [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let vec: Vec<PackedArgb> = vec![
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+///
+/// assert_eq!(array.into_uints(), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(slice.into_uints(), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(slice_mut.into_uints(), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(vec.into_uints(), vec![0xFF17C64C, 0xFF5D12D6]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::IntoUints, rgb::PackedArgb, Srgba};
+///
+/// let array: [PackedArgb; 2] = [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let mut vec: Vec<PackedArgb> = vec![
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+///
+/// assert_eq!((&array).into_uints(), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!((&mut vec).into_uints(), [0xFF17C64C, 0xFF5D12D6]);
+/// ```
+pub trait IntoUints<U> {
+    /// Cast this collection of colors into a collection of unsigned integers.
+    fn into_uints(self) -> U;
+}
+
+impl<C, const N: usize> IntoUints<[C::Uint; N]> for [C; N]
+where
+    C: UintCast,
+{
+    #[inline]
+    fn into_uints(self) -> [C::Uint; N] {
+        into_uint_array(self)
+    }
+}
+
+macro_rules! impl_into_uints_slice {
+    ($($owning:ty $(where ($($ty_input:tt)+))?),*) => {
+        $(
+            impl<'a, C $(, $($ty_input)+)?> IntoUints<&'a [C::Uint]> for &'a $owning
+            where
+                C: UintCast,
+            {
+                #[inline]
+                fn into_uints(self) -> &'a [C::Uint]  {
+                    into_uint_slice(self)
+                }
+            }
+
+            impl<'a, C $(, $($ty_input)+)?> IntoUints<&'a mut [C::Uint]> for &'a mut $owning
+            where
+                C: UintCast,
+            {
+                #[inline]
+                fn into_uints(self) -> &'a mut [C::Uint] {
+                    into_uint_slice_mut(self)
+                }
+            }
+        )*
+    };
+}
+
+impl_into_uints_slice!([C], [C; M] where (const M: usize));
+
+#[cfg(feature = "std")]
+impl_into_uints_slice!(Box<[C]>, Vec<C>);
+
+#[cfg(feature = "std")]
+impl<C> IntoUints<Box<[C::Uint]>> for Box<[C]>
+where
+    C: UintCast,
+{
+    #[inline]
+    fn into_uints(self) -> Box<[C::Uint]> {
+        into_uint_slice_box(self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<C> IntoUints<Vec<C::Uint>> for Vec<C>
+where
+    C: UintCast,
+{
+    #[inline]
+    fn into_uints(self) -> Vec<C::Uint> {
+        into_uint_vec(self)
+    }
+}
+
+/// Trait for casting a collection of unsigned integers from a collection of
+/// colors without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::UintsFrom, rgb::PackedArgb, Srgba};
+///
+/// let array: [PackedArgb; 2] = [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let slice: &[PackedArgb] = &[
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let slice_mut: &mut [PackedArgb] = &mut [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let vec: Vec<PackedArgb> = vec![
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+///
+/// assert_eq!(<[_; 2]>::uints_from(array), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(<&[_]>::uints_from(slice), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(<&mut [_]>::uints_from(slice_mut), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(Vec::<_>::uints_from(vec), vec![0xFF17C64C, 0xFF5D12D6]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::UintsFrom, rgb::PackedArgb, Srgba};
+///
+/// let array: [PackedArgb; 2] = [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+/// let mut vec: Vec<PackedArgb> = vec![
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ];
+///
+/// assert_eq!(<&[_]>::uints_from(&array), [0xFF17C64C, 0xFF5D12D6]);
+/// assert_eq!(<&mut [_]>::uints_from(&mut vec), [0xFF17C64C, 0xFF5D12D6]);
+/// ```
+pub trait UintsFrom<C> {
+    /// Cast a collection of colors into a collection of unsigned integers.
+    fn uints_from(colors: C) -> Self;
+}
+
+impl<C, U> UintsFrom<C> for U
+where
+    C: IntoUints<U>,
+{
+    #[inline]
+    fn uints_from(colors: C) -> Self {
+        colors.into_uints()
+    }
+}
+
+/// Trait for casting a collection of unsigned integers into a collection of
+/// colors without copying.
+///
+/// This trait is meant as a more convenient alternative to the free functions
+/// in [`cast`][crate::cast], to allow method chaining among other things.
+///
+/// ## Examples
+///
+/// ```
+/// use palette::{cast::UintsInto, rgb::PackedArgb, Srgba};
+///
+/// let array: [_; 2] = [0xFF17C64C, 0xFF5D12D6];
+/// let slice: &[_] = &[0xFF17C64C, 0xFF5D12D6];
+/// let slice_mut: &mut [_] = &mut [0xFF17C64C, 0xFF5D12D6];
+/// let vec: Vec<_> = vec![0xFF17C64C, 0xFF5D12D6];
+///
+/// let colors: [PackedArgb; 2] = array.uints_into();
+/// assert_eq!(colors, [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ]);
+///
+/// let colors: &[PackedArgb] = slice.uints_into();
+/// assert_eq!(colors, [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ]);
+///
+/// let colors: &mut [PackedArgb] = slice_mut.uints_into();
+/// assert_eq!(colors, [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ]);
+///
+/// let colors: Vec<PackedArgb> = vec.uints_into();
+/// assert_eq!(colors, vec![
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ]);
+/// ```
+///
+/// Owning types can be cast as slices, too:
+///
+/// ```
+/// use palette::{cast::UintsInto, rgb::PackedArgb, Srgba};
+///
+/// let array: [_; 2] = [0xFF17C64C, 0xFF5D12D6];
+/// let mut vec: Vec<_> = vec![0xFF17C64C, 0xFF5D12D6];
+///
+/// let colors: &[PackedArgb] = (&array).uints_into();
+/// assert_eq!(colors, [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ]);
+///
+/// let colors: &mut [PackedArgb] = (&mut vec).uints_into();
+/// assert_eq!(colors, [
+///     Srgba::new(0x17, 0xC6, 0x4C, 0xFF).into(),
+///     Srgba::new(0x5D, 0x12, 0xD6, 0xFF).into()
+/// ]);
+/// ```
+pub trait UintsInto<C> {
+    /// Cast this collection of unsigned integers into a collection of colors.
+    fn uints_into(self) -> C;
+}
+
+impl<C, U> UintsInto<C> for U
+where
+    C: FromUints<U>,
+{
+    #[inline]
+    fn uints_into(self) -> C {
+        C::from_uints(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{rgb::PackedRgba, Srgba};
+
+    use super::{FromUints, IntoUints, UintsFrom, UintsInto};
+
+    #[test]
+    fn from_uints() {
+        let slice: &[u32] = &[0x01020304, 0x05060708];
+        let slice_mut: &mut [u32] = &mut [0x01020304, 0x05060708];
+        let mut slice_box: Box<[u32]> = vec![0x01020304, 0x05060708].into_boxed_slice();
+        let mut vec: Vec<u32> = vec![0x01020304, 0x05060708];
+        let mut array: [u32; 2] = [0x01020304, 0x05060708];
+
+        let _ = <&[PackedRgba]>::from_uints(slice);
+        let _ = <&[PackedRgba]>::from_uints(&slice_box);
+        let _ = <&[PackedRgba]>::from_uints(&vec);
+        let _ = <&[PackedRgba]>::from_uints(&array);
+
+        let _ = <&mut [PackedRgba]>::from_uints(slice_mut);
+        let _ = <&mut [PackedRgba]>::from_uints(&mut slice_box);
+        let _ = <&mut [PackedRgba]>::from_uints(&mut vec);
+        let _ = <&mut [PackedRgba]>::from_uints(&mut array);
+
+        let _ = Box::<[PackedRgba]>::from_uints(slice_box);
+        let _ = Vec::<PackedRgba>::from_uints(vec);
+        let _ = <[PackedRgba; 2]>::from_uints(array);
+    }
+
+    #[test]
+    fn uints_into() {
+        let slice: &[u32] = &[0x01020304, 0x05060708];
+        let slice_mut: &mut [u32] = &mut [0x01020304, 0x05060708];
+        let mut slice_box: Box<[u32]> = vec![0x01020304, 0x05060708].into_boxed_slice();
+        let mut vec: Vec<u32> = vec![0x01020304, 0x05060708];
+        let mut array: [u32; 2] = [0x01020304, 0x05060708];
+
+        let _: &[PackedRgba] = slice.uints_into();
+        let _: &[PackedRgba] = (&slice_box).uints_into();
+        let _: &[PackedRgba] = (&vec).uints_into();
+        let _: &[PackedRgba] = (&array).uints_into();
+
+        let _: &mut [PackedRgba] = slice_mut.uints_into();
+        let _: &mut [PackedRgba] = (&mut slice_box).uints_into();
+        let _: &mut [PackedRgba] = (&mut vec).uints_into();
+        let _: &mut [PackedRgba] = (&mut array).uints_into();
+
+        let _: Box<[PackedRgba]> = slice_box.uints_into();
+        let _: Vec<PackedRgba> = vec.uints_into();
+        let _: [PackedRgba; 2] = array.uints_into();
+    }
+
+    #[test]
+    fn into_uints() {
+        let slice: &[PackedRgba] = &[Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+        let slice_mut: &mut [PackedRgba] =
+            &mut [Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+        let mut slice_box: Box<[PackedRgba]> =
+            vec![Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()].into_boxed_slice();
+        let mut vec: Vec<PackedRgba> =
+            vec![Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+        let mut array: [PackedRgba; 2] =
+            [Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+
+        let _: &[u32] = slice.into_uints();
+        let _: &[u32] = (&slice_box).into_uints();
+        let _: &[u32] = (&vec).into_uints();
+        let _: &[u32] = (&array).into_uints();
+
+        let _: &mut [u32] = slice_mut.into_uints();
+        let _: &mut [u32] = (&mut slice_box).into_uints();
+        let _: &mut [u32] = (&mut vec).into_uints();
+        let _: &mut [u32] = (&mut array).into_uints();
+
+        let _: Box<[u32]> = slice_box.into_uints();
+        let _: Vec<u32> = vec.into_uints();
+        let _: [u32; 2] = array.into_uints();
+    }
+
+    #[test]
+    fn uints_from() {
+        let slice: &[PackedRgba] = &[Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+        let slice_mut: &mut [PackedRgba] =
+            &mut [Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+        let mut slice_box: Box<[PackedRgba]> =
+            vec![Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()].into_boxed_slice();
+        let mut vec: Vec<PackedRgba> =
+            vec![Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+        let mut array: [PackedRgba; 2] =
+            [Srgba::new(1, 2, 3, 4).into(), Srgba::new(5, 6, 7, 8).into()];
+
+        let _ = <&[u32]>::uints_from(slice);
+        let _ = <&[u32]>::uints_from(&slice_box);
+        let _ = <&[u32]>::uints_from(&vec);
+        let _ = <&[u32]>::uints_from(&array);
+
+        let _ = <&mut [u32]>::uints_from(slice_mut);
+        let _ = <&mut [u32]>::uints_from(&mut slice_box);
+        let _ = <&mut [u32]>::uints_from(&mut vec);
+        let _ = <&mut [u32]>::uints_from(&mut array);
+
+        let _ = Box::<[u32]>::uints_from(slice_box);
+        let _ = Vec::<u32>::uints_from(vec);
+        let _ = <[u32; 2]>::uints_from(array);
+    }
+}

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -138,7 +138,7 @@
 //! #[macro_use]
 //! extern crate approx;
 //!
-//! use palette::cast::{self, ArrayCast};
+//! use palette::cast::{ComponentsInto, ArrayCast};
 //! use palette::rgb::{Rgb, RgbSpace, RgbStandard};
 //! use palette::encoding::Linear;
 //! use palette::white_point::D65;
@@ -199,8 +199,8 @@
 //!         0.5,
 //!         0.25,
 //!     ];
-//!     let hsv: Hsv<_, f64> = cast::from_component_slice::<Bgr<_>>(&buffer)[1]
-//!         .into_color();
+//!     let buffer: &[Bgr<_>] = (&buffer).components_into();
+//!     let hsv: Hsv<_, f64> = buffer[1].into_color();
 //!
 //!     assert_relative_eq!(hsv, Hsv::new(90.0, 1.0, 0.5));
 //! }

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -490,6 +490,7 @@ mod test {
 
     test_convert_into_from_xyz!(Hsluv);
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn lchuv_round_trip() {
         for hue in (0..=20).map(|x| x as f64 * 18.0) {

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -122,12 +122,12 @@
 //!
 //! ```rust
 //! use image::RgbImage;
-//! use palette::{Srgb, Oklab, cast, Lighten, IntoColor, FromColor};
+//! use palette::{Srgb, Oklab, cast::FromComponents, Lighten, IntoColor, FromColor};
 //!
 //! fn lighten(image: &mut RgbImage, amount: f32) {
 //!     // RgbImage can be dereferenced as [u8], allowing us to cast it as a
 //!     // component slice to sRGB with u8 components.
-//!     for pixel in cast::from_component_slice_mut::<Srgb<u8>>(image) {
+//!     for pixel in <&mut [Srgb<u8>]>::from_components(&mut **image) {
 //!         // Converting to linear sRGB with f32 components, and then to Oklab.
 //!         let color: Oklab = pixel.into_linear::<f32>().into_color();
 //!
@@ -186,12 +186,12 @@
 //! to Palette colors:
 //!
 //! ```rust
-//! # let mut image_buffer: Vec<u8> = vec![];
-//! use palette::{Srgb, cast};
+//! # let mut image_buffer: &mut Vec<u8> = &mut vec![];
+//! use palette::{Srgb, cast::ComponentsInto};
 //!
 //! // This works for any color type (even non-RGB) that can have the
 //! // buffer element type as component.
-//! let color_buffer: &mut [Srgb<u8>] = cast::from_component_slice_mut(&mut image_buffer);
+//! let color_buffer: &mut [Srgb<u8>] = image_buffer.components_into();
 //! ```
 //!
 //! * If you are getting your colors from the GPU, in a game or other graphical

--- a/palette/src/ok_utils.rs
+++ b/palette/src/ok_utils.rs
@@ -494,6 +494,7 @@ mod tests {
     use crate::{encoding, Oklab, OklabHue, Srgb};
     use core::str::FromStr;
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_roundtrip_toe_is_original() {
         let n = 500;
@@ -518,6 +519,7 @@ mod tests {
         assert!(relative_eq!(toe(grey50oklab.l), 0.5, epsilon = 1e-3));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn print_min_max_srgb_chroma_of_all_hues() {
         struct HueLc<T: Real> {

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -251,6 +251,7 @@ mod tests {
 
     test_convert_into_from_xyz!(Okhsl);
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_roundtrip_okhsl_oklab_is_original() {
         let colors = [

--- a/palette/src/okhsv.rs
+++ b/palette/src/okhsv.rs
@@ -302,6 +302,7 @@ mod tests {
 
     test_convert_into_from_xyz!(Okhsv);
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_roundtrip_okhsv_oklab_is_original() {
         let colors = [

--- a/palette/src/okhwb.rs
+++ b/palette/src/okhwb.rs
@@ -180,6 +180,7 @@ mod tests {
 
     test_convert_into_from_xyz!(Okhwb);
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_roundtrip_okhwb_oklab_is_original() {
         let colors = [


### PR DESCRIPTION
These traits are alternatives to the free functions in `cast`. The idea is to have less "type information" in the naming and only focus on the high level transform. In essence what `From` and `Into` also does. For example, with these changes:

```rust
let raw = &[0xFF7F0080u32, 0xFF60BBCC];

// Before
use palette::{rgb::PackedArgb, cast};
let colors = cast::from_uint_slice::<PackedArgb>(raw);

// After
use palette::{rgb::PackedArgb, cast::UintsInto};
let colors: &[PackedArgb] = raw.uints_into();
``` 

Casting from owned to slice is limited to a fixed set of owning types, since it's hard to cover everything that resembles a slice. Arrays and slices don't implement `Deref<Target=[T]>`, for example, while `AsRef<[T]>` doesn't work for the `Self` type...

In addition to that, I also upgraded some actions in the workflows and added Miri checks to CI. It's good to keep an eye on those transmutes and pointer casts and even better to do it automatically. I have only been running it manually so far.