### PR TITLE
Implements Rgba::from_str()

### DIFF
--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -946,6 +946,14 @@ impl From<ParseIntError> for FromHexError {
     }
 }
 
+impl From<&'static str> for FromHexError {
+    fn from(err: &'static str) -> FromHexError {
+        match err {
+            err if err.contains("rgba") => FromHexError::RgbaHexFormatError(err),
+            _ => FromHexError::HexFormatError(err),
+        }
+    }
+}
 impl core::fmt::Display for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &*self {

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -948,12 +948,10 @@ impl From<ParseIntError> for FromHexError {
 
 impl From<&'static str> for FromHexError {
     fn from(err: &'static str) -> FromHexError {
-        match err {
-            err if err.contains("rgba") => FromHexError::RgbaHexFormatError(err),
-            _ => FromHexError::HexFormatError(err),
-        }
+        FromHexError::HexFormatError(err)
     }
 }
+
 impl core::fmt::Display for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &*self {


### PR DESCRIPTION
This change implements the from_str() trait for the Rgba type, adding support for parsing a RGBA hex string with the format `#rrggbbaa`.

No related issue, no breaking changes.