### PR TITLE
Prevent dev dependencies from breaking tests and examples

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -80,13 +80,14 @@ lazy_static = "1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-ron = "0.8.0"
+ron = "=0.8.0" # Pinned due to MSRV mismatch
 enterpolation = "0.2.0"
 scad = "1.2.2" # For regression testing #283
 
 [dev-dependencies.clap]
-version = "3.2.23"
+version = "3.2.25"
 default-features = false
+features = ["std"] # Required since 3.2.25
 
 [dev-dependencies.criterion]
 version = "0.4.0"


### PR DESCRIPTION
Make it so examples build and CI can run with a couple of temporary fixes.

 * Pins `ron`, since they bumped the MSRV in 0.8.1.
 * Enables the `srd` feature for `clap`, since it's required in 3.2.25.

Fixes #348 
