### PR TITLE
Fix potential NaN from Okhsl when the input is white or black

### DIFF
--- a/palette/src/ok_utils.rs
+++ b/palette/src/ok_utils.rs
@@ -141,6 +141,8 @@ where
         + PartialOrd,
     Oklab<T>: IntoColorUnclamped<LinSrgb<T>>,
 {
+    // Corresponds to `get_Cs` in the reference implementation. Assumes that
+    // `lightness != 1.0` and `lightness != 0.0`.
     pub fn from_normalized(lightness: T, a_: T, b_: T) -> Self {
         let cusp = LC::find_cusp(a_.clone(), b_.clone());
 


### PR DESCRIPTION
This turned out to be an error in the reference implementation as well, as I understand it. [This line](https://github.com/bottosson/bottosson.github.io/blob/master/misc/colorpicker/colorconversion.js#L446) in the `get_Cs` function produces NaN when the lightness is 1.0 or 0.0, by dividing 0.0 by 0.0:

```
let k = C_max/Math.min((L*ST_max[0]), (1-L)*ST_max[1]);
```

The reference seem to be missing the necessary safeguards for this. I looked around for other implementations to see if they had the same issue, but didn't find anything so far. Regardless, it breaks down if it gets an `Oklab` value with lightness 1 or 0. Some inaccuracies or rounding made the chroma != 0.0, which bypassed the already added check for that and let the NaNs out.

## Closed Issues

* Fixes #368