### PR TITLE
Fix typo about max range of u8

### DIFF
--- a/palette/src/stimulus.rs
+++ b/palette/src/stimulus.rs
@@ -22,7 +22,7 @@ use crate::{
 ///    the application. For example in 3D rendering, where high values represent
 ///    intense light.
 ///  * Unsigned integer values (`u8`, `u16`, `u32`, etc.) have a range from `0`
-///    to their largest representable value. For example `0u8` to `155u8` or
+///    to their largest representable value. For example `0u8` to `255u8` or
 ///    `0u16` to `65535u16`.
 ///  * Real values (`f32`, `f64`, fixed point types, etc.) have a range from
 ///    `0.0` to `1.0`.


### PR DESCRIPTION
<!-- Describe your changes as well as possible. What has changed and why? Someone who hasn't followed previous discussions should be able to understand why this change was made and/or be able to find out why. -->

- https://docs.rs/palette/0.7.3/palette/stimulus/trait.Stimulus.html lists

> Unsigned integer values (`u8`, `u16`, `u32`, etc.) have a range from `0` to their largest representable value. For example `0u8` to `155u8` [...]

However, the largest value of `u8` is not `155`, it's `255`. Chances are it's just been a typo. 

No code was changed, only the documentation.

<!--
## Closed Issues

* Fixes #1234, by doing XYZ.
* Closes #4321, by implementing ABC.
-->

<!--
## Breaking Change

Will this pull request break dependent code? Describe how/why and give an example of how to migrate existing code to use the new version.
-->

