### PR TITLE
Avoid recursive trait resolution for `IntoIterator`

### DIFF
--- a/palette/src/alpha/alpha.rs
+++ b/palette/src/alpha/alpha.rs
@@ -864,58 +864,6 @@ where
     }
 }
 
-impl<C, A> IntoIterator for Alpha<C, A>
-where
-    C: IntoIterator,
-    A: IntoIterator,
-{
-    type Item = Alpha<C::Item, A::Item>;
-
-    type IntoIter = Iter<C::IntoIter, A::IntoIter>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Iter {
-            color: self.color.into_iter(),
-            alpha: self.alpha.into_iter(),
-        }
-    }
-}
-
-impl<'a, C, A> IntoIterator for &'a Alpha<C, A>
-where
-    &'a C: IntoIterator,
-    &'a A: IntoIterator,
-{
-    type Item = Alpha<<&'a C as IntoIterator>::Item, <&'a A as IntoIterator>::Item>;
-
-    type IntoIter = Iter<<&'a C as IntoIterator>::IntoIter, <&'a A as IntoIterator>::IntoIter>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Iter {
-            color: (&self.color).into_iter(),
-            alpha: (&self.alpha).into_iter(),
-        }
-    }
-}
-
-impl<'a, C, A> IntoIterator for &'a mut Alpha<C, A>
-where
-    &'a mut C: IntoIterator,
-    &'a mut A: IntoIterator,
-{
-    type Item = Alpha<<&'a mut C as IntoIterator>::Item, <&'a mut A as IntoIterator>::Item>;
-
-    type IntoIter =
-        Iter<<&'a mut C as IntoIterator>::IntoIter, <&'a mut A as IntoIterator>::IntoIter>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        Iter {
-            color: (&mut self.color).into_iter(),
-            alpha: (&mut self.alpha).into_iter(),
-        }
-    }
-}
-
 /// An iterator for transparent colors.
 pub struct Iter<C, A> {
     pub(crate) color: C,

--- a/palette/src/cast/array.rs
+++ b/palette/src/cast/array.rs
@@ -1,6 +1,6 @@
 use core::mem::{transmute_copy, ManuallyDrop};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::{boxed::Box, vec::Vec};
 
 pub use palette_derive::ArrayCast;

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -533,9 +533,6 @@ unsafe impl<S: 'static, T> bytemuck::Pod for Hsl<S, T> where T: bytemuck::Pod {}
 mod test {
     use super::Hsl;
 
-    #[cfg(feature = "alloc")]
-    use crate::Srgb;
-
     test_convert_into_from_xyz!(Hsl);
 
     #[cfg(feature = "approx")]

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -622,23 +622,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Hsl<Srgb>,
-        Hsl::new(0.1f32, 0.2, 0.3),
-        Hsl::new(0.2, 0.3, 0.4),
-        Hsl::new(0.3, 0.4, 0.5)
+        Hsl<crate::encoding::Srgb>[hue, saturation, lightness] phantom: standard,
+        super::Hsla::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Hsla::new(0.2, 0.3, 0.4, 0.5),
+        super::Hsla::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{encoding::Srgb, hsl::Hsla};
-
-        struct_of_arrays_tests!(
-            Hsla<Srgb>,
-            Hsla::new(0.1f32, 0.2, 0.3, 0.4),
-            Hsla::new(0.2, 0.3, 0.4, 0.5),
-            Hsla::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -345,23 +345,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Hsluv<D65>,
-        Hsluv::new(0.1f32, 0.2, 0.3),
-        Hsluv::new(0.2, 0.3, 0.4),
-        Hsluv::new(0.3, 0.4, 0.5)
+        Hsluv<D65>[hue, saturation, l] phantom: white_point,
+        super::Hsluva::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Hsluva::new(0.2, 0.3, 0.4, 0.5),
+        super::Hsluva::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{hsluv::Hsluva, white_point::D65};
-
-        struct_of_arrays_tests!(
-            Hsluva<D65>,
-            Hsluva::new(0.1f32, 0.2, 0.3, 0.4),
-            Hsluva::new(0.2, 0.3, 0.4, 0.5),
-            Hsluva::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -629,23 +629,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Hsv<Srgb>,
-        Hsv::new(0.1f32, 0.2, 0.3),
-        Hsv::new(0.2, 0.3, 0.4),
-        Hsv::new(0.3, 0.4, 0.5)
+        Hsv<crate::encoding::Srgb>[hue, saturation, value] phantom: standard,
+        super::Hsva::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Hsva::new(0.2, 0.3, 0.4, 0.5),
+        super::Hsva::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{encoding::Srgb, hsv::Hsva};
-
-        struct_of_arrays_tests!(
-            Hsva<Srgb>,
-            Hsva::new(0.1f32, 0.2, 0.3, 0.4),
-            Hsva::new(0.2, 0.3, 0.4, 0.5),
-            Hsva::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/hsv.rs
+++ b/palette/src/hsv.rs
@@ -540,9 +540,6 @@ unsafe impl<S: 'static, T> bytemuck::Pod for Hsv<S, T> where T: bytemuck::Pod {}
 mod test {
     use super::Hsv;
 
-    #[cfg(feature = "alloc")]
-    use crate::Srgb;
-
     test_convert_into_from_xyz!(Hsv);
 
     #[cfg(feature = "approx")]

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -582,9 +582,19 @@ macro_rules! make_hues {
             }
         }
 
-        impl<C> IntoIterator for $name<C> where C: IntoIterator {
-            type Item = $name<C::Item>;
-            type IntoIter = $iter_name<C::IntoIter>;
+        impl<T, const N: usize> IntoIterator for $name<[T; N]> {
+            type Item = $name<T>;
+            type IntoIter = $iter_name<core::array::IntoIter<T, N>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name(IntoIterator::into_iter(self.0))
+            }
+        }
+
+        impl<'a, T> IntoIterator for $name<&'a [T]> {
+            type Item = $name<&'a T>;
+            type IntoIter = $iter_name<core::slice::Iter<'a, T>>;
 
             #[inline(always)]
             fn into_iter(self) -> Self::IntoIter {
@@ -592,9 +602,9 @@ macro_rules! make_hues {
             }
         }
 
-        impl<'a, C> IntoIterator for &'a $name<C> where &'a C: IntoIterator {
-            type Item = $name<<&'a C as IntoIterator>::Item>;
-            type IntoIter = $iter_name<<&'a C as IntoIterator>::IntoIter>;
+        impl<'a, T> IntoIterator for $name<&'a mut [T]> {
+            type Item = $name<&'a mut T>;
+            type IntoIter = $iter_name<core::slice::IterMut<'a, T>>;
 
             #[inline(always)]
             fn into_iter(self) -> Self::IntoIter {
@@ -602,13 +612,108 @@ macro_rules! make_hues {
             }
         }
 
-        impl<'a, C> IntoIterator for &'a mut $name<C> where &'a mut C: IntoIterator {
-            type Item = $name<<&'a mut C as IntoIterator>::Item>;
-            type IntoIter = $iter_name<<&'a mut C as IntoIterator>::IntoIter>;
+        #[cfg(feature = "alloc")]
+        impl<T> IntoIterator for $name<alloc::vec::Vec<T>> {
+            type Item = $name<T>;
+            type IntoIter = $iter_name<alloc::vec::IntoIter<T>>;
 
             #[inline(always)]
             fn into_iter(self) -> Self::IntoIter {
                 $iter_name(self.0.into_iter())
+            }
+        }
+
+        impl<'a, T, const N: usize> IntoIterator for &'a $name<[T; N]> {
+            type Item = $name<&'a T>;
+            type IntoIter = $iter_name<core::slice::Iter<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&self.0).into_iter())
+            }
+        }
+
+        impl<'a, 'b, T> IntoIterator for &'a $name<&'b [T]> {
+            type Item = $name<&'a T>;
+            type IntoIter = $iter_name<core::slice::Iter<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name(self.0.into_iter())
+            }
+        }
+
+        impl<'a, 'b, T> IntoIterator for &'a $name<&'b mut [T]> {
+            type Item = $name<&'a T>;
+            type IntoIter = $iter_name<core::slice::Iter<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&*self.0).into_iter())
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, T> IntoIterator for &'a $name<alloc::vec::Vec<T>> {
+            type Item = $name<&'a T>;
+            type IntoIter = $iter_name<core::slice::Iter<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&self.0).into_iter())
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, T> IntoIterator for &'a $name<alloc::boxed::Box<[T]>> {
+            type Item = $name<&'a T>;
+            type IntoIter = $iter_name<core::slice::Iter<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&self.0).into_iter())
+            }
+        }
+
+        impl<'a, T, const N: usize> IntoIterator for &'a mut $name<[T; N]> {
+            type Item = $name<&'a mut T>;
+            type IntoIter = $iter_name<core::slice::IterMut<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&mut self.0).into_iter())
+            }
+        }
+
+        impl<'a, 'b, T> IntoIterator for &'a mut $name<&'b mut [T]> {
+            type Item = $name<&'a mut T>;
+            type IntoIter = $iter_name<core::slice::IterMut<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name(self.0.into_iter())
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, T> IntoIterator for &'a mut $name<alloc::vec::Vec<T>> {
+            type Item = $name<&'a mut T>;
+            type IntoIter = $iter_name<core::slice::IterMut<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&mut self.0).into_iter())
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, T> IntoIterator for &'a mut $name<alloc::boxed::Box<[T]>> {
+            type Item = $name<&'a mut T>;
+            type IntoIter = $iter_name<core::slice::IterMut<'a, T>>;
+
+            #[inline(always)]
+            fn into_iter(self) -> Self::IntoIter {
+                $iter_name((&mut *self.0).into_iter())
             }
         }
 

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -3,10 +3,7 @@
 #[cfg(any(feature = "approx", feature = "random"))]
 use core::ops::Mul;
 
-use core::{
-    cmp::PartialEq,
-    ops::{Add, AddAssign, Neg, Sub, SubAssign},
-};
+use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 
 #[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -456,23 +456,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Hwb<Srgb>,
-        Hwb::new(0.1f32, 0.2, 0.3),
-        Hwb::new(0.2, 0.3, 0.4),
-        Hwb::new(0.3, 0.4, 0.5)
+        Hwb<crate::encoding::Srgb>[hue, whiteness, blackness] phantom: standard,
+        super::Hwba::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Hwba::new(0.2, 0.3, 0.4, 0.5),
+        super::Hwba::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{encoding::Srgb, hwb::Hwba};
-
-        struct_of_arrays_tests!(
-            Hwba<Srgb>,
-            Hwba::new(0.1f32, 0.2, 0.3, 0.4),
-            Hwba::new(0.2, 0.3, 0.4, 0.5),
-            Hwba::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/hwb.rs
+++ b/palette/src/hwb.rs
@@ -366,9 +366,6 @@ unsafe impl<S: 'static, T> bytemuck::Pod for Hwb<S, T> where T: bytemuck::Pod {}
 mod test {
     use super::Hwb;
 
-    #[cfg(feature = "alloc")]
-    use crate::Srgb;
-
     test_convert_into_from_xyz!(Hwb);
 
     #[cfg(feature = "approx")]

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -445,23 +445,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Lab<D65>,
-        Lab::new(0.1f32, 0.2, 0.3),
-        Lab::new(0.2, 0.3, 0.4),
-        Lab::new(0.3, 0.4, 0.5)
+        Lab<D65>[l, a, b] phantom: white_point,
+        super::Laba::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Laba::new(0.2, 0.3, 0.4, 0.5),
+        super::Laba::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{lab::Laba, white_point::D65};
-
-        struct_of_arrays_tests!(
-            Laba<D65>,
-            Laba::new(0.1f32, 0.2, 0.3, 0.4),
-            Laba::new(0.2, 0.3, 0.4, 0.5),
-            Laba::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -455,23 +455,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Lch<D65>,
-        Lch::new(0.1f32, 0.2, 0.3),
-        Lch::new(0.2, 0.3, 0.4),
-        Lch::new(0.3, 0.4, 0.5)
+        Lch<D65>[l, chroma, hue] phantom: white_point,
+        super::Lcha::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Lcha::new(0.2, 0.3, 0.4, 0.5),
+        super::Lcha::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{lch::Lcha, white_point::D65};
-
-        struct_of_arrays_tests!(
-            Lcha<D65>,
-            Lcha::new(0.1f32, 0.2, 0.3, 0.4),
-            Lcha::new(0.2, 0.3, 0.4, 0.5),
-            Lcha::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/lchuv.rs
+++ b/palette/src/lchuv.rs
@@ -317,23 +317,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Lchuv<D65>,
-        Lchuv::new(0.1f32, 0.2, 0.3),
-        Lchuv::new(0.2, 0.3, 0.4),
-        Lchuv::new(0.3, 0.4, 0.5)
+        Lchuv<D65>[l, chroma, hue] phantom: white_point,
+        super::Lchuva::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Lchuva::new(0.2, 0.3, 0.4, 0.5),
+        super::Lchuva::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{lchuv::Lchuva, white_point::D65};
-
-        struct_of_arrays_tests!(
-            Lchuva<D65>,
-            Lchuva::new(0.1f32, 0.2, 0.3, 0.4),
-            Lchuva::new(0.2, 0.3, 0.4, 0.5),
-            Lchuva::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/luma/luma.rs
+++ b/palette/src/luma/luma.rs
@@ -895,23 +895,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Luma<Srgb>,
-        Luma::new(0.1f32),
-        Luma::new(0.2),
-        Luma::new(0.3)
+        Luma<Srgb>[luma] phantom: standard,
+        super::Lumaa::new(0.1f32, 0.4),
+        super::Lumaa::new(0.2, 0.5),
+        super::Lumaa::new(0.3, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{encoding::Srgb, luma::Lumaa};
-
-        struct_of_arrays_tests!(
-            Lumaa<Srgb>,
-            Lumaa::new(0.1f32, 0.4),
-            Lumaa::new(0.2, 0.5),
-            Lumaa::new(0.3, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -386,23 +386,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Luv<D65>,
-        Luv::new(0.1f32, 0.2, 0.3),
-        Luv::new(0.2, 0.3, 0.4),
-        Luv::new(0.3, 0.4, 0.5)
+        Luv<D65>[l, u, v] phantom: white_point,
+        super::Luva::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Luva::new(0.2, 0.3, 0.4, 0.5),
+        super::Luva::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{luv::Luva, white_point::D65};
-
-        struct_of_arrays_tests!(
-            Luva<D65>,
-            Luva::new(0.1f32, 0.2, 0.3, 0.4),
-            Luva::new(0.2, 0.3, 0.4, 0.5),
-            Luva::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/macros/struct_of_arrays.rs
+++ b/palette/src/macros/struct_of_arrays.rs
@@ -61,9 +61,21 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
+        impl<$($phantom_ty,)? T, const N: usize> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? [T; N]>, [T; N]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? T>, T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::array::IntoIter<T, N> $(,$phantom_ty)?>, core::array::IntoIter<T, N>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: IntoIterator::into_iter(self.alpha)
+                }
+            }
+        }
+
         impl<'a, $($phantom_ty,)? T> IntoIterator for $self_ty<$($phantom_ty,)? &'a [T]>
-        where
-            T: 'a,
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -78,9 +90,21 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
+        impl<'a, $($phantom_ty,)? T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a [T]>, &'a [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: self.alpha.into_iter(),
+                }
+            }
+        }
+
         impl<'a, $($phantom_ty,)? T> IntoIterator for $self_ty<$($phantom_ty,)? &'a mut [T]>
-        where
-            T: 'a,
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -91,6 +115,20 @@ macro_rules! impl_struct_of_array_traits {
                 Iter {
                     $($element: self.$element.into_iter(),)+
                     $($phantom: core::marker::PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut [T]>, &'a mut [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: self.alpha.into_iter(),
                 }
             }
         }
@@ -111,14 +149,12 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
-        impl<$($phantom_ty,)? C, T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? C>, C>
-        where
-            $self_ty<$($phantom_ty,)? C>: IntoIterator<Item = $self_ty<$($phantom_ty,)? T>>,
-            C: IntoIterator<Item = T>,
+        #[cfg(feature = "alloc")]
+        impl<'a, $($phantom_ty,)? T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>, alloc::vec::Vec<T>>
         {
             type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? T>, T>;
 
-            type IntoIter = crate::alpha::Iter<<$self_ty<$($phantom_ty,)? C> as IntoIterator>::IntoIter, C::IntoIter>;
+            type IntoIter = crate::alpha::Iter<Iter<alloc::vec::IntoIter<T> $(,$phantom_ty)?>, alloc::vec::IntoIter<T>>;
 
             fn into_iter(self) -> Self::IntoIter {
                 crate::alpha::Iter {
@@ -129,8 +165,6 @@ macro_rules! impl_struct_of_array_traits {
         }
 
         impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a $self_ty<$($phantom_ty,)? [T; N]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -141,13 +175,25 @@ macro_rules! impl_struct_of_array_traits {
                 Iter {
                     $($element: (&self.$element).into_iter(),)+
                     $($phantom: core::marker::PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? [T; N]>, [T; N]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&self.color).into_iter(),
+                    alpha: (&self.alpha).into_iter(),
                 }
             }
         }
 
         impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? &'b [T]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -162,9 +208,21 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'b [T]>, &'b [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: self.alpha.into_iter(),
+                }
+            }
+        }
+
         impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? &'b mut [T]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -179,10 +237,22 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'b mut [T]>, &'b mut [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&self.color).into_iter(),
+                    alpha: (&*self.alpha).into_iter(),
+                }
+            }
+        }
+
         #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -193,14 +263,27 @@ macro_rules! impl_struct_of_array_traits {
                 Iter {
                     $($element: (&self.$element).into_iter(),)+
                     $($phantom: core::marker::PhantomData)?
+                }
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>, alloc::vec::Vec<T>>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&self.color).into_iter(),
+                    alpha: (&self.alpha).into_iter(),
                 }
             }
         }
 
         #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -215,15 +298,12 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
-        impl<'a, $($phantom_ty,)? C, T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? C>, C>
-        where
-            &'a $self_ty<$($phantom_ty,)? C>: IntoIterator<Item = $self_ty<$($phantom_ty,)? &'a T>>,
-            &'a C: IntoIterator<Item = &'a T>,
-            T: 'a,
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>, alloc::boxed::Box<[T]>>
         {
             type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
 
-            type IntoIter = crate::alpha::Iter<<&'a $self_ty<$($phantom_ty,)? C> as IntoIterator>::IntoIter, <&'a C as IntoIterator>::IntoIter>;
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
 
             fn into_iter(self) -> Self::IntoIter {
                 crate::alpha::Iter {
@@ -234,8 +314,6 @@ macro_rules! impl_struct_of_array_traits {
         }
 
         impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? [T; N]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -250,9 +328,21 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
+        impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? [T; N]>, [T; N]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&mut self.color).into_iter(),
+                    alpha: (&mut self.alpha).into_iter(),
+                }
+            }
+        }
+
         impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? &'b mut [T]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -267,10 +357,22 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'b mut [T]>, &'b mut [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&mut self.color).into_iter(),
+                    alpha: (self.alpha).into_iter(),
+                }
+            }
+        }
+
         #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -281,6 +383,21 @@ macro_rules! impl_struct_of_array_traits {
                 Iter {
                     $($element: (&mut self.$element).into_iter(),)+
                     $($phantom: core::marker::PhantomData)?
+                }
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>, alloc::vec::Vec<T>>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&mut self.color).into_iter(),
+                    alpha: (&mut self.alpha).into_iter(),
                 }
             }
         }
@@ -303,20 +420,17 @@ macro_rules! impl_struct_of_array_traits {
             }
         }
 
-        impl<'a, $($phantom_ty,)? C, T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? C>, C>
-        where
-            &'a mut $self_ty<$($phantom_ty,)? C>: IntoIterator<Item = $self_ty<$($phantom_ty,)? &'a mut T>>,
-            &'a mut C: IntoIterator<Item = &'a mut T>,
-            T: 'a,
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>, alloc::boxed::Box<[T]>>
         {
             type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
 
-            type IntoIter = crate::alpha::Iter<<&'a mut $self_ty<$($phantom_ty,)? C> as IntoIterator>::IntoIter, <&'a mut C as IntoIterator>::IntoIter>;
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
 
             fn into_iter(self) -> Self::IntoIter {
                 crate::alpha::Iter {
                     color: (&mut self.color).into_iter(),
-                    alpha: (&mut self.alpha).into_iter(),
+                    alpha: (&mut *self.alpha).into_iter(),
                 }
             }
         }
@@ -452,9 +566,21 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<$($phantom_ty,)? T, const N: usize> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? [T; N]>, [T; N]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? T>, T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::array::IntoIter<T, N> $(,$phantom_ty)?>, core::array::IntoIter<T, N>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: IntoIterator::into_iter(self.alpha)
+                }
+            }
+        }
+
         impl<'a, $($phantom_ty,)? T> IntoIterator for $self_ty<$($phantom_ty,)? &'a [T]>
-        where
-            T: 'a,
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -470,9 +596,21 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<'a, $($phantom_ty,)? T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a [T]>, &'a [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: self.alpha.into_iter(),
+                }
+            }
+        }
+
         impl<'a, $($phantom_ty,)? T> IntoIterator for $self_ty<$($phantom_ty,)? &'a mut [T]>
-        where
-            T: 'a,
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -484,6 +622,20 @@ macro_rules! impl_struct_of_array_traits_hue {
                     hue: self.hue.into_iter(),
                     $($element: self.$element.into_iter(),)+
                     $($phantom: core::marker::PhantomData)?
+                }
+            }
+        }
+
+        impl<'a, $($phantom_ty,)? T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut [T]>, &'a mut [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: self.alpha.into_iter(),
                 }
             }
         }
@@ -505,14 +657,12 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
-        impl<$($phantom_ty,)? C, T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? C>, C>
-        where
-            $self_ty<$($phantom_ty,)? C>: IntoIterator<Item = $self_ty<$($phantom_ty,)? T>>,
-            C: IntoIterator<Item = T>,
+        #[cfg(feature = "alloc")]
+        impl<'a, $($phantom_ty,)? T> IntoIterator for crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>, alloc::vec::Vec<T>>
         {
             type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? T>, T>;
 
-            type IntoIter = crate::alpha::Iter<<$self_ty<$($phantom_ty,)? C> as IntoIterator>::IntoIter, C::IntoIter>;
+            type IntoIter = crate::alpha::Iter<Iter<alloc::vec::IntoIter<T> $(,$phantom_ty)?>, alloc::vec::IntoIter<T>>;
 
             fn into_iter(self) -> Self::IntoIter {
                 crate::alpha::Iter {
@@ -523,8 +673,6 @@ macro_rules! impl_struct_of_array_traits_hue {
         }
 
         impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a $self_ty<$($phantom_ty,)? [T; N]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -540,9 +688,21 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? [T; N]>, [T; N]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&self.color).into_iter(),
+                    alpha: (&self.alpha).into_iter(),
+                }
+            }
+        }
+
         impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? &'b [T]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -558,9 +718,21 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'b [T]>, &'b [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: self.color.into_iter(),
+                    alpha: self.alpha.into_iter(),
+                }
+            }
+        }
+
         impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? &'b mut [T]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -576,10 +748,22 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'b mut [T]>, &'b mut [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&self.color).into_iter(),
+                    alpha: (&*self.alpha).into_iter(),
+                }
+            }
+        }
+
         #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -591,14 +775,27 @@ macro_rules! impl_struct_of_array_traits_hue {
                     hue: (&self.hue).into_iter(),
                     $($element: (&self.$element).into_iter(),)+
                     $($phantom: core::marker::PhantomData)?
+                }
+            }
+        }
+
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>, alloc::vec::Vec<T>>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&self.color).into_iter(),
+                    alpha: (&self.alpha).into_iter(),
                 }
             }
         }
 
         #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a $self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a T>;
 
@@ -614,15 +811,12 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
-        impl<'a, $($phantom_ty,)? C, T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? C>, C>
-        where
-            &'a $self_ty<$($phantom_ty,)? C>: IntoIterator<Item = $self_ty<$($phantom_ty,)? &'a T>>,
-            &'a C: IntoIterator<Item = &'a T>,
-            T: 'a,
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>, alloc::boxed::Box<[T]>>
         {
             type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a T>, &'a T>;
 
-            type IntoIter = crate::alpha::Iter<<&'a $self_ty<$($phantom_ty,)? C> as IntoIterator>::IntoIter, <&'a C as IntoIterator>::IntoIter>;
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::Iter<'a, T> $(,$phantom_ty)?>, core::slice::Iter<'a, T>>;
 
             fn into_iter(self) -> Self::IntoIter {
                 crate::alpha::Iter {
@@ -633,8 +827,6 @@ macro_rules! impl_struct_of_array_traits_hue {
         }
 
         impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? [T; N]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -650,9 +842,21 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<'a, $($phantom_ty,)? T, const N: usize> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? [T; N]>, [T; N]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&mut self.color).into_iter(),
+                    alpha: (&mut self.alpha).into_iter(),
+                }
+            }
+        }
+
         impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? &'b mut [T]>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -668,10 +872,22 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'b mut [T]>, &'b mut [T]>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&mut self.color).into_iter(),
+                    alpha: (self.alpha).into_iter(),
+                }
+            }
+        }
+
         #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -688,9 +904,22 @@ macro_rules! impl_struct_of_array_traits_hue {
         }
 
         #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::vec::Vec<T>>, alloc::vec::Vec<T>>
+        {
+            type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
+
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                crate::alpha::Iter {
+                    color: (&mut self.color).into_iter(),
+                    alpha: (&mut self.alpha).into_iter(),
+                }
+            }
+        }
+
+        #[cfg(feature = "alloc")]
         impl<'a, $($phantom_ty,)? T> IntoIterator for &'a mut $self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>
-        where
-            T: 'a
         {
             type Item = $self_ty<$($phantom_ty,)? &'a mut T>;
 
@@ -706,20 +935,17 @@ macro_rules! impl_struct_of_array_traits_hue {
             }
         }
 
-        impl<'a, $($phantom_ty,)? C, T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? C>, C>
-        where
-            &'a mut $self_ty<$($phantom_ty,)? C>: IntoIterator<Item = $self_ty<$($phantom_ty,)? &'a mut T>>,
-            &'a mut C: IntoIterator<Item = &'a mut T>,
-            T: 'a,
+        #[cfg(feature = "alloc")]
+        impl<'a, 'b, $($phantom_ty,)? T> IntoIterator for &'a mut crate::alpha::Alpha<$self_ty<$($phantom_ty,)? alloc::boxed::Box<[T]>>, alloc::boxed::Box<[T]>>
         {
             type Item = crate::alpha::Alpha<$self_ty<$($phantom_ty,)? &'a mut T>, &'a mut T>;
 
-            type IntoIter = crate::alpha::Iter<<&'a mut $self_ty<$($phantom_ty,)? C> as IntoIterator>::IntoIter, <&'a mut C as IntoIterator>::IntoIter>;
+            type IntoIter = crate::alpha::Iter<Iter<core::slice::IterMut<'a, T> $(,$phantom_ty)?>, core::slice::IterMut<'a, T>>;
 
             fn into_iter(self) -> Self::IntoIter {
                 crate::alpha::Iter {
                     color: (&mut self.color).into_iter(),
-                    alpha: (&mut self.alpha).into_iter(),
+                    alpha: (&mut *self.alpha).into_iter(),
                 }
             }
         }

--- a/palette/src/macros/struct_of_arrays.rs
+++ b/palette/src/macros/struct_of_arrays.rs
@@ -1441,23 +1441,48 @@ macro_rules! impl_struct_of_arrays_methods_hue {
 
 #[cfg(test)]
 macro_rules! struct_of_arrays_tests {
-    ($color_ty: ident $(<$phantom_ty:ident>)?, $($values:expr),+) => {
+    ($color_ty: ident $(<$phantom_ty:ty>)? [$($element: ident),+] $(phantom: $phantom: ident)?, $($values:expr),+) => {
         #[cfg(feature = "alloc")]
         #[test]
         fn collect() {
-            let vec_of_colors = vec![$($values),+];
+            let vec_of_colors = vec![$($values.color),+];
             let color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values.color),+]);
+        }
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn collect_alpha() {
+            let vec_of_colors = vec![$($values),+];
+            let color_of_vecs: crate::alpha::Alpha<$color_ty<$($phantom_ty,)? Vec<_>>, Vec<_>> = vec_of_colors.into_iter().collect();
             let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
 
             assert_eq!(vec_of_colors, vec![$($values),+]);
         }
 
+
         #[cfg(feature = "alloc")]
         #[test]
         fn extend() {
+            let vec_of_colors = vec![$($values.color),+];
+
+            let mut color_of_vecs = $color_ty::<$($phantom_ty,)? Vec<_>>::with_capacity(vec_of_colors.len());
+            color_of_vecs.extend(vec_of_colors);
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values.color),+]);
+        }
+
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn extend_alpha() {
             let vec_of_colors = vec![$($values),+];
 
-            let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = $color_ty::with_capacity(vec_of_colors.len());
+            let mut color_of_vecs = crate::alpha::Alpha::<$color_ty<$($phantom_ty,)? Vec<_>>, Vec<_>>::with_capacity(vec_of_colors.len());
             color_of_vecs.extend(vec_of_colors);
 
             let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
@@ -1465,12 +1490,28 @@ macro_rules! struct_of_arrays_tests {
             assert_eq!(vec_of_colors, vec![$($values),+]);
         }
 
+
         #[cfg(feature = "alloc")]
         #[test]
         fn pop_push() {
-            let vec_of_colors = vec![$($values),+];
+            let vec_of_colors = vec![$($values.color),+];
 
             let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+            let last = color_of_vecs.pop().unwrap();
+            color_of_vecs.push(last);
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![$($values.color),+]);
+        }
+
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn pop_push_alpha() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: crate::alpha::Alpha<$color_ty<$($phantom_ty,)? Vec<_>>, Vec<_>> = vec_of_colors.into_iter().collect();
             let last = color_of_vecs.pop().unwrap();
             color_of_vecs.push(last);
 
@@ -1482,7 +1523,7 @@ macro_rules! struct_of_arrays_tests {
         #[cfg(feature = "alloc")]
         #[test]
         fn clear() {
-            let vec_of_colors = vec![$($values),+];
+            let vec_of_colors = vec![$($values.color),+];
 
             let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
             color_of_vecs.clear();
@@ -1494,10 +1535,39 @@ macro_rules! struct_of_arrays_tests {
 
         #[cfg(feature = "alloc")]
         #[test]
-        fn drain() {
+        fn clear_alpha() {
             let vec_of_colors = vec![$($values),+];
 
+            let mut color_of_vecs: crate::alpha::Alpha<$color_ty<$($phantom_ty,)? Vec<_>>, Vec<_>> = vec_of_colors.into_iter().collect();
+            color_of_vecs.clear();
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors, vec![]);
+        }
+
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn drain() {
+            let vec_of_colors = vec![$($values.color),+];
+
             let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
+
+            let vec_of_colors1: Vec<_> = color_of_vecs.drain(..).collect();
+            let vec_of_colors2: Vec<_> = color_of_vecs.into_iter().collect();
+
+            assert_eq!(vec_of_colors1, vec![$($values.color),+]);
+            assert_eq!(vec_of_colors2, vec![]);
+        }
+
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn drain_alpha() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: crate::alpha::Alpha<$color_ty<$($phantom_ty,)? Vec<_>>, Vec<_>> = vec_of_colors.into_iter().collect();
 
             let vec_of_colors1: Vec<_> = color_of_vecs.drain(..).collect();
             let vec_of_colors2: Vec<_> = color_of_vecs.into_iter().collect();
@@ -1509,7 +1579,7 @@ macro_rules! struct_of_arrays_tests {
         #[cfg(feature = "alloc")]
         #[test]
         fn modify() {
-            let vec_of_colors = vec![$($values),+];
+            let vec_of_colors = vec![$($values.color),+];
 
             let mut color_of_vecs: $color_ty<$($phantom_ty,)? Vec<_>> = vec_of_colors.into_iter().collect();
 
@@ -1519,7 +1589,245 @@ macro_rules! struct_of_arrays_tests {
 
             let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
 
+            assert_eq!(vec_of_colors, vec![$($values.color + 2.0),+]);
+        }
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn modify_alpha() {
+            let vec_of_colors = vec![$($values),+];
+
+            let mut color_of_vecs: crate::alpha::Alpha<$color_ty<$($phantom_ty,)? Vec<_>>, Vec<_>> = vec_of_colors.into_iter().collect();
+
+            for mut color in &mut color_of_vecs {
+                color.set(color.copied() + 2.0);
+            }
+
+            let vec_of_colors: Vec<_> = color_of_vecs.into_iter().collect();
+
             assert_eq!(vec_of_colors, vec![$($values + 2.0),+]);
+        }
+
+        #[test]
+        fn into_iterator() {
+            fn expect_move(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? f32>>){}
+            fn expect_ref<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a f32>>){}
+            fn expect_ref_mut<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a mut f32>>){}
+
+            let arrays = $color_ty::<$($phantom_ty,)? [f32; 0]>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+            let slices = $color_ty::<$($phantom_ty,)? &[f32]>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+            let mut_slices = $color_ty::<$($phantom_ty,)? &mut [f32]>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+
+            expect_move(arrays.into_iter());
+            expect_ref(slices.into_iter());
+            expect_ref_mut(mut_slices.into_iter());
+        }
+
+        #[test]
+        fn into_iterator_alpha() {
+            use crate::alpha::Alpha;
+
+            fn expect_move(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? f32>, f32>>){}
+            fn expect_ref<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a f32>, &'a f32>>){}
+            fn expect_ref_mut<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a mut f32>, &'a mut f32>>){}
+
+            let arrays = Alpha::<_, [f32; 0]>{
+                color: $color_ty::<$($phantom_ty,)? [f32; 0]>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+            let slices = Alpha::<_, &[f32]>{
+                color: $color_ty::<$($phantom_ty,)? &[f32]>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+            let mut_slices = Alpha::<_, &mut [f32]>{
+                color: $color_ty::<$($phantom_ty,)? &mut [f32]>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+
+            expect_move(arrays.into_iter());
+            expect_ref(slices.into_iter());
+            expect_ref_mut(mut_slices.into_iter());
+        }
+
+        #[test]
+        fn into_iterator_ref() {
+            fn expect_ref<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a f32>>){}
+            fn expect_ref_mut<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a mut f32>>){}
+
+            let mut arrays = $color_ty::<$($phantom_ty,)? [f32; 0]>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+            let mut slices = $color_ty::<$($phantom_ty,)? &[f32]>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+            let mut mut_slices = $color_ty::<$($phantom_ty,)? &mut [f32]>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+
+            expect_ref((&arrays).into_iter());
+            expect_ref((&slices).into_iter());
+            expect_ref((&mut_slices).into_iter());
+
+            expect_ref_mut((&mut arrays).into_iter());
+            expect_ref((&mut slices).into_iter());
+            expect_ref_mut((&mut mut_slices).into_iter());
+        }
+
+        #[test]
+        fn into_iterator_ref_alpha() {
+            use crate::alpha::Alpha;
+
+            fn expect_ref<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a f32>, &'a f32>>){}
+            fn expect_ref_mut<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a mut f32>, &'a mut f32>>){}
+
+            let mut arrays = Alpha::<_, [f32; 0]>{
+                color: $color_ty::<$($phantom_ty,)? [f32; 0]>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+            let mut slices = Alpha::<_, &[f32]>{
+                color: $color_ty::<$($phantom_ty,)? &[f32]>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+            let mut mut_slices = Alpha::<_, &mut [f32]>{
+                color: $color_ty::<$($phantom_ty,)? &mut [f32]>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+
+            expect_ref((&arrays).into_iter());
+            expect_ref((&slices).into_iter());
+            expect_ref((&mut_slices).into_iter());
+
+            expect_ref_mut((&mut arrays).into_iter());
+            expect_ref((&mut slices).into_iter());
+            expect_ref_mut((&mut mut_slices).into_iter());
+        }
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn into_iterator_alloc() {
+            fn expect_move(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? f32>>){}
+            fn expect_ref<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a f32>>){}
+
+            let vecs = $color_ty::<$($phantom_ty,)? Vec<f32>>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+            let boxed_slices = $color_ty::<$($phantom_ty,)? Box<[f32]>>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+
+            expect_move(vecs.into_iter());
+            expect_ref(boxed_slices.into_iter());
+        }
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn into_iterator_alloc_alpha() {
+            use crate::alpha::Alpha;
+
+            fn expect_move(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? f32>, f32>>){}
+            fn expect_ref<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a f32>, &'a f32>>){}
+
+            let vecs = Alpha::<_, Vec<f32>>{
+                color: $color_ty::<$($phantom_ty,)? Vec<f32>>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+            let boxed_slices = Alpha::<_, Box<[f32]>>{
+                color: $color_ty::<$($phantom_ty,)? Box<[f32]>>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+
+            expect_move(vecs.into_iter());
+            expect_ref(boxed_slices.into_iter());
+        }
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn into_iterator_alloc_ref() {
+            fn expect_ref<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a f32>>){}
+            fn expect_ref_mut<'a>(_: impl Iterator<Item = $color_ty::<$($phantom_ty,)? &'a mut f32>>){}
+
+            let mut vecs = $color_ty::<$($phantom_ty,)? Vec<f32>>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+            let mut boxed_slices = $color_ty::<$($phantom_ty,)? Box<[f32]>>{
+                $($element: Default::default(),)+
+                $($phantom: core::marker::PhantomData,)?
+            };
+
+            expect_ref((&vecs).into_iter());
+            expect_ref((&boxed_slices).into_iter());
+
+            expect_ref_mut((&mut vecs).into_iter());
+            expect_ref_mut((&mut boxed_slices).into_iter());
+        }
+
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn into_iterator_alloc_ref_alpha() {
+            use crate::alpha::Alpha;
+
+            fn expect_ref<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a f32>, &'a f32>>){}
+            fn expect_ref_mut<'a>(_: impl Iterator<Item = Alpha<$color_ty::<$($phantom_ty,)? &'a mut f32>, &'a mut f32>>){}
+
+            let mut vecs = Alpha::<_, Vec<f32>>{
+                color: $color_ty::<$($phantom_ty,)? Vec<f32>>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+            let mut boxed_slices = Alpha::<_, Box<[f32]>>{
+                color: $color_ty::<$($phantom_ty,)? Box<[f32]>>{
+                    $($element: Default::default(),)+
+                    $($phantom: core::marker::PhantomData,)?
+                },
+                alpha: Default::default(),
+            };
+
+            expect_ref((&vecs).into_iter());
+            expect_ref((&boxed_slices).into_iter());
+
+            expect_ref_mut((&mut vecs).into_iter());
+            expect_ref_mut((&mut boxed_slices).into_iter());
         }
     }
 }

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -429,21 +429,9 @@ mod tests {
     }
 
     struct_of_arrays_tests!(
-        Okhsl,
-        Okhsl::new(0.1f32, 0.2, 0.3),
-        Okhsl::new(0.2, 0.3, 0.4),
-        Okhsl::new(0.3, 0.4, 0.5)
+        Okhsl[hue, saturation, lightness],
+        super::Okhsla::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Okhsla::new(0.2, 0.3, 0.4, 0.5),
+        super::Okhsla::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::okhsl::Okhsla;
-
-        struct_of_arrays_tests!(
-            Okhsla,
-            Okhsla::new(0.1f32, 0.2, 0.3, 0.4),
-            Okhsla::new(0.2, 0.3, 0.4, 0.5),
-            Okhsla::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 }

--- a/palette/src/okhsv.rs
+++ b/palette/src/okhsv.rs
@@ -553,21 +553,9 @@ mod tests {
     }
 
     struct_of_arrays_tests!(
-        Okhsv,
-        Okhsv::new(0.1f32, 0.2, 0.3),
-        Okhsv::new(0.2, 0.3, 0.4),
-        Okhsv::new(0.3, 0.4, 0.5)
+        Okhsv[hue, saturation, value],
+        super::Okhsva::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Okhsva::new(0.2, 0.3, 0.4, 0.5),
+        super::Okhsva::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::okhsv::Okhsva;
-
-        struct_of_arrays_tests!(
-            Okhsva,
-            Okhsva::new(0.1f32, 0.2, 0.3, 0.4),
-            Okhsva::new(0.2, 0.3, 0.4, 0.5),
-            Okhsva::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 }

--- a/palette/src/okhwb.rs
+++ b/palette/src/okhwb.rs
@@ -282,21 +282,9 @@ mod tests {
     }
 
     struct_of_arrays_tests!(
-        Okhwb,
-        Okhwb::new(0.1f32, 0.2, 0.3),
-        Okhwb::new(0.2, 0.3, 0.4),
-        Okhwb::new(0.3, 0.4, 0.5)
+        Okhwb[hue, whiteness, blackness],
+        super::Okhwba::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Okhwba::new(0.2, 0.3, 0.4, 0.5),
+        super::Okhwba::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::okhwb::Okhwba;
-
-        struct_of_arrays_tests!(
-            Okhwba,
-            Okhwba::new(0.1f32, 0.2, 0.3, 0.4),
-            Okhwba::new(0.2, 0.3, 0.4, 0.5),
-            Okhwba::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 }

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -679,23 +679,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Oklab,
-        Oklab::new(0.1f32, 0.2, 0.3),
-        Oklab::new(0.2, 0.3, 0.4),
-        Oklab::new(0.3, 0.4, 0.5)
+        Oklab[l, a, b],
+        super::Oklaba::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Oklaba::new(0.2, 0.3, 0.4, 0.5),
+        super::Oklaba::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::oklab::Oklaba;
-
-        struct_of_arrays_tests!(
-            Oklaba,
-            Oklaba::new(0.1f32, 0.2, 0.3, 0.4),
-            Oklaba::new(0.2, 0.3, 0.4, 0.5),
-            Oklaba::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -271,23 +271,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Oklch,
-        Oklch::new(0.1f32, 0.2, 0.3),
-        Oklch::new(0.2, 0.3, 0.4),
-        Oklch::new(0.3, 0.4, 0.5)
+        Oklch[l, chroma, hue],
+        super::Oklcha::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Oklcha::new(0.2, 0.3, 0.4, 0.5),
+        super::Oklcha::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::oklch::Oklcha;
-
-        struct_of_arrays_tests!(
-            Oklcha,
-            Oklcha::new(0.1f32, 0.2, 0.3, 0.4),
-            Oklcha::new(0.2, 0.3, 0.4, 0.5),
-            Oklcha::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     test_uniform_distribution! {
         Oklch<f32> as crate::Oklab {

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1498,23 +1498,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Rgb<Srgb>,
-        Rgb::new(0.1f32, 0.2, 0.3),
-        Rgb::new(0.2, 0.3, 0.4),
-        Rgb::new(0.3, 0.4, 0.5)
+        Rgb<Srgb>[red, green, blue] phantom: standard,
+        Rgba::new(0.1f32, 0.2, 0.3, 0.4),
+        Rgba::new(0.2, 0.3, 0.4, 0.5),
+        Rgba::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{encoding::Srgb, rgb::Rgba};
-
-        struct_of_arrays_tests!(
-            Rgba<Srgb>,
-            Rgba::new(0.1f32, 0.2, 0.3, 0.4),
-            Rgba::new(0.2, 0.3, 0.4, 0.5),
-            Rgba::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     test_uniform_distribution! {
         Rgb<Srgb, f32> {

--- a/palette/src/xyz.rs
+++ b/palette/src/xyz.rs
@@ -493,23 +493,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Xyz<D65>,
-        Xyz::new(0.1f32, 0.2, 0.3),
-        Xyz::new(0.2, 0.3, 0.4),
-        Xyz::new(0.3, 0.4, 0.5)
+        Xyz<D65>[x, y, z] phantom: white_point,
+        super::Xyza::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Xyza::new(0.2, 0.3, 0.4, 0.5),
+        super::Xyza::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{white_point::D65, xyz::Xyza};
-
-        struct_of_arrays_tests!(
-            Xyza<D65>,
-            Xyza::new(0.1f32, 0.2, 0.3, 0.4),
-            Xyza::new(0.2, 0.3, 0.4, 0.5),
-            Xyza::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette/src/yxy.rs
+++ b/palette/src/yxy.rs
@@ -362,23 +362,11 @@ mod test {
     }
 
     struct_of_arrays_tests!(
-        Yxy<D65>,
-        Yxy::new(0.1f32, 0.2, 0.3),
-        Yxy::new(0.2, 0.3, 0.4),
-        Yxy::new(0.3, 0.4, 0.5)
+        Yxy<D65>[x, y, luma] phantom: white_point,
+        super::Yxya::new(0.1f32, 0.2, 0.3, 0.4),
+        super::Yxya::new(0.2, 0.3, 0.4, 0.5),
+        super::Yxya::new(0.3, 0.4, 0.5, 0.6)
     );
-
-    mod alpha {
-        #[cfg(feature = "alloc")]
-        use crate::{white_point::D65, yxy::Yxya};
-
-        struct_of_arrays_tests!(
-            Yxya<D65>,
-            Yxya::new(0.1f32, 0.2, 0.3, 0.4),
-            Yxya::new(0.2, 0.3, 0.4, 0.5),
-            Yxya::new(0.3, 0.4, 0.5, 0.6)
-        );
-    }
 
     #[cfg(feature = "serializing")]
     #[test]

--- a/palette_derive/src/meta/mod.rs
+++ b/palette_derive/src/meta/mod.rs
@@ -207,21 +207,6 @@ impl ::quote::ToTokens for IdentOrIndex {
     }
 }
 
-pub trait MetaParser: Default {
-    fn internal(&mut self);
-    fn parse_attribute(&mut self, attribute_name: Ident, attribute_tts: TokenStream) -> Result<()>;
-}
-
-pub trait DataMetaParser: Default {
-    fn parse_struct_field_attribute(
-        &mut self,
-        field_name: IdentOrIndex,
-        ty: Type,
-        attribute_name: Ident,
-        attribute_tts: TokenStream,
-    ) -> Result<()>;
-}
-
 pub trait AttributeArgumentParser: Default {
     fn argument(&mut self, argument: Meta) -> Result<()>;
 }


### PR DESCRIPTION
A workaround for another case of #283. This time for `IntoIterator`. It avoids the issue by only providing implementations for specific collection types. 

## Closed Issues

* Fixes #283 

## Breaking Change

This makes `IntoIterator` no longer generic over the collection type, but explicitly covers `[T; N]`, `&[T]`, `&mut [T]` , `Vec<T>`,  and `Box<[T]>`.