### PR TITLE
Add traits for color schemes from traditional color theory

### DIFF
--- a/palette/src/color_theory.rs
+++ b/palette/src/color_theory.rs
@@ -1,4 +1,20 @@
 //! Traits related to traditional color theory.
+//!
+//! Traditional color theory is sometimes used as a guide when selecting colors
+//! for artistic purposes. While it's not the same as modern color science, and
+//! much more subjective, it may still be a helpful set of principles.
+//!
+//! This module is primarily based on the 12 color wheel, meaning that they use
+//! colors that are separated by 30° around the hue circle. There are however
+//! some concepts, such as [`Complementary`] colors, that are generally
+//! independent from the 12 color wheel concept.
+//!
+//! Most of the traits in this module require the color space to have a hue
+//! component. You will often see people use [`Hsv`][crate::Hsv] or
+//! [`Hsl`][crate::Hsl] when demonstrating some of these techniques, but Palette
+//! lets you use any hue based color space. Some traits are also implemented for
+//! other color spaces, when it's possible to avoid converting them to their hue
+//! based counterparts.
 
 use crate::{angle::HalfRotation, num::Real, ShiftHue};
 
@@ -6,7 +22,7 @@ use crate::{angle::HalfRotation, num::Real, ShiftHue};
 ///
 /// A complementary color scheme consists of two colors on the opposite sides of
 /// the color wheel.
-pub trait Complementary {
+pub trait Complementary: Sized {
     /// Return the complementary color of `self`.
     ///
     /// This is the same as if the hue of `self` would be rotated by 180°.

--- a/palette/src/color_theory.rs
+++ b/palette/src/color_theory.rs
@@ -1,0 +1,273 @@
+//! Traits related to traditional color theory.
+
+use crate::{angle::HalfRotation, num::Real, ShiftHue};
+
+/// Represents the complementary color scheme.
+///
+/// A complementary color scheme consists of two colors on the opposite sides of
+/// the color wheel.
+pub trait Complementary {
+    /// Return the complementary color of `self`.
+    ///
+    /// This is the same as if the hue of `self` would be rotated by 180°.
+    ///
+    /// The following example makes a complementary color pair:
+    ///
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(120deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(300deg, 80%, 50%);"></div>
+    ///
+    /// ```
+    /// use palette::{Hsl, color_theory::Complementary};
+    ///
+    /// let primary = Hsl::new_srgb(120.0f32, 8.0, 0.5);
+    /// let complementary = primary.complementary();
+    ///
+    /// let hues = (
+    ///     primary.hue.into_positive_degrees(),
+    ///     complementary.hue.into_positive_degrees(),
+    /// );
+    ///
+    /// assert_eq!(hues, (120.0, 300.0));
+    /// ```
+    fn complementary(self) -> Self;
+}
+
+impl<T> Complementary for T
+where
+    T: ShiftHue,
+    T::Scalar: HalfRotation,
+{
+    fn complementary(self) -> Self {
+        self.shift_hue(T::Scalar::half_rotation())
+    }
+}
+
+/// Represents the split complementary color scheme.
+///
+/// A split complementary color scheme consists of three colors, where the
+/// second and third are adjacent to (30° away from) the complementary color of
+/// the first.
+pub trait SplitComplementary: Sized {
+    /// Return the two split complementary colors of `self`.
+    ///
+    /// The colors are ordered by ascending hue, or `(hue+150°, hue+210°)`.
+    /// Combined with the input color, these make up 3 adjacent colors.
+    ///
+    /// The following example makes a split complementary color scheme:
+    ///
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(120deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(270deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(330deg, 80%, 50%);"></div>
+    ///
+    /// ```
+    /// use palette::{Hsl, color_theory::SplitComplementary};
+    ///
+    /// let primary = Hsl::new_srgb(120.0f32, 8.0, 0.5);
+    /// let (complementary1, complementary2) = primary.split_complementary();
+    ///
+    /// let hues = (
+    ///     primary.hue.into_positive_degrees(),
+    ///     complementary1.hue.into_positive_degrees(),
+    ///     complementary2.hue.into_positive_degrees(),
+    /// );
+    ///
+    /// assert_eq!(hues, (120.0, 270.0, 330.0));
+    /// ```
+    fn split_complementary(self) -> (Self, Self);
+}
+
+impl<T> SplitComplementary for T
+where
+    T: ShiftHue + Clone,
+    T::Scalar: Real,
+{
+    fn split_complementary(self) -> (Self, Self) {
+        let first = self.clone().shift_hue(T::Scalar::from_f64(150.0));
+        let second = self.shift_hue(T::Scalar::from_f64(210.0));
+
+        (first, second)
+    }
+}
+
+/// Represents the analogous color scheme on a 12 color wheel.
+///
+/// An analogous color scheme consists of three colors next to each other (30°
+/// apart) on the color wheel.
+pub trait Analogous: Sized {
+    /// Return the two additional colors of an analogous color scheme.
+    ///
+    /// The colors are ordered by ascending hue difference, or `(hue-30°,
+    /// hue+30°)`. Combined with the input color, these make up 3 adjacent
+    /// colors.
+    ///
+    /// The following example makes a 3 color analogous scheme:
+    ///
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(90deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(120deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(150deg, 80%, 50%);"></div>
+    ///
+    /// ```
+    /// use palette::{Hsl, color_theory::Analogous};
+    ///
+    /// let primary = Hsl::new_srgb(120.0f32, 0.8, 0.5);
+    /// let (analog_down, analog_up) = primary.analogous();
+    ///
+    /// let hues = (
+    ///     analog_down.hue.into_positive_degrees(),
+    ///     primary.hue.into_positive_degrees(),
+    ///     analog_up.hue.into_positive_degrees(),
+    /// );
+    ///
+    /// assert_eq!(hues, (90.0, 120.0, 150.0));
+    /// ```
+    fn analogous(self) -> (Self, Self);
+
+    /// Return the two furthest colors of a 5 color analogous color scheme.
+    ///
+    /// The colors are ordered by ascending hue difference, or `(hue-60°,
+    /// hue+60°)`. Combined with the input color and the colors from
+    /// `analogous`, these make up 5 adjacent colors.
+    ///
+    /// The following example makes a 5 color analogous scheme:
+    ///
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(60deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(90deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(120deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(150deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(180deg, 80%, 50%);"></div>
+    ///
+    /// ```
+    /// use palette::{Hsl, color_theory::Analogous};
+    ///
+    /// let primary = Hsl::new_srgb(120.0f32, 0.8, 0.5);
+    /// let (analog_down1, analog_up1) = primary.analogous();
+    /// let (analog_down2, analog_up2) = primary.analogous2();
+    ///
+    /// let hues = (
+    ///     analog_down2.hue.into_positive_degrees(),
+    ///     analog_down1.hue.into_positive_degrees(),
+    ///     primary.hue.into_positive_degrees(),
+    ///     analog_up1.hue.into_positive_degrees(),
+    ///     analog_up2.hue.into_positive_degrees(),
+    /// );
+    ///
+    /// assert_eq!(hues, (60.0, 90.0, 120.0, 150.0, 180.0));
+    /// ```
+    fn analogous2(self) -> (Self, Self);
+}
+
+impl<T> Analogous for T
+where
+    T: ShiftHue + Clone,
+    T::Scalar: Real,
+{
+    fn analogous(self) -> (Self, Self) {
+        let first = self.clone().shift_hue(T::Scalar::from_f64(330.0));
+        let second = self.shift_hue(T::Scalar::from_f64(30.0));
+
+        (first, second)
+    }
+
+    fn analogous2(self) -> (Self, Self) {
+        let first = self.clone().shift_hue(T::Scalar::from_f64(300.0));
+        let second = self.shift_hue(T::Scalar::from_f64(60.0));
+
+        (first, second)
+    }
+}
+
+/// Represents the triadic color scheme.
+///
+/// A triadic color scheme consists of thee colors at a 120° distance from each
+/// other.
+pub trait Triadic: Sized {
+    /// Return the two additional colors of a triadic color scheme.
+    ///
+    /// The colors are ordered by ascending relative hues, or `(hue+120°,
+    /// hue+240°)`.
+    ///
+    /// The following example makes a triadic scheme:
+    ///
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(120deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(240deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(0deg, 80%, 50%);"></div>
+    ///
+    /// ```
+    /// use palette::{Hsl, color_theory::Triadic};
+    ///
+    /// let primary = Hsl::new_srgb(120.0f32, 0.8, 0.5);
+    /// let (triadic1, triadic2) = primary.triadic();
+    ///
+    /// let hues = (
+    ///     primary.hue.into_positive_degrees(),
+    ///     triadic1.hue.into_positive_degrees(),
+    ///     triadic2.hue.into_positive_degrees(),
+    /// );
+    ///
+    /// assert_eq!(hues, (120.0, 240.0, 0.0));
+    /// ```
+    fn triadic(self) -> (Self, Self);
+}
+
+impl<T> Triadic for T
+where
+    T: ShiftHue + Clone,
+    T::Scalar: Real,
+{
+    fn triadic(self) -> (Self, Self) {
+        let first = self.clone().shift_hue(T::Scalar::from_f64(120.0));
+        let second = self.shift_hue(T::Scalar::from_f64(240.0));
+
+        (first, second)
+    }
+}
+
+/// Represents the tetradic, or square, color scheme.
+///
+/// A tetradic color scheme consists of four colors at a 90° distance from each
+/// other. These form two pairs of complementary colors.
+#[doc(alias = "Square")]
+pub trait Tetradic: Sized {
+    /// Return the three additional colors of a tetradic color scheme.
+    ///
+    /// The colors are ordered by ascending relative hues, or `(hue+90°,
+    /// hue+180°, hue+270°)`.
+    ///
+    /// The following example makes a tetradic scheme:
+    ///
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(120deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(210deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(300deg, 80%, 50%);"></div>
+    /// <div style="display: inline-block; width: 3em; height: 1em; border: 1px solid black; background: hsl(30deg, 80%, 50%);"></div>
+    ///
+    /// ```
+    /// use palette::{Hsl, color_theory::Tetradic};
+    ///
+    /// let primary = Hsl::new_srgb(120.0f32, 0.8, 0.5);
+    /// let (tetradic1, tetradic2, tetradic3) = primary.tetradic();
+    ///
+    /// let hues = (
+    ///     primary.hue.into_positive_degrees(),
+    ///     tetradic1.hue.into_positive_degrees(),
+    ///     tetradic2.hue.into_positive_degrees(),
+    ///     tetradic3.hue.into_positive_degrees(),
+    /// );
+    ///
+    /// assert_eq!(hues, (120.0, 210.0, 300.0, 30.0));
+    /// ```
+    fn tetradic(self) -> (Self, Self, Self);
+}
+
+impl<T> Tetradic for T
+where
+    T: ShiftHue + Clone,
+    T::Scalar: Real,
+{
+    fn tetradic(self) -> (Self, Self, Self) {
+        let first = self.clone().shift_hue(T::Scalar::from_f64(90.0));
+        let second = self.clone().shift_hue(T::Scalar::from_f64(180.0));
+        let third = self.shift_hue(T::Scalar::from_f64(270.0));
+
+        (first, second, third)
+    }
+}

--- a/palette/src/lab.rs
+++ b/palette/src/lab.rs
@@ -231,6 +231,7 @@ impl_lighten!(Lab<Wp> increase {l => [Self::min_l(), Self::max_l()]} other {a, b
 impl_premultiply!(Lab<Wp> {l, a, b} phantom: white_point);
 impl_euclidean_distance!(Lab<Wp> {l, a, b});
 impl_hyab!(Lab<Wp> {lightness: l, chroma1: a, chroma2: b});
+impl_lab_color_schemes!(Lab<Wp>[l, white_point]);
 
 impl<Wp, T> GetHue for Lab<Wp, T>
 where
@@ -389,6 +390,9 @@ mod test {
     use super::Lab;
     use crate::white_point::D65;
 
+    #[cfg(feature = "approx")]
+    use crate::Lch;
+
     test_convert_into_from_xyz!(Lab);
 
     #[cfg(feature = "approx")]
@@ -476,4 +480,6 @@ mod test {
         min: Lab::new(0.0f32, -128.0, -128.0),
         max: Lab::new(100.0, 127.0, 127.0)
     }
+
+    test_lab_color_schemes!(Lab/Lch [l, white_point]);
 }

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -347,6 +347,7 @@ pub mod bool_mask;
 pub mod cast;
 pub mod chromatic_adaptation;
 pub mod color_difference;
+pub mod color_theory;
 pub mod convert;
 pub mod encoding;
 pub mod hsl;

--- a/palette/src/luv.rs
+++ b/palette/src/luv.rs
@@ -233,6 +233,7 @@ impl_lighten!(Luv<Wp> increase {l => [Self::min_l(), Self::max_l()]} other {u, v
 impl_premultiply!(Luv<Wp> {l, u, v} phantom: white_point);
 impl_euclidean_distance!(Luv<Wp> {l, u, v});
 impl_hyab!(Luv<Wp> {lightness: l, chroma1: u, chroma2: v});
+impl_lab_color_schemes!(Luv<Wp>[u, v][l, white_point]);
 
 impl<Wp, T> GetHue for Luv<Wp, T>
 where
@@ -313,6 +314,9 @@ unsafe impl<Wp: 'static, T> bytemuck::Pod for Luv<Wp, T> where T: bytemuck::Pod 
 mod test {
     use super::Luv;
     use crate::white_point::D65;
+
+    #[cfg(feature = "approx")]
+    use crate::Lchuv;
 
     test_convert_into_from_xyz!(Luv);
 
@@ -417,4 +421,6 @@ mod test {
         min: Luv::new(0.0f32, -84.0, -135.0),
         max: Luv::new(100.0, 176.0, 108.0)
     }
+
+    test_lab_color_schemes!(Luv / Lchuv [u, v][l, white_point]);
 }

--- a/palette/src/macros.rs
+++ b/palette/src/macros.rs
@@ -37,3 +37,5 @@ mod copy_clone;
 mod hue;
 #[macro_use]
 mod random;
+#[macro_use]
+mod color_theory;

--- a/palette/src/macros/color_theory.rs
+++ b/palette/src/macros/color_theory.rs
@@ -1,0 +1,145 @@
+macro_rules! impl_lab_color_schemes {
+    ($color_ty: ident $(<$phantom_ty: ident>)? [$a: ident, $b: ident] [$($other_component: ident),+]) => {
+        impl<$($phantom_ty,)? T> crate::color_theory::Complementary for $color_ty<$($phantom_ty,)? T>
+        where
+            T: core::ops::Neg<Output = T>,
+        {
+            fn complementary(self) -> Self {
+                Self {
+                    $a: -self.$a,
+                    $b: -self.$b,
+                    $($other_component: self.$other_component,)+
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T, A> crate::color_theory::Complementary for crate::Alpha<$color_ty<$($phantom_ty,)? T>, A>
+        where
+            $color_ty<$($phantom_ty,)? T>: crate::color_theory::Complementary,
+        {
+            fn complementary(self) -> Self {
+                crate::Alpha {
+                    color: self.color.complementary(),
+                    alpha: self.alpha
+                }
+            }
+        }
+
+        impl<$($phantom_ty,)? T> crate::color_theory::Tetradic for $color_ty<$($phantom_ty,)? T>
+        where
+            T: core::ops::Neg<Output = T> + Clone,
+        {
+            fn tetradic(self) -> (Self, Self, Self) {
+                use crate::color_theory::Complementary;
+
+                let first = Self {
+                    $a: -self.$b.clone(),
+                    $b: self.$a.clone(),
+                    $($other_component: self.$other_component.clone(),)+
+                };
+
+                let second = self.clone().complementary();
+                let third = first.clone().complementary();
+
+                (first, second, third)
+            }
+        }
+
+        impl<$($phantom_ty,)? T, A> crate::color_theory::Tetradic for crate::Alpha<$color_ty<$($phantom_ty,)? T>, A>
+        where
+            $color_ty<$($phantom_ty,)? T>: crate::color_theory::Tetradic,
+            A: Clone,
+        {
+            fn tetradic(self) -> (Self, Self, Self) {
+                let (color1, color2, color3) = self.color.tetradic();
+
+                (
+                    crate::Alpha{
+                        color: color1,
+                        alpha: self.alpha.clone(),
+                    },
+                    crate::Alpha{
+                        color: color2,
+                        alpha: self.alpha.clone(),
+                    },
+                    crate::Alpha{
+                        color: color3,
+                        alpha: self.alpha,
+                    },
+                )
+            }
+        }
+    };
+    ($color_ty: ident $(<$phantom_ty:ident>)? [$($other_component: ident),+]) => {
+        impl_lab_color_schemes!($color_ty $(<$phantom_ty>)? [a, b] [$($other_component),+]);
+    };
+}
+
+#[cfg(test)]
+macro_rules! test_lab_color_schemes {
+    ($color_ty: ident / $radial_ty: ident [$a: ident, $b: ident] [$($other_component: ident),+]) => {
+        #[cfg(feature = "approx")]
+        #[test]
+        fn complementary() {
+            use crate::{color_theory::Complementary, convert::FromColorUnclamped};
+
+            let quadrant1: $color_ty = $color_ty::new(0.5f32, 0.1, 0.3);
+            let quadrant2: $color_ty = $color_ty::new(0.5f32, 0.1, -0.3);
+            let quadrant3: $color_ty = $color_ty::new(0.5f32, -0.1, -0.3);
+            let quadrant4: $color_ty = $color_ty::new(0.5f32, -0.1, 0.3);
+
+            let quadrant1_radial = $radial_ty::from_color_unclamped(quadrant1);
+            let quadrant2_radial = $radial_ty::from_color_unclamped(quadrant2);
+            let quadrant3_radial = $radial_ty::from_color_unclamped(quadrant3);
+            let quadrant4_radial = $radial_ty::from_color_unclamped(quadrant4);
+
+            assert_relative_eq!(quadrant1.complementary(), $color_ty::from_color_unclamped(quadrant1_radial.complementary()), epsilon = 0.000001);
+            assert_relative_eq!(quadrant2.complementary(), $color_ty::from_color_unclamped(quadrant2_radial.complementary()), epsilon = 0.000001);
+            assert_relative_eq!(quadrant3.complementary(), $color_ty::from_color_unclamped(quadrant3_radial.complementary()), epsilon = 0.000001);
+            assert_relative_eq!(quadrant4.complementary(), $color_ty::from_color_unclamped(quadrant4_radial.complementary()), epsilon = 0.000001);
+        }
+
+        #[cfg(feature = "approx")]
+        #[test]
+        fn tetradic() {
+            use crate::{color_theory::Tetradic, convert::FromColorUnclamped};
+            fn convert_tuple<T, U>(input: (T, T, T)) -> (U, U, U)
+            where
+                U: FromColorUnclamped<T>,
+            {
+                (
+                    U::from_color_unclamped(input.0),
+                    U::from_color_unclamped(input.1),
+                    U::from_color_unclamped(input.2),
+                )
+            }
+
+            fn check_tuples(a: ($color_ty, $color_ty, $color_ty), b: ($color_ty, $color_ty, $color_ty)) {
+                let (a1, a2, a3) = a;
+                let (b1, b2, b3) = b;
+
+                assert_relative_eq!(a1, b1, epsilon = 0.000001);
+                assert_relative_eq!(a2, b2, epsilon = 0.000001);
+                assert_relative_eq!(a3, b3, epsilon = 0.000001);
+            }
+
+            let quadrant1 = $color_ty::new(0.5f32, 0.1, 0.3);
+            let quadrant2 = $color_ty::new(0.5f32, 0.1, -0.3);
+            let quadrant3 = $color_ty::new(0.5f32, -0.1, -0.3);
+            let quadrant4 = $color_ty::new(0.5f32, -0.1, 0.3);
+
+            let quadrant1_radial = $radial_ty::from_color_unclamped(quadrant1);
+            let quadrant2_radial = $radial_ty::from_color_unclamped(quadrant2);
+            let quadrant3_radial = $radial_ty::from_color_unclamped(quadrant3);
+            let quadrant4_radial = $radial_ty::from_color_unclamped(quadrant4);
+
+            check_tuples(quadrant1.tetradic(), convert_tuple::<_, $color_ty>(quadrant1_radial.tetradic()));
+            check_tuples(quadrant2.tetradic(), convert_tuple::<_, $color_ty>(quadrant2_radial.tetradic()));
+            check_tuples(quadrant3.tetradic(), convert_tuple::<_, $color_ty>(quadrant3_radial.tetradic()));
+            check_tuples(quadrant4.tetradic(), convert_tuple::<_, $color_ty>(quadrant4_radial.tetradic()));
+        }
+    };
+    ($color_ty: ident / $radial_ty: ident [$($other_component: ident),+]) => {
+        test_lab_color_schemes!($color_ty / $radial_ty [a, b] [$($other_component),+]);
+    };
+}

--- a/palette/src/oklab/properties.rs
+++ b/palette/src/oklab/properties.rs
@@ -33,6 +33,7 @@ impl_hyab!(Oklab {
     chroma1: a,
     chroma2: b
 });
+impl_lab_color_schemes!(Oklab[l]);
 
 impl<T> GetHue for Oklab<T>
 where
@@ -72,4 +73,12 @@ where
 
         crate::contrast_ratio(xyz1.y, xyz2.y)
     }
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "approx")]
+    use crate::{Oklab, Oklch};
+
+    test_lab_color_schemes!(Oklab / Oklch[l]);
 }

--- a/palette/src/serde/alpha_serializer.rs
+++ b/palette/src/serde/alpha_serializer.rs
@@ -79,13 +79,13 @@ where
         })
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         let mut serializer = self.serialize_tuple_struct(name, 1)?;
         serializer.serialize_field(value)?;
@@ -162,9 +162,9 @@ where
         alpha_serializer_error()
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         alpha_serializer_error()
     }
@@ -198,7 +198,7 @@ where
         alpha_serializer_error()
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -206,7 +206,7 @@ where
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         alpha_serializer_error()
     }
@@ -239,9 +239,9 @@ where
 
     type Error = S::Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_element(value)
     }
@@ -261,9 +261,9 @@ where
 
     type Error = S::Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_element(value)
     }
@@ -283,9 +283,9 @@ where
 
     type Error = S::Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_field(value)
     }
@@ -305,9 +305,9 @@ where
 
     type Error = S::Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_field(value)
     }
@@ -327,28 +327,24 @@ where
 
     type Error = S::Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_key(key)
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_value(value)
     }
 
-    fn serialize_entry<K: ?Sized, V: ?Sized>(
-        &mut self,
-        key: &K,
-        value: &V,
-    ) -> Result<(), Self::Error>
+    fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>
     where
-        K: Serialize,
-        V: Serialize,
+        K: Serialize + ?Sized,
+        V: Serialize + ?Sized,
     {
         self.inner.serialize_entry(key, value)
     }
@@ -368,13 +364,9 @@ where
 
     type Error = S::Error;
 
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_field(key, value)
     }
@@ -398,13 +390,9 @@ where
 
     type Error = S::Error;
 
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         self.inner.serialize_field(key, value)
     }


### PR DESCRIPTION
This adds traits for the complementary, split complementary, analogous, triadic and tetradic color schemes. A trait for the complementary color was requested in #383, but all of these may be useful.