### PR TITLE
chore(bench): update CodSpeed/action to v2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build the benchmark target(s)
         run: cargo codspeed build -p benchmarks --features all_features
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
           run: cargo codspeed run
           working-directory: integration_tests # mimics how tests work, so the colors CSV can be found


### PR DESCRIPTION
Upgrading to the v2 of https://github.com/CodSpeedHQ/action will bring a better base run selection algorithm, better logging, and continued support.

