### PR TITLE
chore(bench): make benchmarks work again

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,5 +32,4 @@ jobs:
         uses: CodSpeedHQ/action@v2
         with:
           run: cargo codspeed run
-          working-directory: integration_tests # mimics how tests work, so the colors CSV can be found
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/benchmarks/benches/cie.rs
+++ b/benchmarks/benches/cie.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 use palette::{
     color_difference::{Ciede2000, DeltaE, ImprovedDeltaE},
@@ -22,7 +24,7 @@ use data_color_mine::{load_data, ColorMine};
 
 fn cie_conversion(c: &mut Criterion) {
     let mut group = c.benchmark_group("Cie family");
-    let mut colormine: Vec<ColorMine<f32>> = load_data();
+    let mut colormine: Vec<ColorMine<f32>> = load_data(Some(Path::new("../integration_tests/tests/convert/data_color_mine.csv")));
     colormine.truncate(colormine.len() - colormine.len() % 8);
     assert_eq!(
         colormine.len() % 8,
@@ -121,7 +123,7 @@ fn cie_conversion(c: &mut Criterion) {
 
 fn cie_delta_e(c: &mut Criterion) {
     let mut group = c.benchmark_group("Cie delta E");
-    let colormine: Vec<ColorMine<f32>> = load_data();
+    let colormine: Vec<ColorMine<f32>> = load_data(Some(Path::new("../integration_tests/tests/convert/data_color_mine.csv")));
 
     let lab: Vec<Lab> = colormine
         .iter()

--- a/benchmarks/benches/rgb.rs
+++ b/benchmarks/benches/rgb.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 use palette::convert::FromColorUnclamped;
 use palette::encoding;
@@ -39,7 +41,7 @@ use data_color_mine::{load_data, ColorMine};
 
 fn rgb_conversion(c: &mut Criterion) {
     let mut group = c.benchmark_group("Rgb family");
-    let mut colormine: Vec<ColorMine<f32>> = load_data();
+    let mut colormine: Vec<ColorMine<f32>> = load_data(Some(Path::new("../integration_tests/tests/convert/data_color_mine.csv")));
     colormine.truncate(colormine.len() - colormine.len() % 8);
     assert_eq!(
         colormine.len() % 8,

--- a/integration_tests/tests/convert/data_color_mine.rs
+++ b/integration_tests/tests/convert/data_color_mine.rs
@@ -2,6 +2,8 @@
 List of color from www.colormine.org
 */
 
+use std::path::Path;
+
 use approx::assert_relative_eq;
 use lazy_static::lazy_static;
 use serde_derive::Deserialize;
@@ -318,16 +320,18 @@ where
 }
 
 lazy_static! {
-    static ref TEST_DATA: Vec<ColorMine<f64>> = load_data();
+    static ref TEST_DATA: Vec<ColorMine<f64>> = load_data(None);
 }
 
-pub fn load_data<F>() -> Vec<ColorMine<F>>
+pub fn load_data<F>(data_path: Option<&Path>) -> Vec<ColorMine<F>>
 where
     F: for<'a> serde::Deserialize<'a>,
     ColorMineRaw<F>: Into<ColorMine<F>>,
 {
-    let mut rdr = csv::Reader::from_path("tests/convert/data_color_mine.csv")
-        .expect("csv file could not be loaded in tests for color mine data");
+    let mut rdr = csv::Reader::from_path(
+        data_path.unwrap_or_else(|| Path::new("tests/convert/data_color_mine.csv")),
+    )
+    .expect("csv file could not be loaded in tests for color mine data");
     let mut color_data: Vec<ColorMine<F>> = Vec::new();
     for record in rdr.deserialize() {
         let r: ColorMineRaw<F> =


### PR DESCRIPTION
Make benchmarks and CodSpeed work again.

Implemented after this discussion: https://github.com/Ogeon/palette/pull/391#issuecomment-2080461609

This is not a long term fix, but it has the merit of making everything work again.