### PR TITLE
Increment MSRV to 1.61.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: dtolnay/rust-toolchain@1.61.0
         with:
           components: clippy
       - uses: taiki-e/install-action@cargo-hack

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
+This version of Palette has been automatically tested with Rust version `1.61.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 
 ## Contributing
 

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2018"
 resolver = "2"
 categories = ["graphics", "multimedia::images", "no-std"]
 build = "build/main.rs"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 
 [features]
 default = ["named_from_str", "std", "approx"]

--- a/palette/README.md
+++ b/palette/README.md
@@ -15,7 +15,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
+This version of Palette has been automatically tested with Rust version `1.61.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 
 ## Getting Started
 

--- a/palette/src/convert/from_into_color_mut.rs
+++ b/palette/src/convert/from_into_color_mut.rs
@@ -132,8 +132,8 @@ where
 
 impl<T, U> FromColorMut<[U]> for [T]
 where
-    T: FromColorMut<U> + ArrayCast + ?Sized,
-    U: FromColorMut<T> + ArrayCast<Array = T::Array> + ?Sized,
+    T: FromColorMut<U> + ArrayCast,
+    U: FromColorMut<T> + ArrayCast<Array = T::Array>,
 {
     #[inline]
     fn from_color_mut(colors: &mut [U]) -> FromColorMutGuard<Self, [U]> {

--- a/palette/src/convert/from_into_color_unclamped_mut.rs
+++ b/palette/src/convert/from_into_color_unclamped_mut.rs
@@ -133,8 +133,8 @@ where
 
 impl<T, U> FromColorUnclampedMut<[U]> for [T]
 where
-    T: FromColorUnclampedMut<U> + ArrayCast + ?Sized,
-    U: FromColorUnclampedMut<T> + ArrayCast<Array = T::Array> + ?Sized,
+    T: FromColorUnclampedMut<U> + ArrayCast,
+    U: FromColorUnclampedMut<T> + ArrayCast<Array = T::Array>,
 {
     #[inline]
     fn from_color_unclamped_mut(colors: &mut [U]) -> FromColorUnclampedMutGuard<Self, [U]> {

--- a/palette/src/stimulus.rs
+++ b/palette/src/stimulus.rs
@@ -294,11 +294,11 @@ mod test {
             1.0,
             1.4,
             f32::from_bits(0x4b44_0000),
-            core::f32::MAX,
-            core::f32::MIN,
-            core::f32::NAN,
-            core::f32::INFINITY,
-            core::f32::NEG_INFINITY,
+            f32::MAX,
+            f32::MIN,
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
         ];
 
         let expected = vec![
@@ -333,11 +333,11 @@ mod test {
             1.0,
             1.4,
             f64::from_bits(0x4334_0000_0000_0000),
-            core::f64::MAX,
-            core::f64::MIN,
-            core::f64::NAN,
-            core::f64::INFINITY,
-            core::f64::NEG_INFINITY,
+            f64::MAX,
+            f64::MIN,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
         ];
 
         let expected = vec![

--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["palette", "derive", "macros"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 resolver = "2"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 
 [lib]
 proc-macro = true

--- a/palette_derive/README.md
+++ b/palette_derive/README.md
@@ -4,7 +4,7 @@ Contains derive macros for the [`palette`](https://crates.io/crates/palette/) cr
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.60.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
+This version of Palette has been automatically tested with Rust version `1.61.0` and the `stable`, `beta`, and `nightly` channels. Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 
 ## License
 


### PR DESCRIPTION
Following the change of MSRV in `syn`, the MSRV of Palette is incremented from 1.60.0 to 1.61.0.