### PR TITLE
Make hue `::from_degrees` and some `palette::cast::*` functions `const fn`

### DIFF
--- a/palette/src/cast/array.rs
+++ b/palette/src/cast/array.rs
@@ -238,15 +238,12 @@ where
 /// let array3 = <&[_; 3]>::from(&color);
 /// ```
 #[inline]
-pub fn into_array_ref<T>(value: &T) -> &T::Array
+pub const fn into_array_ref<T>(value: &T) -> &T::Array
 where
     T: ArrayCast,
 {
-    assert_eq!(core::mem::size_of::<T::Array>(), core::mem::size_of::<T>());
-    assert_eq!(
-        core::mem::align_of::<T::Array>(),
-        core::mem::align_of::<T>()
-    );
+    assert!(core::mem::size_of::<T::Array>() == core::mem::size_of::<T>());
+    assert!(core::mem::align_of::<T::Array>() == core::mem::align_of::<T>());
 
     let value: *const T = value;
 
@@ -282,15 +279,12 @@ where
 /// let color3 = <&Srgb<u8>>::from(&array);
 /// ```
 #[inline]
-pub fn from_array_ref<T>(value: &T::Array) -> &T
+pub const fn from_array_ref<T>(value: &T::Array) -> &T
 where
     T: ArrayCast,
 {
-    assert_eq!(core::mem::size_of::<T::Array>(), core::mem::size_of::<T>());
-    assert_eq!(
-        core::mem::align_of::<T::Array>(),
-        core::mem::align_of::<T>()
-    );
+    assert!(core::mem::size_of::<T::Array>() == core::mem::size_of::<T>());
+    assert!(core::mem::align_of::<T::Array>() == core::mem::align_of::<T>());
 
     let value: *const T::Array = value;
 

--- a/palette/src/cast/uint.rs
+++ b/palette/src/cast/uint.rs
@@ -110,12 +110,12 @@ where
 /// assert_eq!(cast::into_uint_ref(&color), &0xFF17C64C);
 /// ```
 #[inline]
-pub fn into_uint_ref<T>(value: &T) -> &T::Uint
+pub const fn into_uint_ref<T>(value: &T) -> &T::Uint
 where
     T: UintCast,
 {
-    assert_eq!(core::mem::size_of::<T::Uint>(), core::mem::size_of::<T>());
-    assert_eq!(core::mem::align_of::<T::Uint>(), core::mem::align_of::<T>());
+    assert!(core::mem::size_of::<T::Uint>() == core::mem::size_of::<T>());
+    assert!(core::mem::align_of::<T::Uint>() == core::mem::align_of::<T>());
 
     let value: *const T = value;
 
@@ -133,12 +133,12 @@ where
 /// assert_eq!(cast::from_uint_ref::<PackedArgb>(&0xFF17C64C), &color);
 /// ```
 #[inline]
-pub fn from_uint_ref<T>(value: &T::Uint) -> &T
+pub const fn from_uint_ref<T>(value: &T::Uint) -> &T
 where
     T: UintCast,
 {
-    assert_eq!(core::mem::size_of::<T::Uint>(), core::mem::size_of::<T>());
-    assert_eq!(core::mem::align_of::<T::Uint>(), core::mem::align_of::<T>());
+    assert!(core::mem::size_of::<T::Uint>() == core::mem::size_of::<T>());
+    assert!(core::mem::align_of::<T::Uint>() == core::mem::align_of::<T>());
 
     let value: *const T::Uint = value;
 

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -81,7 +81,7 @@ macro_rules! make_hues {
         impl<T: RealAngle> $name<T> {
             /// Create a new hue from degrees. This is an alias for `new`.
             #[inline]
-            pub fn from_degrees(degrees: T) -> Self {
+            pub const fn from_degrees(degrees: T) -> Self {
                 Self::new(degrees)
             }
 


### PR DESCRIPTION
This makes the following functions `const fn`, as allowed by Rust 1.61.0:

* `::from_degrees` for hue types
* `palette::cast::into_array_ref`
* `palette::cast::from_array_ref`
* `palette::cast::into_uint_ref`
* `palette::cast::from_uint_ref`