### PR TITLE
Add conversion matrix and `Convert{Once}` traits

### DIFF
--- a/benchmarks/benches/matrix.rs
+++ b/benchmarks/benches/matrix.rs
@@ -1,36 +1,17 @@
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 
 use palette::encoding;
-use palette::matrix::{
-    matrix_inverse, multiply_3x3, multiply_rgb_to_xyz, multiply_xyz, multiply_xyz_to_rgb,
-    rgb_to_xyz_matrix,
-};
-use palette::white_point::{WhitePoint, D65};
-use palette::{LinSrgb, Xyz};
+use palette::matrix::{matrix_inverse, multiply_3x3, rgb_to_xyz_matrix};
 
 fn matrix(c: &mut Criterion) {
     let mut group = c.benchmark_group("Matrix functions");
 
-    let inp1 = [0.1, 0.2, 0.3, 0.3, 0.2, 0.1, 0.2, 0.1, 0.3];
-    let inp2 = Xyz::new(0.4, 0.6, 0.8);
-    let inp3 = [1.0f32, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
-    let inp4 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
+    let inp1 = [1.0f32, 2.0, 3.0, 3.0, 2.0, 1.0, 2.0, 1.0, 3.0];
+    let inp2 = [4.0, 5.0, 6.0, 6.0, 5.0, 4.0, 4.0, 6.0, 5.0];
     let inverse: [f32; 9] = [3.0, 0.0, 2.0, 2.0, 0.0, -2.0, 0.0, 1.0, 1.0];
-    let color = LinSrgb::new(0.2f32, 0.8, 0.4);
-    let mat3 = rgb_to_xyz_matrix::<encoding::Srgb, f32>();
-    let wp: Xyz<D65, f32> = D65::get_xyz().with_white_point();
 
-    group.bench_function("multiply_xyz", |b| {
-        b.iter(|| multiply_xyz::<_>(black_box(inp1), black_box(inp2)))
-    });
-    group.bench_function("multiply_xyz_to_rgb", |b| {
-        b.iter(|| multiply_xyz_to_rgb::<encoding::Srgb, _, _>(black_box(inp1), black_box(wp)))
-    });
-    group.bench_function("multiply_rgb_to_xyz", |b| {
-        b.iter(|| multiply_rgb_to_xyz(black_box(mat3), black_box(color)))
-    });
     group.bench_function("multiply_3x3", |b| {
-        b.iter(|| multiply_3x3(black_box(inp3), black_box(inp4)))
+        b.iter(|| multiply_3x3(black_box(inp1), black_box(inp2)))
     });
     group.bench_with_input("matrix_inverse", &inverse, |b, inverse| {
         b.iter(|| matrix_inverse(*inverse))

--- a/palette/src/convert/matrix3.rs
+++ b/palette/src/convert/matrix3.rs
@@ -1,0 +1,248 @@
+use core::marker::PhantomData;
+
+use crate::{
+    cast::{self, ArrayCast},
+    matrix::{matrix_inverse, multiply_3x3, multiply_3x3_and_vec3},
+    num::{Arithmetics, IsValidDivisor, One, Recip, Zero},
+    ArrayExt, Mat3,
+};
+
+use super::{Convert, ConvertOnce};
+
+/// A statically typed 3x3 conversion matrix.
+///
+/// It's applied via [`Convert`] or [`ConvertOnce`] and helps making some
+/// conversions more efficient by only needing to be constructed once.
+///
+/// ```
+/// use palette::{
+///     Xyz, Srgb,
+///     convert::{Convert, Matrix3},
+/// };
+///
+/// // Multiple matrices can be combined into one:
+/// let matrix = Xyz::matrix_from_rgb()
+///     .then(Matrix3::scale(0.5, 0.5, 0.5));
+///
+/// let rgb = Srgb::new(0.8f32, 0.3, 0.3).into_linear();
+/// let scaled_xyz = matrix.convert(rgb);
+/// ```
+pub struct Matrix3<I, O>
+where
+    I: ArrayCast,
+{
+    matrix: Mat3<<I::Array as ArrayExt>::Item>,
+    transform: PhantomData<fn(I) -> O>,
+}
+
+impl<I, O> Convert<I, O> for Matrix3<I, O>
+where
+    Self: ConvertOnce<I, O> + Copy,
+    I: ArrayCast,
+{
+    #[inline]
+    fn convert(&self, input: I) -> O {
+        Self::convert_once(*self, input)
+    }
+}
+
+impl<T, I, O> ConvertOnce<I, O> for Matrix3<I, O>
+where
+    T: Arithmetics,
+    I: ArrayCast<Array = [T; 3]>,
+    O: ArrayCast<Array = I::Array>,
+{
+    #[inline]
+    fn convert_once(self, input: I) -> O {
+        cast::from_array(multiply_3x3_and_vec3(self.matrix, cast::into_array(input)))
+    }
+}
+
+impl<T, C> Matrix3<C, C>
+where
+    C: ArrayCast<Array = [T; 3]>,
+{
+    /// Produce an identity matrix, which leaves the components unchanged.
+    ///
+    /// ```
+    /// use palette::{Srgb, convert::{Matrix3, Convert}};
+    ///
+    /// let matrix = Matrix3::identity();
+    ///
+    /// let input = Srgb::new(0.1, 0.2, 0.3);
+    /// let output = matrix.convert(input);
+    ///
+    /// assert_eq!(input, output);
+    /// ```
+    #[rustfmt::skip]
+    #[inline]
+    pub fn identity() -> Self where T: One + Zero {
+        Self::from_array([
+            T::one(), T::zero(), T::zero(),
+            T::zero(), T::one(), T::zero(),
+            T::zero(), T::zero(), T::one(),
+        ])
+    }
+
+    /// Produce a scale matrix, which scales each component separately.
+    ///
+    /// ```
+    /// use palette::{Srgb, convert::{Matrix3, Convert}};
+    ///
+    /// let matrix = Matrix3::scale(0.1, 0.2, 0.3);
+    ///
+    /// let input = Srgb::new(1.0, 1.0, 1.0);
+    /// let output = matrix.convert(input);
+    ///
+    /// assert_eq!(Srgb::new(0.1, 0.2, 0.3), output);
+    /// ```
+    #[rustfmt::skip]
+    #[inline]
+    pub fn scale(s1: T, s2: T, s3: T) -> Self where T: Zero {
+        Self::from_array([
+            s1, T::zero(), T::zero(),
+            T::zero(), s2, T::zero(),
+            T::zero(), T::zero(), s3,
+        ])
+    }
+}
+
+impl<T, I, O> Matrix3<I, O>
+where
+    I: ArrayCast<Array = [T; 3]>,
+    O: ArrayCast<Array = I::Array>,
+{
+    /// Chain another matrix after this one.
+    ///
+    /// The combined matrix will result in the same values as if the two
+    /// matrices were applied separately, at the cost of only applying a single
+    /// matrix. This may speed up computations if the matrix can be constructed
+    /// once, and applied multiple times.
+    ///
+    /// ```
+    /// use palette::{
+    ///     lms::VonKriesLms, Xyz, Srgb,
+    ///     convert::Convert,
+    ///     white_point::D65,
+    /// };
+    /// use approx::assert_relative_eq;
+    ///
+    /// let rgb_to_xyz = Xyz::matrix_from_rgb();
+    /// let xyz_to_lms = VonKriesLms::<D65, _>::matrix_from_xyz();
+    ///
+    /// let rgb_to_lms = rgb_to_xyz.then(xyz_to_lms);
+    ///
+    /// let rgb = Srgb::new(0.8f32, 0.3, 0.3).into_linear();
+    /// let lms = rgb_to_lms.convert(rgb);
+    ///
+    /// // Applying the matrices separately for comparison:
+    /// let xyz = rgb_to_xyz.convert(rgb);
+    /// let lms2 = xyz_to_lms.convert(xyz);
+    /// assert_relative_eq!(lms, lms2);
+    /// ```
+    #[inline]
+    pub fn then<U>(self, next: Matrix3<O, U>) -> Matrix3<I, U>
+    where
+        U: ArrayCast<Array = I::Array>,
+        T: Arithmetics + Clone,
+    {
+        Matrix3 {
+            matrix: multiply_3x3(next.matrix, self.matrix),
+            transform: PhantomData,
+        }
+    }
+
+    /// Invert the matrix to create a reversed conversion.
+    ///
+    /// ## Panics
+    ///
+    /// A matrix that cannot be inverted will result in a panic.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use palette::{
+    ///     Xyz, Srgb,
+    ///     convert::Convert,
+    /// };
+    /// use approx::assert_relative_eq;
+    ///
+    /// let rgb_to_xyz = Xyz::matrix_from_rgb();
+    /// let xyz_to_rgb = rgb_to_xyz.invert();
+    ///
+    /// let rgb = Srgb::new(0.8f32, 0.3, 0.3).into_linear();
+    /// let xyz = rgb_to_xyz.convert(rgb);
+    /// let rgb2 = xyz_to_rgb.convert(xyz);
+    ///
+    /// assert_relative_eq!(rgb, rgb2);
+    /// ```
+    #[inline]
+    pub fn invert(self) -> Matrix3<O, I>
+    where
+        T: Recip + IsValidDivisor<Mask = bool> + Arithmetics + Clone,
+    {
+        Matrix3 {
+            matrix: matrix_inverse(self.matrix),
+            transform: PhantomData,
+        }
+    }
+
+    /// Create a conversion matrix from a plain array.
+    ///
+    /// The matrix elements are expected to be in row-major order.
+    ///
+    /// <p class="warning">
+    /// This doesn't verify that the conversion results in correct or expected values.
+    /// </p>
+    ///
+    /// ```
+    /// use palette::{Srgb, convert::{Matrix3, Convert}};
+    ///
+    /// let matrix = Matrix3::from_array([
+    ///     1.0, 0.0, 0.0,
+    ///     0.0, 1.0, 0.0,
+    ///     0.0, 0.0, 1.0,
+    /// ]);
+    ///
+    /// let input = Srgb::new(0.1, 0.2, 0.3);
+    /// let output = matrix.convert(input);
+    ///
+    /// assert_eq!(input, output);
+    /// ```
+    #[inline]
+    pub const fn from_array(matrix: Mat3<T>) -> Self {
+        Self {
+            matrix,
+            transform: PhantomData,
+        }
+    }
+
+    /// Extract the inner array.
+    ///
+    /// The matrix elements are stored in row-major order.
+    #[inline]
+    pub fn into_array(self) -> Mat3<T> {
+        self.matrix
+    }
+}
+
+impl<I, O> Clone for Matrix3<I, O>
+where
+    I: ArrayCast,
+    <I::Array as ArrayExt>::Item: Clone,
+{
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            matrix: self.matrix.clone(),
+            transform: self.transform,
+        }
+    }
+}
+
+impl<I, O> Copy for Matrix3<I, O>
+where
+    I: ArrayCast,
+    <I::Array as ArrayExt>::Item: Copy,
+{
+}

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -9,7 +9,7 @@ use crate::{
     bool_mask::HasBoolMask,
     convert::{FromColorUnclamped, IntoColorUnclamped},
     encoding::{IntoLinear, Srgb},
-    matrix::multiply_xyz,
+    matrix::multiply_3x3_and_vec3,
     num::{Arithmetics, Cbrt, Hypot, MinMax, One, Powi, Real, Sqrt, Trigonometry, Zero},
     ok_utils::{toe_inv, ChromaValues, LC, ST},
     rgb::{Rgb, RgbSpace, RgbStandard},
@@ -267,15 +267,8 @@ where
         let m1 = m1();
         let m2 = m2();
 
-        let Xyz {
-            x: l, y: m, z: s, ..
-        } = multiply_xyz(m1, color.with_white_point());
-
-        let l_m_s_ = Xyz::new(l.cbrt(), m.cbrt(), s.cbrt());
-
-        let Xyz {
-            x: l, y: a, z: b, ..
-        } = multiply_xyz(m2, l_m_s_);
+        let [l, m, s] = multiply_3x3_and_vec3(m1, color.into());
+        let [l, a, b] = multiply_3x3_and_vec3(m2, [l.cbrt(), m.cbrt(), s.cbrt()]);
 
         Self::new(l, a, b)
     }


### PR DESCRIPTION
Adds a few basic tools for reusable converters, similar to what's discussed in #396:

 * `convert::Matrix3`, which represents a 3x3 conversion matrix from one type to another. It may speed up multi-step conversions that can be simplified as a single matrix.
 * `convert::Convert` and `convert::ConvertOnce` traits for abstracting over types that can convert other types, similar to `Fn` and `FnOnce` in relation to each other. They are implemented by `convert::Matrix3` and `cam16::BakedParameters`.
* `Rgb::matrix_from_xyz`, `Xyz::matrix_from_rgb`, `Xyz::matrix_from_lms` and `Lms::matrix_from_xyz` as initial building blocks for composing conversion matrices.

Some old matrix code has also been cleaned up or replaced. The `matrix` module is not considered public, so its content should not be relied upon.