### PR TITLE
Add Adobe RGB

### DIFF
--- a/palette/src/encoding.rs
+++ b/palette/src/encoding.rs
@@ -5,11 +5,13 @@
 //! represented as type parameters in Palette, as a form of type branding, to
 //! prevent accidental mixups.
 
+pub use self::adobe::AdobeRgb;
 pub use self::gamma::{F2p2, Gamma};
 pub use self::linear::Linear;
 pub use self::rec_standards::{Rec2020, Rec709};
 pub use self::srgb::Srgb;
 
+pub mod adobe;
 pub mod gamma;
 pub mod linear;
 pub mod rec_standards;

--- a/palette/src/encoding/adobe.rs
+++ b/palette/src/encoding/adobe.rs
@@ -1,0 +1,109 @@
+//! The Adobe RGB (1998) standard.
+
+use crate::{
+    encoding::gamma::GammaFn,
+    luma::LumaStandard,
+    num::Real,
+    rgb::{Primaries, RgbSpace, RgbStandard},
+    white_point::{Any, D65},
+    Mat3, Yxy,
+};
+
+/// The Adobe RGB (1998) (a.k.a. opRGB) color space and standard.
+///
+/// This color space was designed to encompass most colors achievable by CMYK
+/// printers using RGB primaries. It has a wider color gamut than sRGB, primarily
+/// in cyan-green hues.
+///
+/// The Adobe RGB standard uses a gamma 2.2 transfer function.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AdobeRgb;
+
+impl<T: Real> Primaries<T> for AdobeRgb {
+    // Primary values from https://www.adobe.com/digitalimag/pdfs/AdobeRGB1998.pdf with
+    // `luma` values taken from the conversion matrix in `RgbSpace` implementation.
+    fn red() -> Yxy<Any, T> {
+        Yxy::new(
+            T::from_f64(0.6400),
+            T::from_f64(0.3300),
+            T::from_f64(0.2974),
+        )
+    }
+    fn green() -> Yxy<Any, T> {
+        Yxy::new(
+            T::from_f64(0.2100),
+            T::from_f64(0.7100),
+            T::from_f64(0.6273),
+        )
+    }
+    fn blue() -> Yxy<Any, T> {
+        Yxy::new(
+            T::from_f64(0.1500),
+            T::from_f64(0.0600),
+            T::from_f64(0.0753),
+        )
+    }
+}
+
+impl RgbSpace for AdobeRgb {
+    type Primaries = AdobeRgb;
+    type WhitePoint = D65;
+
+    #[rustfmt::skip]
+    #[inline(always)]
+    fn rgb_to_xyz_matrix() -> Option<Mat3<f64>> {
+        // Matrix from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+        Some([
+            0.5767309, 0.1855540, 0.1881852,
+            0.2973769, 0.6273491, 0.0752741,
+            0.0270343, 0.0706872, 0.9911085,
+        ])
+    }
+
+    #[rustfmt::skip]
+    #[inline(always)]
+    fn xyz_to_rgb_matrix() -> Option<Mat3<f64>> {
+        // Matrix from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+        Some([
+             2.0413690, -0.5649464, -0.3446944,
+            -0.9692660,  1.8760108,  0.0415560,
+             0.0134474, -0.1183897,  1.0154096,
+        ])
+    }
+}
+
+impl RgbStandard for AdobeRgb {
+    type Space = AdobeRgb;
+    type TransferFn = GammaFn;
+}
+
+impl LumaStandard for AdobeRgb {
+    type WhitePoint = D65;
+    type TransferFn = GammaFn;
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "approx")]
+    mod conversion {
+        use crate::{
+            encoding::adobe::AdobeRgb,
+            matrix::{matrix_inverse, rgb_to_xyz_matrix},
+            rgb::RgbSpace,
+        };
+
+        #[test]
+        fn rgb_to_xyz() {
+            let dynamic = rgb_to_xyz_matrix::<AdobeRgb, f64>();
+            let constant = AdobeRgb::rgb_to_xyz_matrix().unwrap();
+            assert_relative_eq!(dynamic[..], constant[..], epsilon = 0.0000001);
+        }
+
+        #[test]
+        fn xyz_to_rgb() {
+            let dynamic = matrix_inverse(rgb_to_xyz_matrix::<AdobeRgb, f64>());
+            let constant = AdobeRgb::xyz_to_rgb_matrix().unwrap();
+            assert_relative_eq!(dynamic[..], constant[..], epsilon = 0.0000001);
+        }
+    }
+}

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -312,7 +312,10 @@ pub use oklab::{Oklab, Oklaba};
 #[doc(inline)]
 pub use oklch::{Oklch, Oklcha};
 #[doc(inline)]
-pub use rgb::{GammaSrgb, GammaSrgba, LinRec2020, LinSrgb, LinSrgba, Rec2020, Rec709, Srgb, Srgba};
+pub use rgb::{
+    AdobeRgb, AdobeRgba, GammaSrgb, GammaSrgba, LinAdobeRgb, LinAdobeRgba, LinRec2020, LinSrgb,
+    LinSrgba, Rec2020, Rec709, Srgb, Srgba,
+};
 #[doc(inline)]
 pub use xyz::{Xyz, Xyza};
 #[doc(inline)]

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -133,6 +133,42 @@ pub type GammaSrgb<T = f32> = Rgb<Gamma<encoding::Srgb>, T>;
 /// create a value and use it.
 pub type GammaSrgba<T = f32> = Rgba<Gamma<encoding::Srgb>, T>;
 
+/// Non-linear Adobe RGB.
+///
+/// This is a gamma 2.2 encoded RGB color space designed to include most colors
+/// producable by CMYK printers.
+///
+/// See [`Rgb`] for more details on how to create a value and use it.
+pub type AdobeRgb<T = f32> = Rgb<encoding::AdobeRgb, T>;
+
+/// Non-linear Adobe RGB with an alpha component.
+///
+/// This is a transparent version of [`AdobeRgb`], which is commonly used as the
+/// input or output format.
+///
+/// See [`Rgb`], [`Rgba`] and [`Alpha`](crate::Alpha) for more details on how to
+/// create a value and use it.
+pub type AdobeRgba<T = f32> = Rgba<encoding::AdobeRgb, T>;
+
+/// Linear Adobe RGB.
+///
+/// You probably want [`AdobeRgb`] if you are looking for an input or output format.
+/// This is the linear version of Adobe RGB, which is what you would usually convert
+/// to before working with the color.
+///
+/// See [`Rgb`] for more details on how to create a value and use it.
+pub type LinAdobeRgb<T = f32> = Rgb<Linear<encoding::AdobeRgb>, T>;
+
+/// Linear Adobe RGB with an alpha component.
+///
+/// You probably want [`AdobeRgba`] if you are looking for an input or output format.
+/// This is the linear version of Adobe RGBA, which is what you would usually convert
+/// to before working with the color.
+///
+/// See [`Rgb`], [`Rgba`] and [`Alpha`](crate::Alpha) for more details on how to
+/// create a value and use it.
+pub type LinAdobeRgba<T = f32> = Rgba<Linear<encoding::AdobeRgb>, T>;
+
 /// Rec. 709.
 ///
 /// This standard has the same primaries as [`Srgb`], but uses the transfer


### PR DESCRIPTION
<!-- Describe your changes as well as possible. What has changed and why? Someone who hasn't followed previous discussions should be able to understand why this change was made and/or be able to find out why. -->

This adds the Adobe RGB (1998) color space and standard (which uses a gamma 2.2 transfer function).

<!--
## Closed Issues

* Fixes #1234, by doing XYZ.
* Closes #4321, by implementing ABC.
-->

* Completes `a98-rgb` task of #408 by implementing Adobe RGB (1998).

<!--
## Breaking Change

Will this pull request break dependent code? Describe how/why and give an example of how to migrate existing code to use the new version.
-->
