### PR TITLE
Update `image` dev-dependency

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -76,7 +76,7 @@ ron = "=0.8.0" # Pinned due to MSRV mismatch
 enterpolation = "0.2.0"
 
 [dev-dependencies.image]
-version = "0.23.14"
+version = "0.25.2"
 default-features = false
 features = ["png"]
 


### PR DESCRIPTION
Update the `image` dev dependency to the current version. This no visible end-user impact.