### PR TITLE
Fix upcoming Clippy lifetime warnings

### DIFF
--- a/palette/src/convert/from_into_color_mut.rs
+++ b/palette/src/convert/from_into_color_mut.rs
@@ -316,7 +316,7 @@ where
     }
 }
 
-impl<'a, T, U> Deref for FromColorMutGuard<'a, T, U>
+impl<T, U> Deref for FromColorMutGuard<'_, T, U>
 where
     T: FromColorMut<U> + ?Sized,
     U: FromColorMut<T> + ?Sized,
@@ -333,7 +333,7 @@ where
     }
 }
 
-impl<'a, T, U> DerefMut for FromColorMutGuard<'a, T, U>
+impl<T, U> DerefMut for FromColorMutGuard<'_, T, U>
 where
     T: FromColorMut<U> + ?Sized,
     U: FromColorMut<T> + ?Sized,
@@ -348,7 +348,7 @@ where
     }
 }
 
-impl<'a, T, U> Drop for FromColorMutGuard<'a, T, U>
+impl<T, U> Drop for FromColorMutGuard<'_, T, U>
 where
     T: FromColorMut<U> + ?Sized,
     U: FromColorMut<T> + ?Sized,

--- a/palette/src/convert/from_into_color_unclamped_mut.rs
+++ b/palette/src/convert/from_into_color_unclamped_mut.rs
@@ -317,7 +317,7 @@ where
     }
 }
 
-impl<'a, T, U> Deref for FromColorUnclampedMutGuard<'a, T, U>
+impl<T, U> Deref for FromColorUnclampedMutGuard<'_, T, U>
 where
     T: FromColorUnclampedMut<U> + ?Sized,
     U: FromColorUnclampedMut<T> + ?Sized,
@@ -334,7 +334,7 @@ where
     }
 }
 
-impl<'a, T, U> DerefMut for FromColorUnclampedMutGuard<'a, T, U>
+impl<T, U> DerefMut for FromColorUnclampedMutGuard<'_, T, U>
 where
     T: FromColorUnclampedMut<U> + ?Sized,
     U: FromColorUnclampedMut<T> + ?Sized,
@@ -349,7 +349,7 @@ where
     }
 }
 
-impl<'a, T, U> Drop for FromColorUnclampedMutGuard<'a, T, U>
+impl<T, U> Drop for FromColorUnclampedMutGuard<'_, T, U>
 where
     T: FromColorUnclampedMut<U> + ?Sized,
     U: FromColorUnclampedMut<T> + ?Sized,

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -225,7 +225,7 @@ macro_rules! make_hues {
 
             /// Get a hue, or slice of hues, with references to the values at `index`. See [`slice::get`] for details.
             #[inline(always)]
-            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$name<&<I as core::slice::SliceIndex<[T]>>::Output>>
+            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$name<&'a <I as core::slice::SliceIndex<[T]>>::Output>>
             where
                 T: 'a,
                 C: AsRef<[T]>,
@@ -236,7 +236,7 @@ macro_rules! make_hues {
 
             /// Get a hue, or slice of hues, that allows modifying the values at `index`. See [`slice::get_mut`] for details.
             #[inline(always)]
-            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$name<&mut <I as core::slice::SliceIndex<[T]>>::Output>>
+            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$name<&'a mut <I as core::slice::SliceIndex<[T]>>::Output>>
             where
                 T: 'a,
                 C: AsMut<[T]>,

--- a/palette/src/macros/struct_of_arrays.rs
+++ b/palette/src/macros/struct_of_arrays.rs
@@ -1044,7 +1044,7 @@ macro_rules! impl_struct_of_arrays_methods {
 
             /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
             #[inline(always)]
-            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>>
+            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$self_ty<$($phantom_ty,)? &'a <I as core::slice::SliceIndex<[T]>>::Output>>
             where
                 T: 'a,
                 C: AsRef<[T]>,
@@ -1064,7 +1064,7 @@ macro_rules! impl_struct_of_arrays_methods {
 
             /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
             #[inline(always)]
-            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>>
+            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$self_ty<$($phantom_ty,)? &'a mut <I as core::slice::SliceIndex<[T]>>::Output>>
             where
                 T: 'a,
                 C: AsMut<[T]>,
@@ -1136,8 +1136,8 @@ macro_rules! impl_struct_of_arrays_methods {
             /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
             #[inline(always)]
             pub fn get<'a, I, T, A>(&'a self, index: I) -> Option<crate::Alpha<
-                $self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>,
-                &<I as core::slice::SliceIndex<[A]>>::Output
+                $self_ty<$($phantom_ty,)? &'a <I as core::slice::SliceIndex<[T]>>::Output>,
+                &'a <I as core::slice::SliceIndex<[A]>>::Output
             >>
             where
                 T: 'a,
@@ -1159,8 +1159,8 @@ macro_rules! impl_struct_of_arrays_methods {
             /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
             #[inline(always)]
             pub fn get_mut<'a, I, T, A>(&'a mut self, index: I) -> Option<crate::Alpha<
-                $self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>,
-                &mut <I as core::slice::SliceIndex<[A]>>::Output
+                $self_ty<$($phantom_ty,)? &'a mut <I as core::slice::SliceIndex<[T]>>::Output>,
+                &'a mut <I as core::slice::SliceIndex<[A]>>::Output
             >>
             where
                 T: 'a,
@@ -1252,7 +1252,7 @@ macro_rules! impl_struct_of_arrays_methods_hue {
 
             /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
             #[inline(always)]
-            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>>
+            pub fn get<'a, I, T>(&'a self, index: I) -> Option<$self_ty<$($phantom_ty,)? &'a <I as core::slice::SliceIndex<[T]>>::Output>>
             where
                 T: 'a,
                 C: AsRef<[T]>,
@@ -1270,7 +1270,7 @@ macro_rules! impl_struct_of_arrays_methods_hue {
 
             /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
             #[inline(always)]
-            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>>
+            pub fn get_mut<'a, I, T>(&'a mut self, index: I) -> Option<$self_ty<$($phantom_ty,)? &'a mut <I as core::slice::SliceIndex<[T]>>::Output>>
             where
                 T: 'a,
                 C: AsMut<[T]>,
@@ -1343,8 +1343,8 @@ macro_rules! impl_struct_of_arrays_methods_hue {
             /// Get a color, or slice of colors, with references to the components at `index`. See [`slice::get`] for details.
             #[inline(always)]
             pub fn get<'a, I, T, A>(&'a self, index: I) -> Option<crate::Alpha<
-                $self_ty<$($phantom_ty,)? &<I as core::slice::SliceIndex<[T]>>::Output>,
-                &<I as core::slice::SliceIndex<[A]>>::Output
+                $self_ty<$($phantom_ty,)? &'a <I as core::slice::SliceIndex<[T]>>::Output>,
+                &'a <I as core::slice::SliceIndex<[A]>>::Output
             >>
             where
                 T: 'a,
@@ -1366,8 +1366,8 @@ macro_rules! impl_struct_of_arrays_methods_hue {
             /// Get a color, or slice of colors, that allows modifying the components at `index`. See [`slice::get_mut`] for details.
             #[inline(always)]
             pub fn get_mut<'a, I, T, A>(&'a mut self, index: I) -> Option<crate::Alpha<
-                $self_ty<$($phantom_ty,)? &mut <I as core::slice::SliceIndex<[T]>>::Output>,
-                &mut <I as core::slice::SliceIndex<[A]>>::Output
+                $self_ty<$($phantom_ty,)? &'a mut <I as core::slice::SliceIndex<[T]>>::Output>,
+                &'a mut <I as core::slice::SliceIndex<[A]>>::Output
             >>
             where
                 T: 'a,

--- a/palette/src/serde/alpha_deserializer.rs
+++ b/palette/src/serde/alpha_deserializer.rs
@@ -12,7 +12,7 @@ pub(crate) struct AlphaDeserializer<'a, D, A> {
     pub alpha: &'a mut Option<A>,
 }
 
-impl<'de, 'a, D, A> Deserializer<'de> for AlphaDeserializer<'a, D, A>
+impl<'de, D, A> Deserializer<'de> for AlphaDeserializer<'_, D, A>
 where
     D: Deserializer<'de>,
     A: Deserialize<'de>,
@@ -305,7 +305,7 @@ struct AlphaSeqVisitor<'a, D, A> {
     alpha: &'a mut Option<A>,
 }
 
-impl<'de, 'a, D, A> Visitor<'de> for AlphaSeqVisitor<'a, D, A>
+impl<'de, D, A> Visitor<'de> for AlphaSeqVisitor<'_, D, A>
 where
     D: Visitor<'de>,
     A: Deserialize<'de>,
@@ -336,7 +336,7 @@ struct AlphaMapVisitor<'a, D, A> {
     field_count: Option<usize>,
 }
 
-impl<'de, 'a, D, A> Visitor<'de> for AlphaMapVisitor<'a, D, A>
+impl<'de, D, A> Visitor<'de> for AlphaMapVisitor<'_, D, A>
 where
     D: Visitor<'de>,
     A: Deserialize<'de>,
@@ -390,7 +390,7 @@ struct MapWrapper<'a, T, A> {
     field_count: Option<usize>,
 }
 
-impl<'a, 'de, T, A> MapAccess<'de> for MapWrapper<'a, T, A>
+impl<'de, T, A> MapAccess<'de> for MapWrapper<'_, T, A>
 where
     T: MapAccess<'de>,
     A: Deserialize<'de>,
@@ -554,7 +554,7 @@ struct StructFieldDeserializer<'a, E> {
     error: PhantomData<fn() -> E>,
 }
 
-impl<'a, 'de, E> Deserializer<'de> for StructFieldDeserializer<'a, E>
+impl<'de, E> Deserializer<'de> for StructFieldDeserializer<'_, E>
 where
     E: serde::de::Error,
 {

--- a/palette/src/serde/alpha_serializer.rs
+++ b/palette/src/serde/alpha_serializer.rs
@@ -230,7 +230,7 @@ fn alpha_serializer_error() -> ! {
     unimplemented!("AlphaSerializer can only serialize structs, maps and sequences")
 }
 
-impl<'a, S, A> SerializeSeq for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeSeq for AlphaSerializer<'_, S, A>
 where
     S: SerializeSeq,
     A: Serialize,
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<'a, S, A> SerializeTuple for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeTuple for AlphaSerializer<'_, S, A>
 where
     S: SerializeTuple,
     A: Serialize,
@@ -274,7 +274,7 @@ where
     }
 }
 
-impl<'a, S, A> SerializeTupleStruct for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeTupleStruct for AlphaSerializer<'_, S, A>
 where
     S: SerializeTupleStruct,
     A: Serialize,
@@ -296,7 +296,7 @@ where
     }
 }
 
-impl<'a, S, A> SerializeTupleVariant for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeTupleVariant for AlphaSerializer<'_, S, A>
 where
     S: SerializeTupleVariant,
     A: Serialize,
@@ -318,7 +318,7 @@ where
     }
 }
 
-impl<'a, S, A> SerializeMap for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeMap for AlphaSerializer<'_, S, A>
 where
     S: SerializeMap,
     A: Serialize,
@@ -355,7 +355,7 @@ where
     }
 }
 
-impl<'a, S, A> SerializeStruct for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeStruct for AlphaSerializer<'_, S, A>
 where
     S: SerializeStruct,
     A: Serialize,
@@ -381,7 +381,7 @@ where
     }
 }
 
-impl<'a, S, A> SerializeStructVariant for AlphaSerializer<'a, S, A>
+impl<S, A> SerializeStructVariant for AlphaSerializer<'_, S, A>
 where
     S: SerializeStructVariant,
     A: Serialize,


### PR DESCRIPTION
Clarifies implicitly named lifetimes, and elides named lifetimes that only appear once. Shouldn't affect the type checking.