### PR TITLE
Add `Rgb::from_hex` and implement parsing for `u16`, `u32`, `f32`, `f64`

### DIFF
--- a/palette/src/color_difference.rs
+++ b/palette/src/color_difference.rs
@@ -310,7 +310,7 @@ pub trait EuclideanDistance: Sized {
 ///
 /// // the rustdoc "DARK" theme background and text colors
 /// let background: Srgb<f32> = Srgb::from(0x353535).into_format();
-/// let foreground = Srgb::from_str("#ddd")?.into_format();
+/// let foreground = Srgb::from_str("#ddd")?;
 ///
 /// assert!(background.has_enhanced_contrast_text(foreground));
 /// # Ok(())
@@ -515,7 +515,7 @@ mod test {
             black.relative_contrast(white)
         );
 
-        let c1 = Srgb::from_str("#600").unwrap().into_format();
+        let c1 = Srgb::from_str("#600").unwrap();
 
         assert_relative_eq!(c1.relative_contrast(white), 13.41, epsilon = 0.01);
         assert_relative_eq!(c1.relative_contrast(black), 1.56, epsilon = 0.01);
@@ -532,12 +532,12 @@ mod test {
         assert!(!c1.has_enhanced_contrast_large_text(black));
         assert!(!c1.has_min_contrast_graphics(black));
 
-        let c1 = Srgb::from_str("#066").unwrap().into_format();
+        let c1 = Srgb::from_str("#066").unwrap();
 
         assert_relative_eq!(c1.relative_contrast(white), 6.79, epsilon = 0.01);
         assert_relative_eq!(c1.relative_contrast(black), 3.09, epsilon = 0.01);
 
-        let c1 = Srgb::from_str("#9f9").unwrap().into_format();
+        let c1 = Srgb::from_str("#9f9").unwrap();
 
         assert_relative_eq!(c1.relative_contrast(white), 1.22, epsilon = 0.01);
         assert_relative_eq!(c1.relative_contrast(black), 17.11, epsilon = 0.01);

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -368,7 +368,7 @@ mod tests {
         #[test]
         fn test_srgb_to_okhsl() {
             let red_hex = "#834941";
-            let rgb: Srgb<f64> = Srgb::from_str(red_hex).unwrap().into_format();
+            let rgb: Srgb<f64> = Srgb::from_str(red_hex).unwrap();
             let lin_rgb = LinSrgb::<f64>::from_color_unclamped(rgb);
             let oklab = Oklab::from_color_unclamped(lin_rgb);
             println!(

--- a/palette/src/okhsv.rs
+++ b/palette/src/okhsv.rs
@@ -292,8 +292,6 @@ mod tests {
 
     #[cfg(feature = "approx")]
     mod conversion {
-        use core::str::FromStr;
-
         use crate::{
             convert::FromColorUnclamped, encoding, rgb::Rgb, visual::VisuallyEqual, LinSrgb, Okhsv,
             Oklab, OklabHue, Srgb,
@@ -403,9 +401,7 @@ mod tests {
         #[test]
         fn test_srgb_to_okhsv() {
             let red_hex = "#ff0004";
-            let rgb: Srgb = Rgb::<encoding::Srgb, _>::from_str(red_hex)
-                .unwrap()
-                .into_format();
+            let rgb: Srgb = red_hex.parse().unwrap();
             let okhsv = Okhsv::from_color_unclamped(rgb);
             assert_relative_eq!(okhsv.saturation, 1.0, epsilon = 1e-3);
             assert_relative_eq!(okhsv.value, 1.0, epsilon = 1e-3);

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -545,7 +545,7 @@ mod test {
         /// Asserts that, for any color space, the lightness of pure white is converted to `l == 1.0`
         #[test]
         fn lightness_of_white_is_one() {
-            let rgb: Srgb<f64> = Rgb::from_str("#ffffff").unwrap().into_format();
+            let rgb: Srgb<f64> = Rgb::from_str("#ffffff").unwrap();
             let lin_rgb = LinSrgb::from_color_unclamped(rgb);
             let oklab = Oklab::from_color_unclamped(lin_rgb);
             println!("white {rgb:?} == {oklab:?}");
@@ -565,7 +565,7 @@ mod test {
         #[test]
         fn blue_srgb() {
             // use f64 to be comparable to javascript
-            let rgb: Srgb<f64> = Rgb::from_str("#0000ff").unwrap().into_format();
+            let rgb: Srgb<f64> = Rgb::from_str("#0000ff").unwrap();
             let lin_rgb = LinSrgb::from_color_unclamped(rgb);
             let oklab = Oklab::from_color_unclamped(lin_rgb);
 

--- a/palette/src/relative_contrast.rs
+++ b/palette/src/relative_contrast.rs
@@ -26,7 +26,7 @@ use crate::{
 ///
 /// // the rustdoc "DARK" theme background and text colors
 /// let background: Srgb<f32> = Srgb::from(0x353535).into_format();
-/// let foreground = Srgb::from_str("#ddd")?.into_format();
+/// let foreground = Srgb::from_str("#ddd")?;
 ///
 /// assert!(background.has_enhanced_contrast_text(foreground));
 /// # Ok(())
@@ -145,7 +145,7 @@ mod test {
             black.get_contrast_ratio(white)
         );
 
-        let c1 = Srgb::from_str("#600").unwrap().into_format();
+        let c1 = Srgb::from_str("#600").unwrap();
 
         assert_relative_eq!(c1.get_contrast_ratio(white), 13.41, epsilon = 0.01);
         assert_relative_eq!(c1.get_contrast_ratio(black), 1.56, epsilon = 0.01);
@@ -162,12 +162,12 @@ mod test {
         assert!(!c1.has_enhanced_contrast_large_text(black));
         assert!(!c1.has_min_contrast_graphics(black));
 
-        let c1 = Srgb::from_str("#066").unwrap().into_format();
+        let c1 = Srgb::from_str("#066").unwrap();
 
         assert_relative_eq!(c1.get_contrast_ratio(white), 6.79, epsilon = 0.01);
         assert_relative_eq!(c1.get_contrast_ratio(black), 3.09, epsilon = 0.01);
 
-        let c1 = Srgb::from_str("#9f9").unwrap().into_format();
+        let c1 = Srgb::from_str("#9f9").unwrap();
 
         assert_relative_eq!(c1.get_contrast_ratio(white), 1.22, epsilon = 0.01);
         assert_relative_eq!(c1.get_contrast_ratio(black), 17.11, epsilon = 0.01);

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -70,6 +70,7 @@ use crate::{
 pub use self::rgb::{FromHexError, Iter, Rgb, Rgba};
 
 pub mod channels;
+mod hex;
 #[allow(clippy::module_inception)]
 mod rgb;
 

--- a/palette/src/rgb/hex.rs
+++ b/palette/src/rgb/hex.rs
@@ -1,0 +1,69 @@
+use core::num::ParseIntError;
+
+#[inline]
+pub(crate) fn rgb_from_hex_4bit(hex: &str) -> Result<(u8, u8, u8), ParseIntError> {
+    let red = u8::from_str_radix(&hex[..1], 16)?;
+    let green = u8::from_str_radix(&hex[1..2], 16)?;
+    let blue = u8::from_str_radix(&hex[2..3], 16)?;
+
+    Ok((red * 17, green * 17, blue * 17))
+}
+
+#[inline]
+pub(crate) fn rgba_from_hex_4bit(hex: &str) -> Result<(u8, u8, u8, u8), ParseIntError> {
+    let (red, green, blue) = rgb_from_hex_4bit(hex)?;
+    let alpha = u8::from_str_radix(&hex[3..4], 16)?;
+
+    Ok((red, green, blue, alpha * 17))
+}
+
+#[inline]
+pub(crate) fn rgb_from_hex_8bit(hex: &str) -> Result<(u8, u8, u8), ParseIntError> {
+    let red = u8::from_str_radix(&hex[..2], 16)?;
+    let green = u8::from_str_radix(&hex[2..4], 16)?;
+    let blue = u8::from_str_radix(&hex[4..6], 16)?;
+
+    Ok((red, green, blue))
+}
+
+#[inline]
+pub(crate) fn rgba_from_hex_8bit(hex: &str) -> Result<(u8, u8, u8, u8), ParseIntError> {
+    let (red, green, blue) = rgb_from_hex_8bit(hex)?;
+    let alpha = u8::from_str_radix(&hex[6..8], 16)?;
+
+    Ok((red, green, blue, alpha))
+}
+
+#[inline]
+pub(crate) fn rgb_from_hex_16bit(hex: &str) -> Result<(u16, u16, u16), ParseIntError> {
+    let red = u16::from_str_radix(&hex[..4], 16)?;
+    let green = u16::from_str_radix(&hex[4..8], 16)?;
+    let blue = u16::from_str_radix(&hex[8..12], 16)?;
+
+    Ok((red, green, blue))
+}
+
+#[inline]
+pub(crate) fn rgba_from_hex_16bit(hex: &str) -> Result<(u16, u16, u16, u16), ParseIntError> {
+    let (red, green, blue) = rgb_from_hex_16bit(hex)?;
+    let alpha = u16::from_str_radix(&hex[12..16], 16)?;
+
+    Ok((red, green, blue, alpha))
+}
+
+#[inline]
+pub(crate) fn rgb_from_hex_32bit(hex: &str) -> Result<(u32, u32, u32), ParseIntError> {
+    let red = u32::from_str_radix(&hex[..8], 16)?;
+    let green = u32::from_str_radix(&hex[8..16], 16)?;
+    let blue = u32::from_str_radix(&hex[16..24], 16)?;
+
+    Ok((red, green, blue))
+}
+
+#[inline]
+pub(crate) fn rgba_from_hex_32bit(hex: &str) -> Result<(u32, u32, u32, u32), ParseIntError> {
+    let (red, green, blue) = rgb_from_hex_32bit(hex)?;
+    let alpha = u32::from_str_radix(&hex[24..32], 16)?;
+
+    Ok((red, green, blue, alpha))
+}

--- a/palette/src/stimulus.rs
+++ b/palette/src/stimulus.rs
@@ -238,6 +238,26 @@ macro_rules! convert_uint_to_uint {
     };
 }
 
+macro_rules! convert_uint_to_larger_uint {
+    ($uint: ident; next $next: ident ($($other: ident),*)) => {
+        impl IntoStimulus<$next> for $uint {
+            #[inline]
+            fn into_stimulus(self) -> $next {
+                ((self as $next) << Self::BITS) | self as $next
+            }
+        }
+
+        $(
+            impl IntoStimulus<$other> for $uint {
+                #[inline]
+                fn into_stimulus(self) -> $other {
+                    $next::from_stimulus(self).into_stimulus()
+                }
+            }
+        )*
+    };
+}
+
 impl IntoStimulus<f64> for f32 {
     #[inline]
     fn into_stimulus(self) -> f64 {
@@ -254,16 +274,19 @@ impl IntoStimulus<f32> for f64 {
 }
 convert_double_to_uint!(f64; direct (u8, u16, u32, u64, u128););
 
-convert_uint_to_uint!(u8; via f32 (u16); via f64 (u32, u64, u128););
+convert_uint_to_larger_uint!(u8; next u16 (u32, u64, u128));
 
 convert_uint_to_float!(u16; via f32 (f32); via f64 (f64););
-convert_uint_to_uint!(u16; via f32 (u8); via f64 (u32, u64, u128););
+convert_uint_to_uint!(u16; via f32 (u8););
+convert_uint_to_larger_uint!(u16; next u32 (u64, u128));
 
 convert_uint_to_float!(u32; via f64 (f32, f64););
-convert_uint_to_uint!(u32; via f64 (u8, u16, u64, u128););
+convert_uint_to_uint!(u32; via f64 (u8, u16););
+convert_uint_to_larger_uint!(u32; next u64 (u128));
 
 convert_uint_to_float!(u64; via f64 (f32, f64););
-convert_uint_to_uint!(u64; via f64 (u8, u16, u32, u128););
+convert_uint_to_uint!(u64; via f64 (u8, u16, u32););
+convert_uint_to_larger_uint!(u64; next u128 ());
 
 convert_uint_to_float!(u128; via f64 (f32, f64););
 convert_uint_to_uint!(u128; via f64 (u8, u16, u32, u64););


### PR DESCRIPTION
This expands hexadecimal parsing for `Rgb` to support more component types (`u16`, `u32`, `f32`, `f64`) and add an easier to find `from_hex` constructor for both `Rgb` and `Rgba`. It also updates component conversion when increasing bit depth to not convert via floating point types.

## Closed Issues

* Closes #420.
* Closes #306, by adding a `from_hex` constructor to `Rgb`.

## Type Inference Breaking Change

This affects type inference by making `Srgb::from_str(hex)?.into_format()` and similar situations ambiguous. This example can be resolved by either specifying the component type or removing `.into_format()`.