### PR TITLE
Deprecate `encoding::gamma` and its content

### DIFF
--- a/palette/src/encoding.rs
+++ b/palette/src/encoding.rs
@@ -6,6 +6,7 @@
 //! prevent accidental mixups.
 
 pub use self::adobe::AdobeRgb;
+#[allow(deprecated)]
 pub use self::gamma::{F2p2, Gamma};
 pub use self::linear::Linear;
 pub use self::p3::{DciP3, DciP3Plus, DisplayP3};
@@ -14,6 +15,10 @@ pub use self::rec_standards::{Rec2020, Rec709};
 pub use self::srgb::Srgb;
 
 pub mod adobe;
+#[deprecated(
+    since = "0.7.7",
+    note = "`Gamma`, `GammaFn` and `F2p2` are error prone and incorrectly implemented. See `palette::encoding` for possible alternatives or implement `palette::encoding::FromLinear` and `palette::encoding::IntoLinear` for a custom type."
+)]
 pub mod gamma;
 pub mod linear;
 pub mod p3;

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -298,6 +298,7 @@ pub use lch::{Lch, Lcha};
 #[doc(inline)]
 pub use lchuv::{Lchuv, Lchuva};
 #[doc(inline)]
+#[allow(deprecated)]
 pub use luma::{GammaLuma, GammaLumaa, LinLuma, LinLumaa, SrgbLuma, SrgbLumaa};
 #[doc(inline)]
 pub use luv::{Luv, Luva};
@@ -312,6 +313,7 @@ pub use oklab::{Oklab, Oklaba};
 #[doc(inline)]
 pub use oklch::{Oklch, Oklcha};
 #[doc(inline)]
+#[allow(deprecated)]
 pub use rgb::{
     AdobeRgb, AdobeRgba, GammaSrgb, GammaSrgba, LinAdobeRgb, LinAdobeRgba, LinRec2020, LinSrgb,
     LinSrgba, Rec2020, Rec709, Srgb, Srgba,

--- a/palette/src/luma.rs
+++ b/palette/src/luma.rs
@@ -3,7 +3,7 @@
 pub mod channels;
 #[allow(clippy::module_inception)]
 mod luma;
-
+#[allow(deprecated)]
 use crate::encoding::{Gamma, Linear, Srgb};
 use crate::white_point::D65;
 
@@ -22,8 +22,18 @@ pub type LinLuma<Wp = D65, T = f32> = Luma<Linear<Wp>, T>;
 pub type LinLumaa<Wp = D65, T = f32> = Lumaa<Linear<Wp>, T>;
 
 /// Gamma 2.2 encoded luminance.
+#[deprecated(
+    since = "0.7.7",
+    note = "`Gamma`, `GammaFn` and `F2p2` are error prone and incorrectly implemented. See `palette::encoding` for possible alternatives or implement `palette::encoding::FromLinear` and `palette::encoding::IntoLinear` for a custom type."
+)]
+#[allow(deprecated)]
 pub type GammaLuma<T = f32> = Luma<Gamma<D65>, T>;
 /// Gamma 2.2 encoded luminance with an alpha component.
+#[deprecated(
+    since = "0.7.7",
+    note = "`Gamma`, `GammaFn` and `F2p2` are error prone and incorrectly implemented. See `palette::encoding` for possible alternatives or implement `palette::encoding::FromLinear` and `palette::encoding::IntoLinear` for a custom type."
+)]
+#[allow(deprecated)]
 pub type GammaLumaa<T = f32> = Lumaa<Gamma<D65>, T>;
 
 /// A white point and a transfer function.

--- a/palette/src/rgb.rs
+++ b/palette/src/rgb.rs
@@ -60,6 +60,7 @@
 //! colors correctly and still allow advanced users a high degree of
 //! flexibility.
 
+#[allow(deprecated)]
 use crate::{
     encoding::{self, FromLinear, Gamma, IntoLinear, Linear},
     stimulus::{FromStimulus, Stimulus},
@@ -121,6 +122,11 @@ pub type LinSrgba<T = f32> = Rgba<Linear<encoding::Srgb>, T>;
 /// from `u8` at the same time.
 ///
 /// See [`Rgb`] for more details on how to create a value and use it.
+#[deprecated(
+    since = "0.7.7",
+    note = "`Gamma`, `GammaFn` and `F2p2` are error prone and incorrectly implemented. See `palette::encoding` for possible alternatives or implement `palette::encoding::FromLinear` and `palette::encoding::IntoLinear` for a custom type."
+)]
+#[allow(deprecated)]
 pub type GammaSrgb<T = f32> = Rgb<Gamma<encoding::Srgb>, T>;
 
 /// Gamma 2.2 encoded sRGB with an alpha component.
@@ -132,6 +138,11 @@ pub type GammaSrgb<T = f32> = Rgb<Gamma<encoding::Srgb>, T>;
 ///
 /// See [`Rgb`], [`Rgba`] and [`Alpha`](crate::Alpha) for more details on how to
 /// create a value and use it.
+#[deprecated(
+    since = "0.7.7",
+    note = "`Gamma`, `GammaFn` and `F2p2` are error prone and incorrectly implemented. See `palette::encoding` for possible alternatives or implement `palette::encoding::FromLinear` and `palette::encoding::IntoLinear` for a custom type."
+)]
+#[allow(deprecated)]
 pub type GammaSrgba<T = f32> = Rgba<Gamma<encoding::Srgb>, T>;
 
 /// Non-linear Adobe RGB.


### PR DESCRIPTION
Deprecates `Gamma`, `GammaFn` and `F2p2` due to being incorrectly implemented and being more error prone than just implementing `FromLinear` and `IntoLinear` for a custom type.

The current implementation of `GammaFn` has the `FromLinear` and `IntoLinear` implementations reversed, and fixing that would break code that compensates for the error. Deprecation, together with the extended number of RGB standards added recently, should hopefully provide better alternatives without suddenly changing the visual output of existing uses.

The recommended migration options are to either find a fitting alternative in `palette::encoding` or implementing `FromLinear` and `IntoLinear` for a custom type. Suggestions for more additions are also welcome.