### PR TITLE
feat: implemented palette angle/bool_mask/num traits for simba's Wide* wrapper types

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -35,6 +35,7 @@ find-crate = ["palette_derive/find-crate"]
 std = ["alloc", "approx?/std"]
 alloc = []
 gamma_lut_u16 = []
+wide = ["dep:wide", "simba?/wide"]
 
 # Deprecated. Alias for `"named"`.
 named_from_str = ["named"]
@@ -70,6 +71,10 @@ optional = true
 version = "0.7.3"
 optional = true
 default-features = false
+
+[dependencies.simba]
+version = "0.9"
+optional = true
 
 [dev-dependencies]
 serde_json = "1"

--- a/palette/src/angle.rs
+++ b/palette/src/angle.rs
@@ -8,6 +8,9 @@ use crate::{
 #[cfg(feature = "wide")]
 mod wide;
 
+#[cfg(all(feature = "simba", feature = "wide"))]
+mod simba_wide;
+
 /// Represents types that can express half of a rotation (i.e. 180 degrees).
 pub trait HalfRotation {
     /// Return a value that represents half of a rotation (i.e. 180 degrees).

--- a/palette/src/angle/simba_wide.rs
+++ b/palette/src/angle/simba_wide.rs
@@ -1,0 +1,62 @@
+use ::simba::scalar::SupersetOf;
+use ::simba::simd::{SimdPartialOrd, SimdRealField, WideF32x4, WideF32x8, WideF64x4};
+
+use super::*;
+
+macro_rules! impl_angle_simba_float {
+    ($($ty: ident ($scalar_ty: ident)),+) => {
+        $(
+
+            impl HalfRotation for $ty {
+                #[inline(always)]
+                fn half_rotation() -> Self {
+                    Self::from_subset(&(180.0 as $scalar_ty))
+                }
+            }
+
+            impl FullRotation for $ty {
+                #[inline(always)]
+                fn full_rotation() -> Self {
+                    Self::from_subset(&(360.0 as $scalar_ty))
+                }
+            }
+
+            impl RealAngle for $ty {
+                #[inline(always)]
+                fn degrees_to_radians(self) -> Self {
+                    let rads_per_degree = Self::simd_pi() / Self::from_subset(&(180.0 as $scalar_ty));
+                    self * rads_per_degree
+                }
+
+                #[inline(always)]
+                fn radians_to_degrees(self) -> Self {
+                    let pis_in_180 = Self::from_subset(&(57.2957795130823208767981548141051703 as $scalar_ty));
+                    self * pis_in_180
+                }
+            }
+
+            impl AngleEq for $ty {
+                #[inline(always)]
+                fn angle_eq(&self, other: &Self) -> Self::Mask {
+                    self.normalize_unsigned_angle().simd_eq(other.normalize_unsigned_angle())
+                }
+            }
+
+            impl SignedAngle for $ty {
+                #[inline(always)]
+                fn normalize_signed_angle(self) -> Self {
+                    self - Round::ceil(((self + Self::from_subset(&(180.0 as $scalar_ty))) / Self::from_subset(&(360.0 as $scalar_ty))) - Self::from_subset(&(1.0 as $scalar_ty))) * Self::from_subset(&(360.0 as $scalar_ty))
+                }
+            }
+
+            impl UnsignedAngle for $ty {
+                #[inline(always)]
+                fn normalize_unsigned_angle(self) -> Self {
+                    self - (Round::floor(self / Self::from_subset(&(360.0 as $scalar_ty))) * Self::from_subset(&(360.0 as $scalar_ty)))
+                }
+            }
+        )+
+    };
+}
+
+impl_angle_simba_float!(WideF32x4(f32), WideF32x8(f32), WideF64x4(f64));

--- a/palette/src/bool_mask.rs
+++ b/palette/src/bool_mask.rs
@@ -8,6 +8,9 @@ use core::ops::{BitAnd, BitOr, BitXor, Not};
 #[cfg(feature = "wide")]
 mod wide;
 
+#[cfg(all(feature = "simba", feature = "wide"))]
+mod simba_wide;
+
 /// Associates a Boolean type to the implementing type.
 ///
 /// This is primarily used in traits and functions that can accept SIMD values

--- a/palette/src/bool_mask/simba_wide.rs
+++ b/palette/src/bool_mask/simba_wide.rs
@@ -1,0 +1,96 @@
+use ::simba::simd::{
+    SimdBool, SimdValue, WideBoolF32x4, WideBoolF32x8, WideBoolF64x4, WideF32x4, WideF32x8,
+    WideF64x4,
+};
+
+use super::{BoolMask, HasBoolMask, LazySelect, Select};
+
+macro_rules! impl_simba_bool_mask {
+    ($($ty: ident: ($bool: ident,$uint: ident, $lanes: expr)),+) => {
+        $(
+
+            impl HasBoolMask for $ty {
+               type Mask = $bool;
+            }
+
+            impl HasBoolMask for $bool {
+               type Mask = Self;
+            }
+
+
+            impl BoolMask for $bool {
+                #[inline(always)]
+                fn from_bool(value: bool) -> Self {
+                    Self::splat(value)
+                }
+
+                #[inline(always)]
+                fn is_true(&self) -> bool {
+                    self.0.all()
+                }
+
+                #[inline(always)]
+                fn is_false(&self) -> bool{
+                    self.0.none()
+                }
+            }
+
+
+            impl<T> Select<T>  for $bool where T: HasBoolMask<Mask = Self> + SimdValue<SimdBool = Self>, {
+                #[inline(always)]
+                fn select(self, a: T, b: T) -> T {
+                    SimdValue::select(a, self, b)
+                }
+            }
+
+
+            impl<T> LazySelect<T>  for $bool where T: HasBoolMask<Mask = Self> + SimdValue<SimdBool = Self>, {
+                #[inline(always)]
+                fn lazy_select<A, B>(self, a: A, b: B) -> T
+                where
+                    A: FnOnce() -> T,
+                    B: FnOnce() -> T,
+                {
+                    self.if_else(a, b)
+                }
+            }
+        )+
+    };
+}
+
+impl_simba_bool_mask!(
+    WideF32x4: (WideBoolF32x4, u32, 4),
+    WideF32x8: (WideBoolF32x8, u32, 8),
+    WideF64x4: (WideBoolF64x4, u64, 4)
+);
+
+#[cfg(test)]
+mod test {
+    use ::simba::simd::{WideBoolF32x4, WideBoolF32x8, WideBoolF64x4};
+
+    use crate::bool_mask::BoolMask;
+
+    #[test]
+    fn from_true() {
+        assert!(WideBoolF32x4::from_bool(true).is_true());
+        assert!(!WideBoolF32x4::from_bool(true).is_false());
+
+        assert!(WideBoolF32x8::from_bool(true).is_true());
+        assert!(!WideBoolF32x8::from_bool(true).is_false());
+
+        assert!(WideBoolF64x4::from_bool(true).is_true());
+        assert!(!WideBoolF64x4::from_bool(true).is_false());
+    }
+
+    #[test]
+    fn from_false() {
+        assert!(WideBoolF32x4::from_bool(false).is_false());
+        assert!(!WideBoolF32x4::from_bool(false).is_true());
+
+        assert!(WideBoolF32x8::from_bool(false).is_false());
+        assert!(!WideBoolF32x8::from_bool(false).is_true());
+
+        assert!(WideBoolF64x4::from_bool(false).is_false());
+        assert!(!WideBoolF64x4::from_bool(false).is_true());
+    }
+}

--- a/palette/src/num.rs
+++ b/palette/src/num.rs
@@ -21,6 +21,9 @@ mod libm;
 #[cfg(feature = "wide")]
 mod wide;
 
+#[cfg(all(feature = "simba", feature = "wide"))]
+mod simba_wide;
+
 /// Numbers that belong to the real number set. It's both a semantic marker and
 /// provides a constructor for number constants.
 pub trait Real {

--- a/palette/src/num/simba_wide.rs
+++ b/palette/src/num/simba_wide.rs
@@ -1,0 +1,320 @@
+use ::simba::scalar::SupersetOf;
+use ::simba::simd::{
+    SimdComplexField, SimdPartialOrd, SimdRealField, WideBoolF32x4, WideBoolF32x8, WideBoolF64x4,
+    WideF32x4, WideF32x8, WideF64x4,
+};
+
+use super::*;
+
+macro_rules! impl_simba_float {
+    ($($ty: ident ($bool: ident, $scalar: ty, $lanes: expr)),+) => {
+        $(
+            impl Real for $ty {
+                #[inline(always)]
+                fn from_f64(n: f64) -> Self {
+                   Self::from_subset(&n)
+                }
+            }
+
+
+            impl Zero for $ty {
+                #[inline(always)]
+                fn zero() -> Self {
+                     Self::ZERO
+                }
+            }
+
+
+            impl One for $ty {
+                #[inline(always)]
+                fn one() -> Self {
+                    Self::ONE
+                }
+            }
+
+
+            impl MinMax for $ty {
+                #[inline(always)]
+                fn min(self, other: Self) -> Self {
+                    self.simd_min(other)
+                }
+
+                #[inline(always)]
+                fn max(self, other: Self) -> Self {
+                    self.simd_max(other)
+                }
+
+                #[inline(always)]
+                fn min_max(self, other: Self) -> (Self, Self){
+                    (self.simd_min(other), self.simd_max(other))
+                }
+            }
+
+
+            impl Clamp for $ty {
+                #[inline(always)]
+                fn clamp(self, min: Self, max: Self) -> Self {
+                    self.simd_clamp(min, max)
+                }
+
+                #[inline(always)]
+                fn clamp_min(self, min: Self) -> Self{
+                    self.simd_max(min)
+                }
+
+
+                #[inline(always)]
+                fn clamp_max(self, max: Self) -> Self{
+                    self.simd_min(max)
+                }
+            }
+
+
+            impl ClampAssign for $ty {
+                #[inline(always)]
+                fn clamp_assign(&mut self, min: Self, max: Self) {
+                    *self = self.simd_clamp(min, max);
+                }
+
+                #[inline(always)]
+                fn clamp_min_assign(&mut self, min: Self){
+                    *self = self.simd_max(min);
+                }
+
+
+                #[inline(always)]
+                fn clamp_max_assign(&mut self, max: Self){
+                    *self = self.simd_min(max);
+                }
+            }
+
+
+            impl PartialCmp for $ty {
+                #[inline(always)]
+                fn lt(&self, other: &Self) -> Self::Mask{
+                    self.simd_lt(*other)
+                }
+                #[inline(always)]
+                fn lt_eq(&self, other: &Self) -> Self::Mask {
+                    self.simd_le(*other)
+                }
+                #[inline(always)]
+                fn eq(&self, other: &Self) -> Self::Mask {
+                    self.simd_eq(*other)
+                }
+                #[inline(always)]
+                fn neq(&self, other: &Self) -> Self::Mask {
+                    self.simd_ne(*other)
+                }
+                #[inline(always)]
+                fn gt_eq(&self, other: &Self) -> Self::Mask {
+                    self.simd_ge(*other)
+                }
+                #[inline(always)]
+                fn gt(&self, other: &Self) -> Self::Mask {
+                    self.simd_gt(*other)
+                }
+            }
+
+
+            impl Abs for $ty {
+                #[inline(always)]
+                fn abs(self) -> Self {
+                    self.simd_abs()
+                }
+            }
+
+
+            impl Cbrt for $ty {
+                #[inline(always)]
+                fn cbrt(self) -> Self {
+                    self.simd_cbrt()
+                }
+            }
+
+
+            impl Exp for $ty {
+                #[inline(always)]
+                fn exp(self) -> Self {
+                    self.simd_exp()
+                }
+            }
+
+
+            impl Ln for $ty {
+                #[inline(always)]
+                fn ln(self) -> Self {
+                    self.simd_ln()
+                }
+            }
+
+
+            impl Powf for $ty {
+                #[inline(always)]
+                fn powf(self, exp: Self) -> Self {
+                    self.simd_powf(exp)
+                }
+            }
+
+
+            impl Powi for $ty {
+                #[inline(always)]
+                fn powi(self, exp: i32) -> Self {
+                    self.simd_powi(exp)
+                }
+            }
+
+
+            impl Recip for $ty {
+                #[inline(always)]
+                fn recip(self) -> Self {
+                    self.simd_recip()
+                }
+            }
+
+
+            impl Signum for $ty {
+                #[inline(always)]
+                fn signum(self) -> Self {
+                    self.simd_signum()
+                }
+            }
+
+
+
+            impl Round for $ty {
+                #[inline(always)]
+                fn round(self) -> Self {
+                    self.simd_round()
+                }
+
+                #[inline(always)]
+                fn floor(self) -> Self {
+                    self.simd_floor()
+                }
+
+                #[inline(always)]
+                fn ceil(self) -> Self {
+                    self.simd_ceil()
+                }
+            }
+
+
+            impl IsValidDivisor for $ty {
+                #[inline(always)]
+                fn is_valid_divisor(&self) -> Self::Mask {
+                    self.simd_ne(Self::from_subset(&(0.0 as $scalar))) & self.simd_ne(Self::from_subset(&(-0.0  as $scalar))) & $bool(self.0.is_finite())
+                }
+            }
+
+
+            impl MulAdd for $ty {
+                #[inline(always)]
+                fn mul_add(self, m: Self, a: Self) -> Self {
+                    self.simd_mul_add(m, a)
+                }
+            }
+
+
+            impl MulSub for $ty {
+                #[inline(always)]
+                fn mul_sub(self, m: Self, s: Self) -> Self {
+                    self.simd_mul_add(m, -s)
+                }
+            }
+
+
+            impl FromScalar for $ty {
+                type Scalar = $scalar;
+
+                #[inline(always)]
+                fn from_scalar(scalar: Self::Scalar) -> Self {
+                    Self::from_subset(&scalar)
+                }
+            }
+
+
+            impl FromScalarArray<$lanes> for $ty {
+                #[inline(always)]
+                fn from_array(scalars: [Self::Scalar; $lanes]) -> Self {
+                    Self::from(scalars)
+                }
+            }
+
+
+            impl IntoScalarArray<$lanes> for $ty {
+                #[inline(always)]
+                fn into_array(self) ->  [Self::Scalar; $lanes] {
+                    self.into()
+                }
+            }
+
+
+            impl Hypot for $ty {
+                #[inline(always)]
+                fn hypot(self, other: Self) -> Self {
+                    self.simd_hypot(other)
+                }
+            }
+
+
+            impl Sqrt for $ty {
+                #[inline(always)]
+                fn sqrt(self) -> Self {
+                    self.simd_sqrt()
+                }
+            }
+
+
+            impl Trigonometry for $ty {
+                #[inline(always)]
+                fn sin(self) -> Self {
+                    self.simd_sin()
+                }
+
+                #[inline(always)]
+                fn cos(self) -> Self {
+                    self.simd_cos()
+                }
+
+                #[inline(always)]
+                fn sin_cos(self) -> (Self, Self) {
+                    (self.simd_sin(), self.simd_cos())
+                }
+
+                #[inline(always)]
+                fn tan(self) -> Self {
+                    self.simd_tan()
+                }
+
+                #[inline(always)]
+                fn asin(self) -> Self {
+                    self.simd_asin()
+                }
+
+                #[inline(always)]
+                fn acos(self) -> Self {
+                    self.simd_acos()
+                }
+
+
+                #[inline(always)]
+                fn atan(self) -> Self {
+                    self.simd_atan()
+                }
+
+
+                #[inline(always)]
+                fn atan2(self, other: Self) -> Self {
+                    self.simd_atan2(other)
+                }
+            }
+        )+
+    };
+}
+
+impl_simba_float!(
+    WideF32x4(WideBoolF32x4, f32, 4),
+    WideF32x8(WideBoolF32x8, f32, 8),
+    WideF64x4(WideBoolF64x4, f64, 4)
+);


### PR DESCRIPTION
Implements the angle/bool_mask/num traits for simba's `Wide*` wrapper types behind a `simba` feature flag.

*Note*: to activate the implementation, both the `wide` and the `simba` feature must be enabled.

## Closed Issues

* Closes #430, by implementing palette's "primitive" traits for simba's wide wrappers


