### PR TITLE
Update no_std_test to work with latest nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           targets: thumbv6m-none-eabi
       - name: "Build with #[no_std]"
-        run: cargo build -v -p no_std_test --all-features --target thumbv6m-none-eabi
+        run: cargo rustc -v -p no_std_test --all-features --target thumbv6m-none-eabi -- -C panic=abort
   miri:
     name: Miri tests
     runs-on: ubuntu-latest

--- a/no_std_test/src/main.rs
+++ b/no_std_test/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(start))]
+#![cfg_attr(feature = "nightly", no_main)]
 #![no_std]
 
 #[cfg(feature = "nightly")]
@@ -7,8 +7,8 @@ use core::panic::PanicInfo;
 extern crate libc;
 
 #[cfg(feature = "nightly")]
-#[start]
-fn start(_argc: isize, _argv: *const *const u8) -> isize {
+#[no_mangle]
+pub extern "C" fn main(_argc: isize, _argv: *const *const u8) -> isize {
     let _magenta = palette::Srgb::new(255u8, 0, 255);
 
     0


### PR DESCRIPTION
The `start` feature and attribute is gone, and we use a C-style main function instead. Also had to specify `panic=abort` to prevent panic handlers.