### PR TITLE
Specify full dependency versions and check compatibility in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,17 @@ jobs:
         run: cargo miri test -p palette --lib --features "bytemuck" -- -Z unstable-options --report-time
       - name: Documentation tests
         run: cargo miri test -p palette --doc --features "bytemuck" -- -Z unstable-options --report-time
+  minimal_versions:
+    name: Minimal dependency versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - name: Check minimal versions
+        run: cargo minimal-versions check --ignore-private --all-features
   documentation:
     name: Documentation
     runs-on: ubuntu-latest

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -44,7 +44,7 @@ bench = false
 
 [dependencies]
 palette_derive = { version = "0.7.6", path = "../palette_derive" }
-approx = { version = "0.5", default-features = false, optional = true }
+approx = { version = "0.5.0", default-features = false, optional = true }
 libm = { version = "0.2.1", default-features = false, optional = true }
 
 [dependencies.phf]
@@ -53,17 +53,17 @@ optional = true
 default-features = false
 
 [dependencies.rand]
-version = "0.8"
+version = "0.8.0"
 default-features = false
 optional = true
 
 [dependencies.serde]
-version = "1"
+version = "1.0.103"
 features = ["serde_derive"]
 optional = true
 
 [dependencies.bytemuck]
-version = "1"
+version = "1.0.0"
 optional = true
 
 [dependencies.wide]
@@ -72,7 +72,7 @@ optional = true
 default-features = false
 
 [dev-dependencies]
-serde_json = "1"
+serde_json = "1.0.0"
 ron = "=0.8.0"          # Pinned due to MSRV mismatch
 enterpolation = "0.2.0"
 
@@ -82,7 +82,7 @@ default-features = false
 features = ["png"]
 
 [dev-dependencies.rand_mt]
-version = "4"
+version = "4.0.0"
 default-features = false
 features = ["rand-traits"]
 

--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -26,7 +26,7 @@ syn = { version = "2.0.13", default-features = false, features = [
     "extra-traits",
     "proc-macro",
 ] }
-quote = "^1.0"
-proc-macro2 = "^1.0"
+quote = "1.0.0"
+proc-macro2 = "1.0.0"
 by_address = "1.2.1"
-find-crate = { version = "0.6", optional = true }
+find-crate = { version = "0.6.0", optional = true }


### PR DESCRIPTION
This makes the minimal supported dependency versions explicit and checked with every change.

Most notably, this sets `serde` to >= 1.0.103, since it's the earliest version that can be checked in CI. It's 5 years old, so hopefully not a problem, but please file an issue if this broke your build.