### PR TITLE
Warning fixes, miri test fixes, limit crc32fast version

### DIFF
--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -74,6 +74,7 @@ default-features = false
 serde_json = "1.0.0"
 ron = "=0.8.0"          # Pinned due to MSRV mismatch
 enterpolation = "0.2.0"
+crc32fast = "~1.4.0" # Limited due to MSRV mismatch
 
 [dev-dependencies.image]
 version = "0.23.14"

--- a/palette/examples/blend.rs
+++ b/palette/examples/blend.rs
@@ -68,7 +68,7 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/blend.png") {
         Ok(()) => println!("see 'example-data/output/blend.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/blend.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/blend.png': {e}"),
     }
 }
 

--- a/palette/examples/compose.rs
+++ b/palette/examples/compose.rs
@@ -123,7 +123,7 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/compose.png") {
         Ok(()) => println!("see 'example-data/output/compose.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/compose.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/compose.png': {e}"),
     }
 }
 

--- a/palette/examples/gradient.rs
+++ b/palette/examples/gradient.rs
@@ -113,6 +113,6 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/gradient.png") {
         Ok(()) => println!("see 'example-data/output/gradient.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/gradient.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/gradient.png': {e}"),
     }
 }

--- a/palette/examples/hue.rs
+++ b/palette/examples/hue.rs
@@ -23,6 +23,6 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/hue.png") {
         Ok(()) => println!("see 'example-data/output/hue.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/hue.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/hue.png': {e}"),
     }
 }

--- a/palette/examples/random.rs
+++ b/palette/examples/random.rs
@@ -111,6 +111,6 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/random.png") {
         Ok(()) => println!("see 'example-data/output/random.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/random.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/random.png': {e}"),
     }
 }

--- a/palette/examples/readme_examples.rs
+++ b/palette/examples/readme_examples.rs
@@ -46,8 +46,8 @@ fn pixels_and_buffers() {
     swap_red_and_blue(&mut image);
     let filename = "example-data/output/readme_pixels_and_buffers.png";
     match image.save(filename) {
-        Ok(()) => println!("see '{}' for the result", filename),
-        Err(e) => println!("could not write '{}': {}", filename, e),
+        Ok(()) => println!("see '{filename}' for the result"),
+        Err(e) => println!("could not write '{filename}': {e}"),
     }
 }
 
@@ -126,8 +126,8 @@ fn color_operations_2() {
     alpha_blend_images(&mut image1, &image2);
     let filename = "example-data/output/readme_color_operations_2.png";
     match image1.save(filename) {
-        Ok(()) => println!("see '{}' for the result", filename),
-        Err(e) => println!("could not write '{}': {}", filename, e),
+        Ok(()) => println!("see '{filename}' for the result"),
+        Err(e) => println!("could not write '{filename}': {e}"),
     }
 }
 
@@ -191,8 +191,8 @@ fn display_colors(filename: &str, displays: &[DisplayType]) {
 
     let _ = std::fs::create_dir("example-data/output");
     match image.save(filename) {
-        Ok(()) => println!("see '{}' for the result", filename),
-        Err(e) => println!("could not write '{}': {}", filename, e),
+        Ok(()) => println!("see '{filename}' for the result"),
+        Err(e) => println!("could not write '{filename}': {e}"),
     }
 }
 

--- a/palette/examples/saturate.rs
+++ b/palette/examples/saturate.rs
@@ -53,6 +53,6 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/saturate.png") {
         Ok(()) => println!("see 'example-data/output/saturate.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/saturate.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/saturate.png': {e}"),
     }
 }

--- a/palette/examples/shade.rs
+++ b/palette/examples/shade.rs
@@ -84,6 +84,6 @@ fn main() {
     let _ = std::fs::create_dir("example-data/output");
     match image.save("example-data/output/shade.png") {
         Ok(()) => println!("see 'example-data/output/shade.png' for the result"),
-        Err(e) => println!("failed to write 'example-data/output/shade.png': {}", e),
+        Err(e) => println!("failed to write 'example-data/output/shade.png': {e}"),
     }
 }

--- a/palette/src/cam16/full.rs
+++ b/palette/src/cam16/full.rs
@@ -484,7 +484,11 @@ mod test {
         cam16.colorfulness = 0.0;
         cam16.saturation = 0.0;
 
-        assert_eq!(cam16.into_xyz(parameters), cam16jch.into_xyz(parameters));
+        assert_relative_eq!(
+            cam16.into_xyz(parameters),
+            cam16jch.into_xyz(parameters),
+            epsilon = 0.00000000000001
+        );
     }
 
     #[test]

--- a/palette/src/cam16/partial.rs
+++ b/palette/src/cam16/partial.rs
@@ -65,6 +65,7 @@ macro_rules! make_partial_cam16 {
             #[doc = concat!("    cam16::{Cam16, Parameters, ", stringify!($name), "},")]
             /// };
             ///
+            /// # fn main() {
             #[doc = concat!("let partial = ", stringify!($name), "::new(50.0f32, 80.0, 120.0);")]
             ///
             /// // There's also `new_const`:
@@ -88,7 +89,8 @@ macro_rules! make_partial_cam16 {
             /// // It's also possible to convert from (and to) arrays and tuples:
             #[doc = concat!("let partial_from_array = ", stringify!($name), "::from([50.0f32, 80.0, 120.0]);")]
             #[doc = concat!("let partial_from_tuple = ", stringify!($name), "::from((50.0f32, 80.0, 120.0));")]
-            ///  ```
+            /// # }
+            /// ```
             #[derive(Clone, Copy, Debug, Default, ArrayCast, WithAlpha, FromColorUnclamped)]
             #[palette(
                 palette_internal,

--- a/palette/src/cam16/partial.rs
+++ b/palette/src/cam16/partial.rs
@@ -57,6 +57,9 @@ macro_rules! make_partial_cam16 {
             /// or to create a new value by calling
             #[doc = concat!("[`new`][", stringify!($name), "::new].")]
             /// ```
+            /// #[macro_use]
+            /// extern crate approx;
+            ///
             /// use palette::{
             ///     Srgb, FromColor, IntoColor, hues::Cam16Hue,
             #[doc = concat!("    cam16::{Cam16, Parameters, ", stringify!($name), "},")]
@@ -80,7 +83,7 @@ macro_rules! make_partial_cam16 {
             #[doc = concat!("let partial_from_full = ", stringify!($name), "::from(cam16_from_rgb);")]
             ///
             /// // Direct conversion has the same result as going via full CAM16.
-            /// assert_eq!(partial_from_rgb, partial_from_full);
+            /// assert_relative_eq!(partial_from_rgb, partial_from_full, epsilon = 0.001);
             ///
             /// // It's also possible to convert from (and to) arrays and tuples:
             #[doc = concat!("let partial_from_array = ", stringify!($name), "::from([50.0f32, 80.0, 120.0]);")]
@@ -748,7 +751,7 @@ mod test {
         // Uses the example color from https://observablehq.com/@jrus/cam16
         let xyz = Srgb::from(0x5588cc).into_linear().into_color_unclamped();
         let cam16: Cam16<f64> = Cam16::from_xyz(xyz, Parameters::TEST_DEFAULTS);
-        assert_partial_to_full!(cam16, epsilon = 0.0000000000001);
+        assert_partial_to_full!(cam16, epsilon = 0.000000000001);
     }
 
     #[test]
@@ -764,7 +767,7 @@ mod test {
         // Checks against the output from https://observablehq.com/@jrus/cam16
         let xyz = Srgb::from(0xffffff).into_linear().into_color_unclamped();
         let cam16: Cam16<f64> = Cam16::from_xyz(xyz, Parameters::TEST_DEFAULTS);
-        assert_partial_to_full!(cam16, epsilon = 0.000000000000001);
+        assert_partial_to_full!(cam16, epsilon = 0.000000000001);
     }
 
     #[test]
@@ -772,7 +775,7 @@ mod test {
         // Checks against the output from https://observablehq.com/@jrus/cam16
         let xyz = Srgb::from(0xff0000).into_linear().into_color_unclamped();
         let cam16: Cam16<f64> = Cam16::from_xyz(xyz, Parameters::TEST_DEFAULTS);
-        assert_partial_to_full!(cam16, epsilon = 0.0000000000001);
+        assert_partial_to_full!(cam16, epsilon = 0.000000000001);
     }
 
     #[test]
@@ -780,7 +783,7 @@ mod test {
         // Checks against the output from https://observablehq.com/@jrus/cam16
         let xyz = Srgb::from(0x00ff00).into_linear().into_color_unclamped();
         let cam16: Cam16<f64> = Cam16::from_xyz(xyz, Parameters::TEST_DEFAULTS);
-        assert_partial_to_full!(cam16, epsilon = 0.0000000000001);
+        assert_partial_to_full!(cam16, epsilon = 0.000000000001);
     }
 
     #[test]
@@ -788,6 +791,6 @@ mod test {
         // Checks against the output from https://observablehq.com/@jrus/cam16
         let xyz = Srgb::from(0x0000ff).into_linear().into_color_unclamped();
         let cam16: Cam16<f64> = Cam16::from_xyz(xyz, Parameters::TEST_DEFAULTS);
-        assert_partial_to_full!(cam16);
+        assert_partial_to_full!(cam16, epsilon = 0.000000000001);
     }
 }

--- a/palette/src/cam16/ucs_jab.rs
+++ b/palette/src/cam16/ucs_jab.rs
@@ -326,7 +326,7 @@ mod test {
         assert_relative_eq!(
             Cam16UcsJab::from_color_unclamped(cam16),
             ucs,
-            epsilon = 0.0000000000001
+            epsilon = 0.000000000001
         );
     }
 

--- a/palette/src/cam16/ucs_jmh.rs
+++ b/palette/src/cam16/ucs_jmh.rs
@@ -328,10 +328,15 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "approx")]
     fn cam16_roundtrip() {
         let ucs = Cam16UcsJmh::new(50.0f64, 80.0, 120.0);
         let cam16 = Cam16Jmh::from_color_unclamped(ucs);
-        assert_eq!(Cam16UcsJmh::from_color_unclamped(cam16), ucs);
+        assert_relative_eq!(
+            Cam16UcsJmh::from_color_unclamped(cam16),
+            ucs,
+            epsilon = 0.0000000000001
+        );
     }
 
     raw_pixel_conversion_tests!(Cam16UcsJmh<>: lightness, colorfulness, hue);
@@ -356,6 +361,7 @@ mod test {
     // Jab and Jmh have the same delta E.
     #[test]
     #[cfg(all(feature = "approx", feature = "alloc"))]
+    #[cfg_attr(miri, ignore)]
     fn jab_delta_e_equality() {
         let mut jab_colors: Vec<Cam16UcsJab<f64>> = alloc::vec::Vec::new();
 
@@ -386,6 +392,7 @@ mod test {
     // delta E.
     #[test]
     #[cfg(all(feature = "approx", feature = "alloc"))]
+    #[cfg_attr(miri, ignore)]
     fn jab_improved_delta_e_equality() {
         let mut jab_colors: Vec<Cam16UcsJab<f64>> = alloc::vec::Vec::new();
 

--- a/palette/src/cam16/ucs_jmh.rs
+++ b/palette/src/cam16/ucs_jmh.rs
@@ -298,13 +298,10 @@ impl_rand_traits_cylinder!(
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        cam16::{Cam16Jmh, Cam16UcsJmh},
-        convert::FromColorUnclamped,
-    };
+    use crate::cam16::Cam16UcsJmh;
 
     #[cfg(feature = "approx")]
-    use crate::color_difference::DeltaE;
+    use crate::{cam16::Cam16Jmh, color_difference::DeltaE, convert::FromColorUnclamped};
 
     #[cfg(all(feature = "approx", feature = "alloc"))]
     use crate::{

--- a/palette/src/cast/array.rs
+++ b/palette/src/cast/array.rs
@@ -1567,6 +1567,9 @@ mod test {
     #[cfg(feature = "alloc")]
     use crate::{LinSrgb, Srgb};
 
+    #[cfg(feature = "approx")]
+    use approx::assert_relative_eq;
+
     #[cfg(feature = "alloc")]
     #[test]
     fn array_vec_len_cap() {
@@ -1594,7 +1597,7 @@ mod test {
         assert_eq!(colors.capacity(), 8);
     }
 
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "approx"))]
     #[test]
     fn map_vec_in_place() {
         fn do_things(rgb: Srgb) -> LinSrgb {
@@ -1605,16 +1608,19 @@ mod test {
 
         let values = vec![Srgb::new(0.8, 1.0, 0.2), Srgb::new(0.9, 0.1, 0.3)];
         let result = super::map_vec_in_place(values, do_things);
-        assert_eq!(
-            result,
-            vec![
-                do_things(Srgb::new(0.8, 1.0, 0.2)),
-                do_things(Srgb::new(0.9, 0.1, 0.3))
-            ]
-        )
+        assert_relative_eq!(
+            result[0],
+            do_things(Srgb::new(0.8, 1.0, 0.2)),
+            epsilon = 0.000001
+        );
+        assert_relative_eq!(
+            result[1],
+            do_things(Srgb::new(0.9, 0.1, 0.3)),
+            epsilon = 0.000001
+        );
     }
 
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", feature = "approx"))]
     #[test]
     fn map_slice_box_in_place() {
         fn do_things(rgb: Srgb) -> LinSrgb {
@@ -1625,13 +1631,15 @@ mod test {
 
         let values = vec![Srgb::new(0.8, 1.0, 0.2), Srgb::new(0.9, 0.1, 0.3)].into_boxed_slice();
         let result = super::map_slice_box_in_place(values, do_things);
-        assert_eq!(
-            result,
-            vec![
-                do_things(Srgb::new(0.8, 1.0, 0.2)),
-                do_things(Srgb::new(0.9, 0.1, 0.3))
-            ]
-            .into_boxed_slice()
-        )
+        assert_relative_eq!(
+            result[0],
+            do_things(Srgb::new(0.8, 1.0, 0.2)),
+            epsilon = 0.000001
+        );
+        assert_relative_eq!(
+            result[1],
+            do_things(Srgb::new(0.9, 0.1, 0.3)),
+            epsilon = 0.000001
+        );
     }
 }

--- a/palette/src/cast/array.rs
+++ b/palette/src/cast/array.rs
@@ -1565,10 +1565,13 @@ pub enum VecCastErrorKind {
 #[cfg(test)]
 mod test {
     #[cfg(feature = "alloc")]
-    use crate::{LinSrgb, Srgb};
+    use crate::Srgb;
 
-    #[cfg(feature = "approx")]
+    #[cfg(all(feature = "approx", feature = "alloc"))]
     use approx::assert_relative_eq;
+
+    #[cfg(all(feature = "approx", feature = "alloc"))]
+    use crate::LinSrgb;
 
     #[cfg(feature = "alloc")]
     #[test]

--- a/palette/src/convert.rs
+++ b/palette/src/convert.rs
@@ -407,7 +407,7 @@
 //!     };
 //!     let color: LinSrgba = css_color.into_color();
 //!
-//!     assert_relative_eq!(color, LinSrgba::new(0.496933, 0.0, 1.0, 0.3));
+//!     assert_relative_eq!(color, LinSrgba::new(0.496933, 0.0, 1.0, 0.3), epsilon = 0.000001);
 //! }
 //! ```
 

--- a/palette/src/convert/from_into_color_mut.rs
+++ b/palette/src/convert/from_into_color_mut.rs
@@ -107,7 +107,7 @@ where
     /// This reuses the memory space, and the returned scope guard will restore
     /// the converted colors to their original type when it's dropped.
     #[must_use]
-    fn from_color_mut(color: &mut T) -> FromColorMutGuard<Self, T>;
+    fn from_color_mut(color: &mut T) -> FromColorMutGuard<'_, Self, T>;
 }
 
 impl<T, U> FromColorMut<U> for T
@@ -116,7 +116,7 @@ where
     U: FromColor<T> + ArrayCast<Array = T::Array> + Clone,
 {
     #[inline]
-    fn from_color_mut(color: &mut U) -> FromColorMutGuard<Self, U> {
+    fn from_color_mut(color: &mut U) -> FromColorMutGuard<'_, Self, U> {
         let color_clone = color.clone();
 
         let result: &mut T = cast::from_array_mut(cast::into_array_mut(color));
@@ -136,7 +136,7 @@ where
     U: FromColorMut<T> + ArrayCast<Array = T::Array>,
 {
     #[inline]
-    fn from_color_mut(colors: &mut [U]) -> FromColorMutGuard<Self, [U]> {
+    fn from_color_mut(colors: &mut [U]) -> FromColorMutGuard<'_, Self, [U]> {
         for color in &mut *colors {
             // Forgetting the guard leaves the colors in the converted state.
             core::mem::forget(T::from_color_mut(color));
@@ -202,7 +202,7 @@ where
     /// the converted colors to their original type when it's dropped.
     #[allow(clippy::wrong_self_convention)]
     #[must_use]
-    fn into_color_mut(&mut self) -> FromColorMutGuard<T, Self>;
+    fn into_color_mut(&mut self) -> FromColorMutGuard<'_, T, Self>;
 }
 
 impl<T, U> IntoColorMut<T> for U
@@ -211,7 +211,7 @@ where
     U: FromColorMut<T> + ?Sized,
 {
     #[inline]
-    fn into_color_mut(&mut self) -> FromColorMutGuard<T, Self> {
+    fn into_color_mut(&mut self) -> FromColorMutGuard<'_, T, Self> {
         T::from_color_mut(self)
     }
 }

--- a/palette/src/convert/from_into_color_unclamped_mut.rs
+++ b/palette/src/convert/from_into_color_unclamped_mut.rs
@@ -108,7 +108,7 @@ where
     /// This reuses the memory space, and the returned scope guard will restore
     /// the converted colors to their original type when it's dropped.
     #[must_use]
-    fn from_color_unclamped_mut(color: &mut T) -> FromColorUnclampedMutGuard<Self, T>;
+    fn from_color_unclamped_mut(color: &mut T) -> FromColorUnclampedMutGuard<'_, Self, T>;
 }
 
 impl<T, U> FromColorUnclampedMut<U> for T
@@ -117,7 +117,7 @@ where
     U: FromColorUnclamped<T> + ArrayCast<Array = T::Array> + Clone,
 {
     #[inline]
-    fn from_color_unclamped_mut(color: &mut U) -> FromColorUnclampedMutGuard<Self, U> {
+    fn from_color_unclamped_mut(color: &mut U) -> FromColorUnclampedMutGuard<'_, Self, U> {
         let color_clone = color.clone();
 
         let result: &mut Self = cast::from_array_mut(cast::into_array_mut(color));
@@ -137,7 +137,7 @@ where
     U: FromColorUnclampedMut<T> + ArrayCast<Array = T::Array>,
 {
     #[inline]
-    fn from_color_unclamped_mut(colors: &mut [U]) -> FromColorUnclampedMutGuard<Self, [U]> {
+    fn from_color_unclamped_mut(colors: &mut [U]) -> FromColorUnclampedMutGuard<'_, Self, [U]> {
         for color in &mut *colors {
             // Forgetting the guard leaves the colors in the converted state.
             core::mem::forget(T::from_color_unclamped_mut(color));
@@ -203,7 +203,7 @@ where
     /// the converted colors to their original type when it's dropped.
     #[allow(clippy::wrong_self_convention)]
     #[must_use]
-    fn into_color_unclamped_mut(&mut self) -> FromColorUnclampedMutGuard<T, Self>;
+    fn into_color_unclamped_mut(&mut self) -> FromColorUnclampedMutGuard<'_, T, Self>;
 }
 
 impl<T, U> IntoColorUnclampedMut<T> for U
@@ -212,7 +212,7 @@ where
     U: FromColorUnclampedMut<T> + ?Sized,
 {
     #[inline]
-    fn into_color_unclamped_mut(&mut self) -> FromColorUnclampedMutGuard<T, Self> {
+    fn into_color_unclamped_mut(&mut self) -> FromColorUnclampedMutGuard<'_, T, Self> {
         T::from_color_unclamped_mut(self)
     }
 }

--- a/palette/src/encoding/prophoto.rs
+++ b/palette/src/encoding/prophoto.rs
@@ -233,6 +233,7 @@ mod test {
 
         #[test]
         #[cfg(feature = "approx")]
+        #[cfg_attr(miri, ignore)]
         fn test_u16_f32_into_impl() {
             for i in 0..=65535u16 {
                 let u16_impl: f32 = ProPhotoRgb::into_linear(i);
@@ -243,6 +244,7 @@ mod test {
 
         #[test]
         #[cfg(feature = "approx")]
+        #[cfg_attr(miri, ignore)]
         fn test_u16_f64_into_impl() {
             for i in 0..=65535u16 {
                 let u16_impl: f64 = ProPhotoRgb::into_linear(i);
@@ -252,6 +254,7 @@ mod test {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn u16_to_f32_to_u16() {
             for expected in 0..=65535u16 {
                 let linear: f32 = ProPhotoRgb::into_linear(expected);
@@ -261,6 +264,7 @@ mod test {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn u16_to_f64_to_u16() {
             for expected in 0..=65535u16 {
                 let linear: f64 = ProPhotoRgb::into_linear(expected);

--- a/palette/src/hsl.rs
+++ b/palette/src/hsl.rs
@@ -658,6 +658,7 @@ mod test {
     /// Sanity check to make sure the test doesn't start accepting known
     /// non-uniform distributions.
     #[cfg(feature = "random")]
+    #[cfg_attr(miri, ignore)]
     #[test]
     #[should_panic(expected = "is not uniform enough")]
     fn uniform_distribution_fail() {

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -916,7 +916,7 @@ mod test {
                 let hue = OklabHue::from_degrees(degree);
                 let (a, b) = hue.into_cartesian();
                 let roundtrip_hue = OklabHue::from_cartesian(a * 10000.0, b * 10000.0);
-                assert_abs_diff_eq!(roundtrip_hue, hue);
+                assert_abs_diff_eq!(roundtrip_hue, hue, epsilon = 0.0000000000001);
             }
         }
 

--- a/palette/src/hues.rs
+++ b/palette/src/hues.rs
@@ -269,7 +269,7 @@ macro_rules! make_hues {
             }
 
             /// Return an iterator that moves hues out of the specified range.
-            pub fn drain<R>(&mut self, range: R) -> $iter_name<alloc::vec::Drain<T>>
+            pub fn drain<R>(&mut self, range: R) -> $iter_name<alloc::vec::Drain<'_, T>>
             where
                 R: core::ops::RangeBounds<usize> + Clone,
             {

--- a/palette/src/lch.rs
+++ b/palette/src/lch.rs
@@ -391,12 +391,13 @@ mod test {
         assert_relative_eq!(
             lhs1.delta_e(rhs1),
             lhs2.delta_e(rhs2),
-            epsilon = 0.0000000000001
+            epsilon = 0.000000000001
         );
     }
 
     // Lab and Lch have the same delta E.
     #[cfg(all(feature = "alloc", feature = "approx"))]
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn lab_delta_e_equality() {
         let mut lab_colors: Vec<Lab<D65, f64>> = Vec::new();
@@ -427,6 +428,7 @@ mod test {
     // Lab and Lch have the same delta E, so should also have the same improved
     // delta E.
     #[cfg(all(feature = "alloc", feature = "approx"))]
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn lab_improved_delta_e_equality() {
         let mut lab_colors: Vec<Lab<D65, f64>> = Vec::new();

--- a/palette/src/luv_bounds.rs
+++ b/palette/src/luv_bounds.rs
@@ -139,7 +139,8 @@ mod tests {
         assert_relative_eq!(
             line.intersect_length_at_angle(core::f64::consts::FRAC_PI_4)
                 .unwrap(),
-            core::f64::consts::FRAC_1_SQRT_2
+            core::f64::consts::FRAC_1_SQRT_2,
+            epsilon = 0.000000000000001
         );
         assert_eq!(
             line.intersect_length_at_angle(-core::f64::consts::FRAC_PI_4),
@@ -154,12 +155,14 @@ mod tests {
         assert_relative_eq!(
             line.intersect_length_at_angle(core::f64::consts::FRAC_PI_2)
                 .unwrap(),
-            2.0
+            2.0,
+            epsilon = 0.000000000000001
         );
         assert_relative_eq!(
             line.intersect_length_at_angle(2.0 * core::f64::consts::FRAC_PI_3)
                 .unwrap(),
-            4.0 / 3.0f64.sqrt()
+            4.0 / 3.0f64.sqrt(),
+            epsilon = 0.00000000000001
         );
     }
 

--- a/palette/src/macros/random.rs
+++ b/palette/src/macros/random.rs
@@ -33,6 +33,7 @@ macro_rules! test_uniform_distribution {
         max: $max:expr$(,)?
     ) => {
         #[cfg(feature = "random")]
+        #[cfg_attr(miri, ignore)]
         #[test]
         fn uniform_distribution_rng_gen() {
             use rand::Rng;
@@ -65,6 +66,7 @@ macro_rules! test_uniform_distribution {
         }
 
         #[cfg(feature = "random")]
+        #[cfg_attr(miri, ignore)]
         #[test]
         fn uniform_distribution_uniform_sample() {
             use rand::distributions::uniform::Uniform;
@@ -99,6 +101,7 @@ macro_rules! test_uniform_distribution {
         }
 
         #[cfg(feature = "random")]
+        #[cfg_attr(miri, ignore)]
         #[test]
         fn uniform_distribution_uniform_sample_inclusive() {
             use rand::distributions::uniform::Uniform;

--- a/palette/src/macros/struct_of_arrays.rs
+++ b/palette/src/macros/struct_of_arrays.rs
@@ -1121,7 +1121,7 @@ macro_rules! impl_struct_of_arrays_methods {
 
             /// Return an iterator that moves colors out of the specified range.
             #[inline(always)]
-            pub fn drain<R>(&mut self, range: R) -> Iter<alloc::vec::Drain<T> $(, $phantom_ty)?>
+            pub fn drain<R>(&mut self, range: R) -> Iter<alloc::vec::Drain<'_, T> $(, $phantom_ty)?>
             where
                 R: core::ops::RangeBounds<usize> + Clone,
             {
@@ -1219,7 +1219,7 @@ macro_rules! impl_struct_of_arrays_methods {
 
             /// Return an iterator that moves colors out of the specified range.
             #[inline(always)]
-            pub fn drain<R>(&mut self, range: R) -> crate::alpha::Iter<Iter<alloc::vec::Drain<T> $(, $phantom_ty)?>, alloc::vec::Drain<A>>
+            pub fn drain<R>(&mut self, range: R) -> crate::alpha::Iter<Iter<alloc::vec::Drain<'_, T> $(, $phantom_ty)?>, alloc::vec::Drain<'_, A>>
             where
                 R: core::ops::RangeBounds<usize> + Clone,
             {
@@ -1327,7 +1327,7 @@ macro_rules! impl_struct_of_arrays_methods_hue {
 
             /// Return an iterator that moves colors out of the specified range.
             #[inline(always)]
-            pub fn drain<R>(&mut self, range: R) -> Iter<alloc::vec::Drain<T> $(, $phantom_ty)?>
+            pub fn drain<R>(&mut self, range: R) -> Iter<alloc::vec::Drain<'_, T> $(, $phantom_ty)?>
             where
                 R: core::ops::RangeBounds<usize> + Clone,
             {
@@ -1426,7 +1426,7 @@ macro_rules! impl_struct_of_arrays_methods_hue {
 
             /// Return an iterator that moves colors out of the specified range.
             #[inline(always)]
-            pub fn drain<R>(&mut self, range: R) -> crate::alpha::Iter<Iter<alloc::vec::Drain<T> $(, $phantom_ty)?>, alloc::vec::Drain<A>>
+            pub fn drain<R>(&mut self, range: R) -> crate::alpha::Iter<Iter<alloc::vec::Drain<'_, T> $(, $phantom_ty)?>, alloc::vec::Drain<'_, A>>
             where
                 R: core::ops::RangeBounds<usize> + Clone,
             {

--- a/palette/src/ok_utils.rs
+++ b/palette/src/ok_utils.rs
@@ -584,8 +584,8 @@ mod tests {
             "Max chroma {} at hue {:?}° (Oklab a and b {}, {}).",
             max_chroma.lc.chroma, max_chroma.hue, max_chroma_a, max_chroma_b
         );
-        println!("{} <= a <= {}", min_a, max_a);
-        println!("{} <= b <= {}", min_b, max_b);
+        println!("{min_a} <= a <= {max_a}");
+        println!("{min_b} <= b <= {max_b}");
     }
 
     #[test]

--- a/palette/src/ok_utils.rs
+++ b/palette/src/ok_utils.rs
@@ -514,8 +514,8 @@ mod tests {
 
     #[test]
     fn test_toe() {
-        assert_eq!(toe(0.0), 0.0);
-        assert_eq!(toe(1.0), 1.0);
+        assert_relative_eq!(toe(0.0), 0.0);
+        assert_relative_eq!(toe(1.0), 1.0);
         let grey50srgb: Srgb = Rgb::<encoding::Srgb, u8>::from_str("#777777")
             .unwrap()
             .into_format();

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -313,22 +313,18 @@ mod tests {
                 let rgb: Srgb<u8> = Srgb::<f64>::from_color_unclamped(color).into_format();
                 println!(
                     "\n\
-                    roundtrip of {} (#{:x} / {:?})\n\
-                    =================================================",
-                    name, rgb, color
+                    roundtrip of {name} (#{rgb:x} / {color:?})\n\
+                    ================================================="
                 );
 
                 println!("Color is white: {}", color.is_white(EPSILON));
 
                 let okhsl = Okhsl::from_color_unclamped(color);
-                println!("Okhsl: {:?}", okhsl);
+                println!("Okhsl: {okhsl:?}");
                 let roundtrip_color = Oklab::from_color_unclamped(okhsl);
                 assert!(
                     Oklab::visually_eq(roundtrip_color, color, EPSILON),
-                    "'{}' failed.\n{:?}\n!=\n{:?}",
-                    name,
-                    roundtrip_color,
-                    color
+                    "'{name}' failed.\n{roundtrip_color:?}\n!=\n{color:?}"
                 );
             }
         }
@@ -372,10 +368,9 @@ mod tests {
             let lin_rgb = LinSrgb::<f64>::from_color_unclamped(rgb);
             let oklab = Oklab::from_color_unclamped(lin_rgb);
             println!(
-                "RGB: {:?}\n\
-            LinRgb: {:?}\n\
-            Oklab: {:?}",
-                rgb, lin_rgb, oklab
+                "RGB: {rgb:?}\n\
+            LinRgb: {lin_rgb:?}\n\
+            Oklab: {oklab:?}"
             );
             let okhsl = Okhsl::from_color_unclamped(oklab);
 
@@ -396,7 +391,7 @@ mod tests {
         let okhsl = Okhsl::new(0.0_f32, 0.5, 0.5);
         let rgb = Srgb::from_color_unclamped(okhsl);
         let rgb8: Rgb<encoding::Srgb, u8> = rgb.into_format();
-        let hex_str = format!("{:x}", rgb8);
+        let hex_str = format!("{rgb8:x}");
         assert_eq!(hex_str, "aa5a74");
     }
 

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -242,12 +242,10 @@ unsafe impl<T> bytemuck::Pod for Okhsl<T> where T: bytemuck::Pod {}
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        convert::{FromColorUnclamped, IntoColorUnclamped},
-        encoding,
-        rgb::Rgb,
-        Okhsl, Oklab, Srgb,
-    };
+    use crate::{convert::FromColorUnclamped, encoding, rgb::Rgb, Okhsl, Srgb};
+
+    #[cfg(feature = "approx")]
+    use crate::{convert::IntoColorUnclamped, Oklab};
 
     test_convert_into_from_xyz!(Okhsl);
 
@@ -402,6 +400,7 @@ mod tests {
         assert_eq!(rgb, Srgb::new(0.0, 0.0, 0.0));
     }
 
+    #[cfg(feature = "approx")]
     #[test]
     fn test_oklab_to_okhsl_saturated_white() {
         // Minimized check for the case in

--- a/palette/src/okhsl.rs
+++ b/palette/src/okhsl.rs
@@ -410,9 +410,10 @@ mod tests {
         // chroma check.
         let oklab = Oklab::new(1.0, 1.0, 0.0);
         let okhsl: Okhsl = oklab.into_color_unclamped();
-        assert_eq!(okhsl, Okhsl::new(0.0, 0.0, 1.0));
+        assert_relative_eq!(okhsl, Okhsl::new(0.0, 0.0, 1.0));
     }
 
+    #[cfg(feature = "approx")]
     #[test]
     fn test_oklab_to_okhsl_saturated_black() {
         // Minimized check for the case in
@@ -420,7 +421,7 @@ mod tests {
         // case, but another variant of it.
         let oklab = Oklab::new(0.0, 1.0, 0.0);
         let okhsl: Okhsl = oklab.into_color_unclamped();
-        assert_eq!(okhsl, Okhsl::new(0.0, 0.0, 0.0));
+        assert_relative_eq!(okhsl, Okhsl::new(0.0, 0.0, 0.0));
     }
 
     struct_of_arrays_tests!(

--- a/palette/src/okhsv.rs
+++ b/palette/src/okhsv.rs
@@ -348,20 +348,16 @@ mod tests {
                     crate::Srgb::<f64>::from_color_unclamped(color).into_format();
                 println!(
                     "\n\
-                    roundtrip of {} (#{:x} / {:?})\n\
-                    =================================================",
-                    name, rgb, color
+                    roundtrip of {name} (#{rgb:x} / {color:?})\n\
+                    ================================================="
                 );
 
                 let okhsv = Okhsv::from_color_unclamped(color);
-                println!("Okhsv: {:?}", okhsv);
+                println!("Okhsv: {okhsv:?}");
                 let roundtrip_color = Oklab::from_color_unclamped(okhsv);
                 assert!(
                     Oklab::visually_eq(roundtrip_color, color, EPSILON),
-                    "'{}' failed.\n{:?}\n!=\n{:?}",
-                    name,
-                    roundtrip_color,
-                    color
+                    "'{name}' failed.\n{roundtrip_color:?}\n!=\n{color:?}"
                 );
             }
         }
@@ -378,7 +374,7 @@ mod tests {
             let oklab_blue_64 = Oklab::<f64>::from_color_unclamped(lin_srgb_blue);
             let okhsv_blue_64 = Okhsv::from_color_unclamped(oklab_blue_64);
 
-            println!("Okhsv f64: {:?}\n", okhsv_blue_64);
+            println!("Okhsv f64: {okhsv_blue_64:?}\n");
             // HSV values of the reference implementation (in C)
             // 1 iteration : 264.0520206380550121, 0.9999910912349018, 0.9999999646150918
             // 2 iterations: 264.0520206380550121, 0.9999999869716002, 0.9999999646150844
@@ -418,7 +414,7 @@ mod tests {
             let okhsv = Okhsv::new(0.0_f32, 0.5, 0.5);
             let rgb = Srgb::from_color_unclamped(okhsv);
             let rgb8: Rgb<encoding::Srgb, u8> = rgb.into_format();
-            let hex_str = format!("{:x}", rgb8);
+            let hex_str = format!("{rgb8:x}");
             assert_eq!(hex_str, "7a4355");
         }
 
@@ -507,43 +503,42 @@ mod tests {
         {
             println!("sRGB Red");
             let oklab = Oklab::from_color_unclamped(LinSrgb::new(1.0, 0.0, 0.0));
-            println!("{:?}", oklab);
+            println!("{oklab:?}");
             let okhsv: Okhsv<f64> = Okhsv::from_color_unclamped(oklab);
-            println!("{:?}", okhsv);
+            println!("{okhsv:?}");
             assert!(okhsv.is_within_bounds());
         }
 
         {
             println!("Double sRGB Red");
             let oklab = Oklab::from_color_unclamped(LinSrgb::new(2.0, 0.0, 0.0));
-            println!("{:?}", oklab);
+            println!("{oklab:?}");
             let okhsv: Okhsv<f64> = Okhsv::from_color_unclamped(oklab);
-            println!("{:?}", okhsv);
+            println!("{okhsv:?}");
             assert!(!okhsv.is_within_bounds());
             let clamped_okhsv = okhsv.clamp();
-            println!("Clamped: {:?}", clamped_okhsv);
+            println!("Clamped: {clamped_okhsv:?}");
             assert!(clamped_okhsv.is_within_bounds());
             let linsrgb = LinSrgb::from_color_unclamped(clamped_okhsv);
-            println!("Clamped as unclamped Linear sRGB: {:?}", linsrgb);
+            println!("Clamped as unclamped Linear sRGB: {linsrgb:?}");
         }
 
         {
             println!("P3 Yellow");
             // display P3 yellow according to https://colorjs.io/apps/convert/?color=color(display-p3%201%201%200)&precision=17
             let oklab = Oklab::from_color_unclamped(LinSrgb::new(1.0, 1.0, -0.098273600140966));
-            println!("{:?}", oklab);
+            println!("{oklab:?}");
             let okhsv: Okhsv<f64> = Okhsv::from_color_unclamped(oklab);
-            println!("{:?}", okhsv);
+            println!("{okhsv:?}");
             assert!(!okhsv.is_within_bounds());
             let clamped_okhsv = okhsv.clamp();
-            println!("Clamped: {:?}", clamped_okhsv);
+            println!("Clamped: {clamped_okhsv:?}");
             assert!(clamped_okhsv.is_within_bounds());
             let linsrgb = LinSrgb::from_color_unclamped(clamped_okhsv);
             println!(
-                "Clamped as unclamped Linear sRGB: {:?}\n\
+                "Clamped as unclamped Linear sRGB: {linsrgb:?}\n\
                 May be different, but should be visually indistinguishable from\n\
-                color.js' gamut mapping red: 1 green: 0.9876530763223166 blue: 0",
-                linsrgb
+                color.js' gamut mapping red: 1 green: 0.9876530763223166 blue: 0"
             );
         }
     }

--- a/palette/src/okhwb.rs
+++ b/palette/src/okhwb.rs
@@ -233,49 +233,37 @@ mod tests {
                     crate::Srgb::<f64>::from_color_unclamped(color).into_format();
                 println!(
                     "\n\
-                    roundtrip of {} (#{:x} / {:?})\n\
-                    =================================================",
-                    name, rgb, color
+                    roundtrip of {name} (#{rgb:x} / {color:?})\n\
+                    ================================================="
                 );
 
                 let okhsv = Okhsv::from_color_unclamped(color);
-                println!("Okhsv: {:?}", okhsv);
+                println!("Okhsv: {okhsv:?}");
                 let okhwb_from_okhsv = Okhwb::from_color_unclamped(okhsv);
                 let okhwb = Okhwb::from_color_unclamped(color);
-                println!("Okhwb: {:?}", okhwb);
+                println!("Okhwb: {okhwb:?}");
                 assert!(
                 Okhwb::visually_eq(okhwb, okhwb_from_okhsv, EPSILON),
-                "Okhwb \n{:?} is not visually equal to Okhwb from Okhsv \n{:?}\nwithin EPSILON {}",
-                okhwb,
-                okhwb_from_okhsv,
-                EPSILON
+                "Okhwb \n{okhwb:?} is not visually equal to Okhwb from Okhsv \n{okhwb_from_okhsv:?}\nwithin EPSILON {EPSILON}"
             );
                 let okhsv_from_okhwb = Okhsv::from_color_unclamped(okhwb);
                 assert!(
                 Okhsv::visually_eq(okhsv, okhsv_from_okhwb, EPSILON),
-                "Okhsv \n{:?} is not visually equal to Okhsv from Okhsv from Okhwb \n{:?}\nwithin EPSILON {}",
-                okhsv,
-                okhsv_from_okhwb, EPSILON
+                "Okhsv \n{okhsv:?} is not visually equal to Okhsv from Okhsv from Okhwb \n{okhsv_from_okhwb:?}\nwithin EPSILON {EPSILON}"
             );
 
                 let roundtrip_color = Oklab::from_color_unclamped(okhwb);
                 let oklab_from_okhsv = Oklab::from_color_unclamped(okhsv);
                 assert!(
                     Oklab::visually_eq(roundtrip_color, oklab_from_okhsv, EPSILON),
-                    "roundtrip color \n{:?} does not match \n{:?}\nwithin EPSILON {}",
-                    roundtrip_color,
-                    oklab_from_okhsv,
-                    EPSILON
+                    "roundtrip color \n{roundtrip_color:?} does not match \n{oklab_from_okhsv:?}\nwithin EPSILON {EPSILON}"
                 );
                 assert!(
                     Oklab::visually_eq(roundtrip_color, color, EPSILON),
-                    "'{}' failed.\n\
-                {:?}\n\
+                    "'{name}' failed.\n\
+                {roundtrip_color:?}\n\
                 !=\n\
-                \n{:?}\n",
-                    name,
-                    roundtrip_color,
-                    color
+                \n{color:?}\n"
                 );
             }
         }

--- a/palette/src/oklab.rs
+++ b/palette/src/oklab.rs
@@ -599,7 +599,7 @@ mod test {
         #[test]
         fn blue() {
             let a = Oklab::from_color(LinSrgb::new(0.0, 0.0, 1.0));
-            println!("Oklab blue: {:?}", a);
+            println!("Oklab blue: {a:?}");
             // from https://github.com/bottosson/bottosson.github.io/blob/master/misc/ok_color.h
             let b = Oklab::new(0.4520137183853429, -0.0324569841687640, -0.3115281476783751);
             assert!(Oklab::visually_eq(a, b, 1e-8));

--- a/palette/src/oklch.rs
+++ b/palette/src/oklch.rs
@@ -210,22 +210,18 @@ mod test {
                 let rgb: Srgb<u8> = Srgb::<f64>::from_color_unclamped(color).into_format();
                 println!(
                     "\n\
-                    roundtrip of {} (#{:x} / {:?})\n\
-                    =================================================",
-                    name, rgb, color
+                    roundtrip of {name} (#{rgb:x} / {color:?})\n\
+                    ================================================="
                 );
 
                 println!("Color is white: {}", color.is_white(EPSILON));
 
                 let oklch = Oklch::from_color_unclamped(color);
-                println!("Oklch: {:?}", oklch);
+                println!("Oklch: {oklch:?}");
                 let roundtrip_color = Oklab::from_color_unclamped(oklch);
                 assert!(
                     Oklab::visually_eq(roundtrip_color, color, EPSILON),
-                    "'{}' failed.\n{:?}\n!=\n{:?}",
-                    name,
-                    roundtrip_color,
-                    color
+                    "'{name}' failed.\n{roundtrip_color:?}\n!=\n{color:?}"
                 );
             }
         }

--- a/palette/src/random_sampling/cone.rs
+++ b/palette/src/random_sampling/cone.rs
@@ -172,8 +172,8 @@ mod test {
             ( $x:expr, $y:expr ) => {{
                 let hsl = sample_hsl($x, $y);
                 let a = invert_hsl_sample(hsl);
-                assert_relative_eq!(a.0, $x);
-                assert_relative_eq!(a.1, $y);
+                assert_relative_eq!(a.0, $x, epsilon = 0.000000000000001);
+                assert_relative_eq!(a.1, $y, epsilon = 0.000000000000001);
             }};
         }
 

--- a/palette/src/rgb/rgb.rs
+++ b/palette/src/rgb/rgb.rs
@@ -1168,16 +1168,14 @@ impl From<&'static str> for FromHexError {
 impl core::fmt::Display for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FromHexError::ParseIntError(e) => write!(f, "{}", e),
+            FromHexError::ParseIntError(e) => write!(f, "{e}"),
             FromHexError::HexFormatError(s) => write!(
                 f,
-                "{}, please use format '#fff', 'fff', '#ffffff', 'ffffff', etc.",
-                s
+                "{s}, please use format '#fff', 'fff', '#ffffff', 'ffffff', etc."
             ),
             FromHexError::RgbaHexFormatError(s) => write!(
                 f,
-                "{}, please use format '#ffff', 'ffff', '#ffffffff', 'ffffffff', etc.",
-                s
+                "{s}, please use format '#ffff', 'ffff', '#ffffffff', 'ffffffff', etc."
             ),
         }
     }

--- a/palette_derive/src/cast/array_cast.rs
+++ b/palette_derive/src/cast/array_cast.rs
@@ -92,10 +92,7 @@ pub fn derive(tokens: TokenStream) -> std::result::Result<TokenStream, Vec<syn::
     if !allowed_repr {
         errors.push(syn::Error::new(
             Span::call_site(),
-            format!(
-                "a `#[repr(C)]` or `#[repr(transparent)]` attribute is required to give `{}` a fixed memory layout",
-                ident
-            ),
+            format!("a `#[repr(C)]` or `#[repr(transparent)]` attribute is required to give `{ident}` a fixed memory layout"),
         ));
     }
 

--- a/palette_derive/src/meta/mod.rs
+++ b/palette_derive/src/meta/mod.rs
@@ -2,10 +2,10 @@ use proc_macro2::TokenStream;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse::{Parse, ParseStream, Parser, Result},
+    parse::{Parser, Result},
     token::Comma,
 };
-use syn::{Attribute, Fields, Ident, Index, LitStr, Meta, Token, Type};
+use syn::{Attribute, Fields, Ident, Index, Meta, Type};
 
 pub use self::field_attributes::*;
 pub use self::type_item_attributes::*;
@@ -138,27 +138,6 @@ pub fn assert_path_meta(meta: &Meta) -> Result<()> {
     }
 
     Ok(())
-}
-
-#[derive(PartialEq, Eq)]
-pub struct KeyValuePair {
-    pub key: Ident,
-    pub value: Ident,
-}
-
-impl Parse for KeyValuePair {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let key: Ident = input.parse()?;
-        input.parse::<Token![=]>()?;
-        let value = input.parse::<LitStr>()?.parse::<Ident>()?;
-        Ok(KeyValuePair { key, value })
-    }
-}
-
-impl PartialEq<str> for KeyValuePair {
-    fn eq(&self, other: &str) -> bool {
-        self.key == other
-    }
 }
 
 #[derive(Clone)]

--- a/palette_derive/src/meta/type_item_attributes.rs
+++ b/palette_derive/src/meta/type_item_attributes.rs
@@ -46,7 +46,7 @@ impl AttributeArgumentParser for TypeItemAttributes {
                         } else {
                             errors.push(syn::Error::new(
                                 skipped_color.span(),
-                                format!("`{}` is not a valid color type", skipped_color),
+                                format!("`{skipped_color}` is not a valid color type"),
                             ));
                             continue;
                         };

--- a/palette_derive/src/util.rs
+++ b/palette_derive/src/util.rs
@@ -36,10 +36,7 @@ fn find_crate_name() -> Ident {
     match find_crate::find_crate(|name| name == "palette") {
         Ok(package) => Ident::new(&package.name, Span::call_site()),
         Err(Error::NotFound) => Ident::new("palette", Span::call_site()),
-        Err(error) => panic!(
-            "error when trying to find the name of the `palette` crate: {}",
-            error
-        ),
+        Err(error) => panic!("error when trying to find the name of the `palette` crate: {error}"),
     }
 }
 


### PR DESCRIPTION
* Fix some new warnings from new `rusc` and `clippy` versions
* Relax some float comparisons since `miri` is now testing math library non-determinism
* Limit `crc32fast` to 1.4.X to avoid increasing MSRV. It's just a dev-dependency.