### PR TITLE
Increase MSRV to 1.68.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.61.0
+      - uses: dtolnay/rust-toolchain@1.68.0
         with:
           components: clippy
       - name: Minimal check
@@ -40,7 +40,7 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.63.0
+      - uses: dtolnay/rust-toolchain@1.68.0
         with:
           components: clippy
       - uses: taiki-e/install-action@cargo-hack

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.61.0`, `1.63.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
+This version of Palette has been automatically tested with Rust version `1.68.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
 
 Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["color", "conversion", "linear", "pixel", "rgb"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 categories = ["graphics", "multimedia::images", "no-std"]
-rust-version = "1.61.0"
+rust-version = "1.68.0"
 
 [features]
 default = ["named_from_str", "std", "approx"]
@@ -74,9 +74,8 @@ default-features = false
 
 [dev-dependencies]
 serde_json = "1.0.0"
-ron = "=0.8.0"          # Pinned due to MSRV mismatch
+ron = "0.8.0"
 enterpolation = "0.2.0"
-crc32fast = "~1.4.0" # Limited due to MSRV mismatch
 
 [dev-dependencies.image]
 version = "0.23.14"

--- a/palette/README.md
+++ b/palette/README.md
@@ -15,7 +15,7 @@ A color management and conversion library that focuses on maintaining correctnes
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.61.0`, `1.63.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
+This version of Palette has been automatically tested with Rust version `1.68.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
 
 Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 

--- a/palette/src/lib.rs
+++ b/palette/src/lib.rs
@@ -901,10 +901,10 @@ where
 /// let blue = LinSrgb::new(0.0f32, 0.0, 1.0);
 /// let gray = LinSrgb::new(0.5f32, 0.5, 0.5);
 ///
-/// assert_relative_eq!(red.get_hue(), 0.0.into());
-/// assert_relative_eq!(green.get_hue(), 120.0.into());
-/// assert_relative_eq!(blue.get_hue(), 240.0.into());
-/// assert_relative_eq!(gray.get_hue(), 0.0.into());
+/// assert_relative_eq!(red.get_hue(), 0.0.into(), epsilon = 0.0001);
+/// assert_relative_eq!(green.get_hue(), 120.0.into(), epsilon = 0.0001);
+/// assert_relative_eq!(blue.get_hue(), 240.0.into(), epsilon = 0.0001);
+/// assert_relative_eq!(gray.get_hue(), 0.0.into(), epsilon = 0.0001);
 /// ```
 pub trait GetHue {
     /// The kind of hue unit this color space uses.

--- a/palette_derive/Cargo.toml
+++ b/palette_derive/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["palette", "derive", "macros"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.68.0"
 
 [lib]
 proc-macro = true

--- a/palette_derive/README.md
+++ b/palette_derive/README.md
@@ -4,7 +4,7 @@ Contains derive macros for the [`palette`](https://crates.io/crates/palette/) cr
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.61.0`, `1.63.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
+This version of Palette has been automatically tested with Rust version `1.68.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
 
 Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 

--- a/palette_math/Cargo.toml
+++ b/palette_math/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 resolver = "2"
 categories = ["graphics", "multimedia::images", "no-std"]
-rust-version = "1.61.0"
+rust-version = "1.68.0"
 
 [features]
 default=["std"]

--- a/palette_math/README.md
+++ b/palette_math/README.md
@@ -4,7 +4,7 @@ The low level color math behind the more high level [`palette`](https://crates.i
 
 ## Minimum Supported Rust Version (MSRV)
 
-This version of Palette has been automatically tested with Rust version `1.61.0`, `1.63.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
+This version of Palette has been automatically tested with Rust version `1.68.0`, and the `stable`, `beta`, and `nightly` channels. The minimum supported version may vary with the set of enabled features.
 
 Future versions of the library may advance the minimum supported version to make use of new language features, but this will normally be considered a breaking change. Exceptions may be made for security patches, dependencies advancing their MSRV in minor or patch releases, and similar changes.
 


### PR DESCRIPTION
This follows an MSRV increase in `syn`, which is a required dependency for generating conversion code among other things.
