### PR TITLE
Add support for `wide` 1.X

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -30,7 +30,7 @@ codspeed-criterion-compat = "2.1.0"
 criterion = { version = "0.5.1", default-features = false }
 csv = "1"
 lazy_static = "1"
-palette = { path = "../palette", features = ["wide"] }
+palette = { path = "../palette", features = ["wide_1"] }
 serde = "1"
 serde_derive = "1"
-wide = "0.7.3"
+wide = "1.2.0"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -17,12 +17,12 @@ path = "regression_tests/issue_283.rs"
 approx = { version = "0.5", default-features = false }
 csv = "1"
 lazy_static = "1"
-palette = { path = "../palette", features = ["wide"] }
+palette = { path = "../palette", features = ["wide_1"] }
 scad = "1.2.2" # For regression testing #283
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 
 [dev-dependencies.wide]
-version = "0.7.3"
+version = "1.2.0"
 default-features = false

--- a/palette/Cargo.toml
+++ b/palette/Cargo.toml
@@ -35,6 +35,7 @@ std = ["alloc", "approx?/std", "palette_math/std"]
 alloc = ["palette_math/alloc"]
 libm = ["dep:libm", "palette_math/libm"]
 wide = ["dep:wide", "palette_math/wide"]
+wide_1 = ["dep:wide_1", "palette_math/wide_1"]
 
 # Deprecated. Alias for `"named"`.
 named_from_str = ["named"]
@@ -47,6 +48,8 @@ palette_derive = { version = "0.7.6", path = "../palette_derive" }
 palette_math = { version = "0.7.6", path = "../palette_math", default-features = false}
 approx = { version = "0.5.0", default-features = false, optional = true }
 libm = { version = "0.2.1", default-features = false, optional = true }
+wide = { version = "0.7.3", default-features = false, optional = true }
+wide_1 = { package = "wide", version = "1.2.0", default-features = false, optional = true }
 
 [dependencies.phf]
 version = "0.12.1"
@@ -66,11 +69,6 @@ optional = true
 [dependencies.bytemuck]
 version = "1.0.0"
 optional = true
-
-[dependencies.wide]
-version = "0.7.3"
-optional = true
-default-features = false
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/palette/README.md
+++ b/palette/README.md
@@ -52,12 +52,13 @@ These features are disabled by default:
 * `"random"` - Enables generating random colors using [`rand`].
 * `"libm"` - Uses the [`libm`] floating point math library (for when the `std` feature is disabled).
 * `"bytemuck"` - Enables casting between plain data types using [`bytemuck`].
-* `"wide"` - Enables support for using SIMD types from [`wide`].
+* `"wide_1"` - Enables support for using SIMD types from [`wide`] 1.X.Y.
 * `"find-crate"` - Enables derives to find the `palette` crate when it's renamed in `Cargo.toml`.
 
 These features have been deprecated:
 
 * `"named_from_str"` - Alias for `"named"`, still enabled by default. <strike>Enables `named::from_str`, which maps name strings to colors.</strike>
+* `"wide"` - Enables support for using SIMD types from [`wide`] 0.7.X.
 
 ### Using palette in an embedded environment
 

--- a/palette/src/angle.rs
+++ b/palette/src/angle.rs
@@ -7,6 +7,8 @@ use crate::{
 
 #[cfg(feature = "wide")]
 mod wide;
+#[cfg(feature = "wide_1")]
+mod wide_1;
 
 /// Represents types that can express half of a rotation (i.e. 180 degrees).
 pub trait HalfRotation {

--- a/palette/src/angle/wide_1.rs
+++ b/palette/src/angle/wide_1.rs
@@ -1,0 +1,58 @@
+use ::wide_1::{f32x4, f32x8, f64x2, f64x4, CmpEq};
+
+use super::*;
+
+macro_rules! impl_angle_wide_float {
+    ($($ty: ident),+) => {
+        $(
+            impl HalfRotation for $ty {
+                #[inline]
+                fn half_rotation() -> Self {
+                    $ty::splat(180.0)
+                }
+            }
+
+            impl FullRotation for $ty {
+                #[inline]
+                fn full_rotation() -> Self {
+                    $ty::splat(360.0)
+                }
+            }
+
+            impl RealAngle for $ty {
+                #[inline]
+                fn degrees_to_radians(self) -> Self {
+                    self.to_radians()
+                }
+
+                #[inline]
+                fn radians_to_degrees(self) -> Self {
+                    self.to_degrees()
+                }
+            }
+
+            impl AngleEq for $ty {
+                #[inline]
+                fn angle_eq(&self, other: &Self) -> Self {
+                    self.normalize_unsigned_angle().simd_eq(other.normalize_unsigned_angle())
+                }
+            }
+
+            impl SignedAngle for $ty {
+                #[inline]
+                fn normalize_signed_angle(self) -> Self {
+                    self - Round::ceil(((self + 180.0) / 360.0) - 1.0) * 360.0
+                }
+            }
+
+            impl UnsignedAngle for $ty {
+                #[inline]
+                fn normalize_unsigned_angle(self) -> Self {
+                    self - (Round::floor(self / 360.0) * 360.0)
+                }
+            }
+        )+
+    };
+}
+
+impl_angle_wide_float!(f32x4, f32x8, f64x2, f64x4);

--- a/palette/src/bool_mask.rs
+++ b/palette/src/bool_mask.rs
@@ -7,6 +7,8 @@ use core::ops::{BitAnd, BitOr, BitXor, Not};
 
 #[cfg(feature = "wide")]
 mod wide;
+#[cfg(feature = "wide_1")]
+mod wide_1;
 
 /// Associates a Boolean type to the implementing type.
 ///

--- a/palette/src/bool_mask/wide_1.rs
+++ b/palette/src/bool_mask/wide_1.rs
@@ -1,0 +1,95 @@
+use wide_1::{f32x4, f32x8, f64x2, f64x4};
+
+use super::{BoolMask, HasBoolMask, LazySelect, Select};
+
+macro_rules! impl_wide_bool_mask {
+    ($($ty: ident: ($scalar: ident, $uint: ident)),+) => {
+        $(
+            impl BoolMask for $ty {
+                #[inline]
+                fn from_bool(value: bool) -> Self {
+                    $ty::splat(if value { $scalar::from_bits($uint::MAX) } else { 0.0 })
+                }
+
+                #[inline]
+                fn is_true(&self) -> bool {
+                    self.all()
+                }
+
+                #[inline]
+                fn is_false(&self) -> bool {
+                    self.none()
+                }
+            }
+
+            impl HasBoolMask for $ty {
+                type Mask = Self;
+            }
+
+            impl Select<Self> for $ty {
+                #[inline]
+                fn select(self, a: Self, b: Self) -> Self {
+                    self.blend(a, b)
+                }
+            }
+
+            impl LazySelect<Self> for $ty {
+                #[inline]
+                fn lazy_select<A, B>(self, a: A, b: B) -> Self
+                where
+                    A: FnOnce() -> Self,
+                    B: FnOnce() -> Self,
+                {
+                    let a = a();
+                    let b = b();
+
+                    self.select(a, b)
+                }
+            }
+        )+
+    };
+}
+
+impl_wide_bool_mask!(
+    f32x4: (f32, u32),
+    f32x8: (f32, u32),
+    f64x2: (f64, u64),
+    f64x4: (f64, u64)
+);
+
+#[cfg(test)]
+mod test {
+    use wide_1::{f32x4, f32x8, f64x2, f64x4};
+
+    use crate::bool_mask::BoolMask;
+
+    #[test]
+    fn from_true() {
+        assert!(f32x4::from_bool(true).is_true());
+        assert!(!f32x4::from_bool(true).is_false());
+
+        assert!(f32x8::from_bool(true).is_true());
+        assert!(!f32x8::from_bool(true).is_false());
+
+        assert!(f64x2::from_bool(true).is_true());
+        assert!(!f64x2::from_bool(true).is_false());
+
+        assert!(f64x4::from_bool(true).is_true());
+        assert!(!f64x4::from_bool(true).is_false());
+    }
+
+    #[test]
+    fn from_false() {
+        assert!(f32x4::from_bool(false).is_false());
+        assert!(!f32x4::from_bool(false).is_true());
+
+        assert!(f32x8::from_bool(false).is_false());
+        assert!(!f32x8::from_bool(false).is_true());
+
+        assert!(f64x2::from_bool(false).is_false());
+        assert!(!f64x2::from_bool(false).is_true());
+
+        assert!(f64x4::from_bool(false).is_false());
+        assert!(!f64x4::from_bool(false).is_true());
+    }
+}

--- a/palette/src/cam16/full.rs
+++ b/palette/src/cam16/full.rs
@@ -649,7 +649,7 @@ mod test {
         );
     }
 
-    #[cfg(feature = "wide")]
+    #[cfg(feature = "wide_1")]
     #[test]
     fn simd() {
         let white_srgb = Srgb::from(0xffffff).into_format();
@@ -692,7 +692,7 @@ mod test {
             saturation: 87.47645277637828,
         };
 
-        let srgb = Srgb::<wide::f64x4>::from([white_srgb, red_srgb, green_srgb, blue_srgb]);
+        let srgb = Srgb::<wide_1::f64x4>::from([white_srgb, red_srgb, green_srgb, blue_srgb]);
         let xyz = srgb.into_linear().into_color_unclamped();
         let mut cam16 = Cam16::from_xyz(xyz, Parameters::TEST_DEFAULTS);
         cam16.hue = cam16.hue.into_positive_degrees().into();

--- a/palette/src/num.rs
+++ b/palette/src/num.rs
@@ -20,6 +20,8 @@ use crate::bool_mask::HasBoolMask;
 mod libm;
 #[cfg(feature = "wide")]
 mod wide;
+#[cfg(feature = "wide_1")]
+mod wide_1;
 
 pub use palette_math::num::{One, Powf, Powi, Powu, Recip};
 

--- a/palette/src/num/wide_1.rs
+++ b/palette/src/num/wide_1.rs
@@ -1,0 +1,296 @@
+use ::wide_1::{f32x4, f32x8, f64x2, f64x4, CmpEq, CmpGe, CmpGt, CmpLe, CmpLt, CmpNe};
+
+use super::*;
+
+macro_rules! impl_wide_float {
+    ($($ty: ident { array: [$scalar: ident; $n: expr], powf: $pow_self: ident, }),+) => {
+        $(
+            impl Real for $ty {
+                #[inline]
+                fn from_f64(n: f64) -> $ty {
+                    $ty::splat(n as $scalar)
+                }
+
+            }
+
+            impl FromScalar for $ty {
+                type Scalar = $scalar;
+
+                #[inline]
+                fn from_scalar(scalar: $scalar) -> Self {
+                    $ty::splat(scalar)
+                }
+            }
+
+            impl FromScalarArray<$n> for $ty {
+                #[inline]
+                fn from_array(scalars: [$scalar; $n]) -> Self {
+                    scalars.into()
+                }
+            }
+
+            impl IntoScalarArray<$n> for $ty {
+                #[inline]
+                fn into_array(self) -> [$scalar; $n] {
+                    self.into()
+                }
+            }
+
+            impl Zero for $ty {
+                #[inline]
+                fn zero() -> Self {
+                    $ty::ZERO
+                }
+            }
+
+            impl MinMax for $ty {
+                #[inline]
+                fn max(self, other: Self) -> Self {
+                    $ty::max(self, other)
+                }
+
+                #[inline]
+                fn min(self, other: Self) -> Self {
+                    $ty::min(self, other)
+                }
+
+                #[inline]
+                fn min_max(self, other: Self) -> (Self, Self) {
+                    ($ty::min(self, other), $ty::max(self, other))
+                }
+            }
+
+            impl IsValidDivisor for $ty {
+                #[inline]
+                fn is_valid_divisor(&self) -> Self {
+                    !self.simd_eq($ty::ZERO)
+                }
+            }
+
+            impl Trigonometry for $ty {
+                #[inline]
+                fn sin(self) -> Self {
+                    $ty::sin(self)
+                }
+
+                #[inline]
+                fn cos(self) -> Self {
+                    $ty::cos(self)
+                }
+
+                #[inline]
+                fn sin_cos(self) -> (Self, Self) {
+                    $ty::sin_cos(self)
+                }
+
+                #[inline]
+                fn tan(self) -> Self {
+                    $ty::tan(self)
+                }
+
+                #[inline]
+                fn asin(self) -> Self {
+                    $ty::asin(self)
+                }
+
+                #[inline]
+                fn acos(self) -> Self {
+                    $ty::acos(self)
+                }
+
+                #[inline]
+                fn atan(self) -> Self {
+                    $ty::atan(self)
+                }
+
+                #[inline]
+                fn atan2(self, other: Self) -> Self {
+                    $ty::atan2(self, other)
+                }
+            }
+
+            impl Abs for $ty {
+                #[inline]
+                fn abs(self) -> Self {
+                    $ty::abs(self)
+                }
+            }
+
+            impl Sqrt for $ty {
+                #[inline]
+                fn sqrt(self) -> Self {
+                    $ty::sqrt(self)
+                }
+            }
+
+            impl Cbrt for $ty {
+                #[inline]
+                fn cbrt(self) -> Self {
+                    let mut array = self.into_array();
+
+                    for scalar in &mut array {
+                        *scalar = scalar.cbrt();
+                    }
+
+                    array.into()
+                }
+            }
+
+            impl Exp for $ty {
+                #[inline]
+                fn exp(self) -> Self {
+                    $ty::exp(self)
+                }
+            }
+
+            impl Hypot for $ty {
+                #[inline]
+                fn hypot(self, other: Self) -> Self {
+                    (self * self + other * other).sqrt()
+                }
+            }
+
+            impl Round for $ty {
+                #[inline]
+                fn round(self) -> Self {
+                    $ty::round(self)
+                }
+
+                #[inline]
+                fn floor(self) -> Self {
+                    let mut array = self.into_array();
+
+                    for scalar in &mut array {
+                        *scalar = scalar.floor();
+                    }
+
+                    array.into()
+                }
+
+                #[inline]
+                fn ceil(self) -> Self {
+                    let mut array = self.into_array();
+
+                    for scalar in &mut array {
+                        *scalar = scalar.ceil();
+                    }
+
+                    array.into()
+                }
+            }
+
+            impl Clamp for $ty {
+                #[inline]
+                fn clamp(self, min: Self, max: Self) -> Self {
+                    self.min(max).max(min)
+                }
+
+                #[inline]
+                fn clamp_min(self, min: Self) -> Self {
+                    $ty::max(self, min)
+                }
+
+                #[inline]
+                fn clamp_max(self, max: Self) -> Self {
+                    $ty::min(self, max)
+                }
+            }
+
+            impl ClampAssign for $ty {
+                #[inline]
+                fn clamp_assign(&mut self, min: Self, max: Self) {
+                    *self = $ty::clamp(*self, min, max);
+                }
+
+                #[inline]
+                fn clamp_min_assign(&mut self, min: Self) {
+                    *self = $ty::max(*self, min);
+                }
+
+                #[inline]
+                fn clamp_max_assign(&mut self, max: Self) {
+                    *self = $ty::min(*self, max);
+                }
+            }
+
+            impl PartialCmp for $ty {
+                #[inline]
+                fn lt(&self, other: &Self) -> Self::Mask {
+                    self.simd_lt(*other)
+                }
+
+                #[inline]
+                fn lt_eq(&self, other: &Self) -> Self::Mask {
+                    self.simd_le(*other)
+                }
+
+                #[inline]
+                fn eq(&self, other: &Self) -> Self::Mask {
+                    self.simd_eq(*other)
+                }
+
+                #[inline]
+                fn neq(&self, other: &Self) -> Self::Mask {
+                    self.simd_ne(*other)
+                }
+
+                #[inline]
+                fn gt_eq(&self, other: &Self) -> Self::Mask {
+                    self.simd_ge(*other)
+                }
+
+                #[inline]
+                fn gt(&self, other: &Self) -> Self::Mask {
+                    self.simd_gt(*other)
+                }
+            }
+
+            impl MulAdd for $ty {
+                #[inline]
+                fn mul_add(self, m: Self, a: Self) -> Self {
+                    $ty::mul_add(self, m, a)
+                }
+            }
+
+            impl MulSub for $ty {
+                #[inline]
+                fn mul_sub(self, m: Self, s: Self) -> Self {
+                    $ty::mul_sub(self, m, s)
+                }
+            }
+
+            impl Signum for $ty {
+                #[inline]
+                fn signum(self) -> Self {
+                    self.is_nan().blend(Self::from($scalar::NAN), $ty::copysign(Self::from(1.0), self))
+                }
+            }
+
+            impl Ln for $ty {
+                #[inline]
+                fn ln(self) -> Self {
+                    self.ln()
+                }
+            }
+        )+
+    };
+}
+
+impl_wide_float!(
+    f32x4 {
+        array: [f32; 4],
+        powf: pow_f32x4,
+    },
+    f32x8 {
+        array: [f32; 8],
+        powf: pow_f32x8,
+    },
+    f64x2 {
+        array: [f64; 2],
+        powf: pow_f64x2,
+    },
+    f64x4 {
+        array: [f64; 4],
+        powf: pow_f64x4,
+    }
+);

--- a/palette_math/Cargo.toml
+++ b/palette_math/Cargo.toml
@@ -20,7 +20,9 @@ std = ["alloc"]
 alloc = []
 libm = ["dep:libm"]
 wide = ["dep:wide"]
+wide_1 = ["dep:wide_1"]
 
 [dependencies]
 libm = { version = "0.2.1", default-features = false, optional = true }
 wide = { version = "0.7.3", default-features = false, optional = true }
+wide_1 = { package = "wide", version = "1.2.0", default-features = false, optional = true }

--- a/palette_math/README.md
+++ b/palette_math/README.md
@@ -34,7 +34,11 @@ These features are enabled by default:
 These features are disabled by default:
 
 * `"libm"` - Uses the [`libm`](https://crates.io/crates/libm) floating point math library (for when the `std` feature is disabled).
-* `"wide"` - Enables support for using SIMD types from [`wide`](https://crates.io/crates/wide).
+* `"wide_1"` - Enables support for using SIMD types from [`wide`](https://crates.io/crates/wide) 1.X.Y.
+
+These features have been deprecated:
+
+* `"wide"` - Enables support for using SIMD types from [`wide`](https://crates.io/crates/wide) 0.7.X.
 
 ### Embedded And `#![no_std]`
 

--- a/palette_math/src/lib.rs
+++ b/palette_math/src/lib.rs
@@ -32,8 +32,13 @@
 //!
 //! * `"libm"` - Uses the [`libm`](https://crates.io/crates/libm) floating point
 //!   math library (for when the `std` feature is disabled).
+//! * `"wide_1"` - Enables support for using SIMD types from
+//!   [`wide`](https://crates.io/crates/wide) 1.X.Y.
+//!
+//! These features have been deprecated:
+//!
 //! * `"wide"` - Enables support for using SIMD types from
-//!   [`wide`](https://crates.io/crates/wide).
+//!   [`wide`](https://crates.io/crates/wide) 0.7.X.
 //!
 //! ## Embedded And `#![no_std]`
 //!

--- a/palette_math/src/num.rs
+++ b/palette_math/src/num.rs
@@ -18,6 +18,8 @@ use core::ops::Mul;
 mod libm;
 #[cfg(feature = "wide")]
 mod wide;
+#[cfg(feature = "wide_1")]
+mod wide_1;
 
 /// Methods for the value `1`.
 pub trait One {

--- a/palette_math/src/num/wide_1.rs
+++ b/palette_math/src/num/wide_1.rs
@@ -1,0 +1,89 @@
+use ::wide_1::{f32x4, f32x8, f64x2, f64x4};
+
+use super::*;
+
+macro_rules! impl_wide_float {
+    ($($ty: ident { array: [$scalar: ident; $n: expr], powf: $pow_self: ident, }),+) => {
+        $(
+            impl One for $ty {
+                #[inline]
+                fn one() -> Self {
+                    $ty::ONE
+                }
+            }
+
+            impl Powf for $ty {
+                #[inline]
+                fn powf(self, exp: Self) -> Self {
+                    $ty::$pow_self(self, exp)
+                }
+            }
+
+            impl Powi for $ty {
+                #[inline]
+                fn powi(mut self, mut exp: i32) -> Self {
+                    if exp < 0 {
+                        exp = exp.wrapping_neg();
+                        self = self.recip();
+                    }
+
+                    Powu::powu(self, exp as u32)
+                }
+            }
+
+            impl Powu for $ty {
+                #[inline]
+                fn powu(self, exp: u32) -> Self {
+                    pow(self, exp)
+                }
+            }
+        )+
+    };
+}
+
+impl_wide_float!(
+    f32x4 {
+        array: [f32; 4],
+        powf: pow_f32x4,
+    },
+    f32x8 {
+        array: [f32; 8],
+        powf: pow_f32x8,
+    },
+    f64x2 {
+        array: [f64; 2],
+        powf: pow_f64x2,
+    },
+    f64x4 {
+        array: [f64; 4],
+        powf: pow_f64x4,
+    }
+);
+
+impl Recip for f32x4 {
+    #[inline]
+    fn recip(self) -> Self {
+        f32x4::recip(self)
+    }
+}
+
+impl Recip for f32x8 {
+    #[inline]
+    fn recip(self) -> Self {
+        f32x8::recip(self)
+    }
+}
+
+impl Recip for f64x2 {
+    #[inline]
+    fn recip(self) -> Self {
+        f64x2::ONE / self
+    }
+}
+
+impl Recip for f64x4 {
+    #[inline]
+    fn recip(self) -> Self {
+        f64x4::ONE / self
+    }
+}


### PR DESCRIPTION
Add support for `wide` 1.X and use it in tests and benchmarks. I's added as a separate feature for backwards compatibility.