### PR TITLE
Fix `normalize_unsigned_angle` output for very small numbers

### DIFF
--- a/palette/src/angle.rs
+++ b/palette/src/angle.rs
@@ -131,7 +131,14 @@ macro_rules! impl_angle_float {
             impl UnsignedAngle for $ty {
                 #[inline]
                 fn normalize_unsigned_angle(self) -> Self {
-                    self - (Round::floor(self / 360.0) * 360.0)
+                    let normalized = self - (Round::floor(self / 360.0) * 360.0);
+
+                    // Check for issues with very small numbers
+                    if normalized.is_subnormal() || normalized >= 360.0 {
+                        0.0
+                    } else {
+                        normalized
+                    }
                 }
             }
         )+
@@ -204,7 +211,7 @@ impl UnsignedAngle for u8 {
 
 #[cfg(test)]
 mod test {
-    use crate::RgbHue;
+    use crate::{angle::UnsignedAngle, RgbHue};
 
     #[test]
     fn f32_to_u8() {
@@ -218,5 +225,15 @@ mod test {
         let hue_f32 = RgbHue::new(128u8);
         let hue_u8 = hue_f32.into_format::<f32>();
         assert_eq!(hue_u8, RgbHue::new(180.0f32));
+    }
+
+    #[test]
+    fn normalize_unsigned_angle() {
+        // Regression test for https://github.com/Ogeon/palette/issues/473.
+        let h1 = -1e-30_f64;
+        assert!(h1.normalize_unsigned_angle() < 360.0);
+
+        let h2 = -5e-324_f64;
+        assert!(h2.normalize_unsigned_angle() >= 0.0);
     }
 }

--- a/palette/src/angle/wide.rs
+++ b/palette/src/angle/wide.rs
@@ -48,7 +48,15 @@ macro_rules! impl_angle_wide_float {
             impl UnsignedAngle for $ty {
                 #[inline]
                 fn normalize_unsigned_angle(self) -> Self {
-                    self - (Round::floor(self / 360.0) * 360.0)
+                    use crate::{num::PartialCmp, bool_mask::Select};
+
+                    let normalized = self - (Round::floor(self / 360.0) * 360.0);
+
+                    // Check for issues with very small numbers
+                    (normalized.gt_eq(&Self::splat(0.0)) & normalized.lt(&Self::splat(360.0))).select(
+                        normalized,
+                        Self::splat(0.0)
+                    )
                 }
             }
         )+
@@ -56,3 +64,19 @@ macro_rules! impl_angle_wide_float {
 }
 
 impl_angle_wide_float!(f32x4, f32x8, f64x2, f64x4);
+
+#[cfg(test)]
+mod test {
+    use wide::f64x2;
+
+    use crate::{angle::UnsignedAngle, bool_mask::BoolMask, num::PartialCmp};
+
+    #[test]
+    fn normalize_unsigned_angle() {
+        // Regression test for https://github.com/Ogeon/palette/issues/473.
+        let hue = f64x2::new([-1e-30_f64, -5e-324_f64]);
+        let normalized = hue.normalize_unsigned_angle();
+        assert!(normalized.lt(&f64x2::splat(360.0)).is_true());
+        assert!(normalized.gt_eq(&f64x2::splat(0.0)).is_true());
+    }
+}

--- a/palette/src/hsluv.rs
+++ b/palette/src/hsluv.rs
@@ -315,6 +315,8 @@ mod test {
         }
     }
 
+    // Miri randomizes floats and it gets a bit too wild here due to https://github.com/Ogeon/palette/issues/475
+    #[cfg_attr(miri, ignore)]
     /// Also regression test for https://github.com/Ogeon/palette/issues/472.
     #[cfg(feature = "approx")]
     #[test]
@@ -327,7 +329,8 @@ mod test {
         assert_relative_eq!(s64.l, 100.0);
         assert_relative_eq!(s64.saturation, 0.0);
     }
-
+    // Miri randomizes floats and it gets a bit too wild here due to https://github.com/Ogeon/palette/issues/475
+    #[cfg_attr(miri, ignore)]
     #[cfg(feature = "approx")]
     #[test]
     fn black() {


### PR DESCRIPTION
Checks if the output of `normalize_unsigned_angle` lands outside the expected range and correct them to `0.0`. This assumes that this only happens for input values just around `0.0`.

## Closed Issues

* Fixes #473
